### PR TITLE
prefix commands with 'alpha'

### DIFF
--- a/cmd/alpha.go
+++ b/cmd/alpha.go
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// AlphaCmd represents the alpha command for unstable features
+var AlphaCmd = &cobra.Command{
+	Use:   "alpha",
+	Short: "Run commands that are considered unstable.",
+	Long:  `Run commands that are considered unstable.`,
+	RunE:  runAlpha,
+}
+
+// runAlpha represents the alpha command for unstable features
+func runAlpha(cmd *cobra.Command, args []string) error {
+
+	return nil
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -16,12 +16,13 @@ func init() {
 	// Create or load a yaml config and the database
 	cobra.OnInitialize(initConfig, setupLogging)
 
-	RootCmd.AddCommand(AddCmd)
-	RootCmd.AddCommand(ListCmd)
-	RootCmd.AddCommand(RemoveCmd)
-	RootCmd.AddCommand(SessionCmd)
-	RootCmd.AddCommand(UpdateCmd)
-	RootCmd.AddCommand(VersionCmd)
+	RootCmd.AddCommand(AlphaCmd)
+	AlphaCmd.AddCommand(AddCmd)
+	AlphaCmd.AddCommand(ListCmd)
+	AlphaCmd.AddCommand(RemoveCmd)
+	AlphaCmd.AddCommand(SessionCmd)
+	AlphaCmd.AddCommand(UpdateCmd)
+	AlphaCmd.AddCommand(VersionCmd)
 
 	// Global root command flags
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", cfgFile, "Path to the configuration file")


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- Prefixes commands with `alpha` to indicate instability


# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

