### PR TITLE
Validate required data is present and reconcile improvements

### DIFF
--- a/cmd/blade/add_blade.go
+++ b/cmd/blade/add_blade.go
@@ -60,14 +60,16 @@ func addBlade(cmd *cobra.Command, args []string) error {
 	passback, err := d.AddBlade(cmd.Context(), args[0], cabinet, chassis, slot)
 	if errors.Is(err, provider.ErrDataValidationFailure) {
 		// TODO the following should probably suggest commands to fix the issue?
-		log.Info().Msgf("Inventory data validation errors encountered")
+		log.Error().Msgf("Inventory data validation errors encountered")
 		for id, failedValidation := range passback.ProviderValidationErrors {
-			log.Info().Msgf("  %s: %s", id, failedValidation.Hardware.LocationPath.String())
+			log.Error().Msgf("  %s: %s", id, failedValidation.Hardware.LocationPath.String())
 			sort.Strings(failedValidation.Errors)
 			for _, validationError := range failedValidation.Errors {
-				log.Info().Msgf("    - %s", validationError)
+				log.Error().Msgf("    - %s", validationError)
 			}
 		}
+
+		return err
 	} else if err != nil {
 		return err
 	}

--- a/cmd/blade/add_blade.go
+++ b/cmd/blade/add_blade.go
@@ -53,7 +53,7 @@ func addBlade(cmd *cobra.Command, args []string) error {
 	}
 
 	// Add the blade from the inventory using domain methods
-	results, err := d.AddBlade(args[0], cabinet, chassis, slot)
+	results, err := d.AddBlade(cmd.Context(), args[0], cabinet, chassis, slot)
 	if err != nil {
 		return err
 	}
@@ -77,9 +77,9 @@ func addBlade(cmd *cobra.Command, args []string) error {
 	// with the node(s) that may need additional metadata added
 
 	// Use a map to track already added nodes.
-	newNodes := []domain.AddHardwareResult{}
+	newNodes := []domain.HardwareLocationPair{}
 
-	for _, result := range results {
+	for _, result := range results.AddedHardware {
 		// If the type is a Node
 		if result.Hardware.Type == hardwaretypes.Node {
 			log.Debug().Msg(result.Location.String())

--- a/cmd/cabinet/add_cabinet.go
+++ b/cmd/cabinet/add_cabinet.go
@@ -55,11 +55,11 @@ func addCabinet(cmd *cobra.Command, args []string) error {
 	}
 
 	// Add the blade from the inventory using domain methods
-	passback, err := d.AddCabinet(cmd.Context(), args[0], cabinet)
+	result, err := d.AddCabinet(cmd.Context(), args[0], cabinet)
 	if errors.Is(err, provider.ErrDataValidationFailure) {
 		// TODO the following should probably suggest commands to fix the issue?
 		log.Error().Msgf("Inventory data validation errors encountered")
-		for id, failedValidation := range passback.ProviderValidationErrors {
+		for id, failedValidation := range result.ProviderValidationErrors {
 			log.Error().Msgf("  %s: %s", id, failedValidation.Hardware.LocationPath.String())
 			sort.Strings(failedValidation.Errors)
 			for _, validationError := range failedValidation.Errors {
@@ -76,7 +76,7 @@ func addCabinet(cmd *cobra.Command, args []string) error {
 	// Use a map to track already added nodes.
 	newNodes := []domain.HardwareLocationPair{}
 
-	for _, result := range passback.AddedHardware {
+	for _, result := range result.AddedHardware {
 		// If the type is a Node
 		if result.Hardware.Type == hardwaretypes.Cabinet {
 			log.Debug().Msg(result.Location.String())

--- a/cmd/cabinet/add_cabinet.go
+++ b/cmd/cabinet/add_cabinet.go
@@ -58,14 +58,16 @@ func addCabinet(cmd *cobra.Command, args []string) error {
 	passback, err := d.AddCabinet(cmd.Context(), args[0], cabinet)
 	if errors.Is(err, provider.ErrDataValidationFailure) {
 		// TODO the following should probably suggest commands to fix the issue?
-		log.Info().Msgf("Inventory data validation errors encountered")
+		log.Error().Msgf("Inventory data validation errors encountered")
 		for id, failedValidation := range passback.ProviderValidationErrors {
-			log.Info().Msgf("  %s: %s", id, failedValidation.Hardware.LocationPath.String())
+			log.Error().Msgf("  %s: %s", id, failedValidation.Hardware.LocationPath.String())
 			sort.Strings(failedValidation.Errors)
 			for _, validationError := range failedValidation.Errors {
-				log.Info().Msgf("    - %s", validationError)
+				log.Error().Msgf("    - %s", validationError)
 			}
 		}
+
+		return err
 	} else if err != nil {
 		return err
 	}

--- a/cmd/cabinet/add_cabinet.go
+++ b/cmd/cabinet/add_cabinet.go
@@ -58,9 +58,9 @@ func addCabinet(cmd *cobra.Command, args []string) error {
 	log.Info().Msgf("Added cabinet %s", args[0])
 
 	// Use a map to track already added nodes.
-	newNodes := []domain.AddHardwareResult{}
+	newNodes := []domain.HardwareLocationPair{}
 
-	for _, result := range results {
+	for _, result := range results.AddedHardware {
 		// If the type is a Node
 		if result.Hardware.Type == hardwaretypes.Cabinet {
 			log.Debug().Msg(result.Location.String())

--- a/cmd/cabinet/add_cabinet.go
+++ b/cmd/cabinet/add_cabinet.go
@@ -24,9 +24,13 @@ OTHER DEALINGS IN THE SOFTWARE.
 package cabinet
 
 import (
+	"errors"
+	"sort"
+
 	root "github.com/Cray-HPE/cani/cmd"
 	"github.com/Cray-HPE/cani/cmd/session"
 	"github.com/Cray-HPE/cani/internal/domain"
+	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -51,8 +55,18 @@ func addCabinet(cmd *cobra.Command, args []string) error {
 	}
 
 	// Add the blade from the inventory using domain methods
-	results, err := d.AddCabinet(args[0], cabinet)
-	if err != nil {
+	passback, err := d.AddCabinet(cmd.Context(), args[0], cabinet)
+	if errors.Is(err, provider.ErrDataValidationFailure) {
+		// TODO the following should probably suggest commands to fix the issue?
+		log.Info().Msgf("Inventory data validation errors encountered")
+		for id, failedValidation := range passback.ProviderValidationErrors {
+			log.Info().Msgf("  %s: %s", id, failedValidation.Hardware.LocationPath.String())
+			sort.Strings(failedValidation.Errors)
+			for _, validationError := range failedValidation.Errors {
+				log.Info().Msgf("    - %s", validationError)
+			}
+		}
+	} else if err != nil {
 		return err
 	}
 	log.Info().Msgf("Added cabinet %s", args[0])
@@ -60,7 +74,7 @@ func addCabinet(cmd *cobra.Command, args []string) error {
 	// Use a map to track already added nodes.
 	newNodes := []domain.HardwareLocationPair{}
 
-	for _, result := range results.AddedHardware {
+	for _, result := range passback.AddedHardware {
 		// If the type is a Node
 		if result.Hardware.Type == hardwaretypes.Cabinet {
 			log.Debug().Msg(result.Location.String())

--- a/cmd/node/update_node.go
+++ b/cmd/node/update_node.go
@@ -30,6 +30,8 @@ func updateNode(cmd *cobra.Command, args []string) error {
 
 	// Push all the CLI flags that were provided into a generic map
 	// TODO Need to figure out how to specify to unset something
+	// Right now the build metadata function in the CSM provider will
+	// unset options if nil is passed in.
 	nodeMeta := map[string]interface{}{
 		"role":    role,
 		"subrole": subrole,

--- a/cmd/node/update_node.go
+++ b/cmd/node/update_node.go
@@ -36,25 +36,34 @@ func updateNode(cmd *cobra.Command, args []string) error {
 	// TODO Need to figure out how to specify to unset something
 	// Right now the build metadata function in the CSM provider will
 	// unset options if nil is passed in.
-	nodeMeta := map[string]interface{}{
-		"role":    role,
-		"subrole": subrole,
-		"alias":   alias,
-		"nid":     nid,
+	nodeMeta := map[string]interface{}{}
+	if role != "" {
+		nodeMeta["role"] = role
+	}
+	if subrole != "" {
+		nodeMeta["subrole"] = subrole
+	}
+	if alias != "" {
+		nodeMeta["alias"] = alias
+	}
+	if nid != 0 {
+		nodeMeta["nid"] = nid
 	}
 
 	// Remove the node from the inventory using domain methods
 	passback, err := d.UpdateNode(cmd.Context(), cabinet, chassis, slot, bmc, node, nodeMeta)
 	if errors.Is(err, provider.ErrDataValidationFailure) {
 		// TODO the following should probably suggest commands to fix the issue?
-		log.Info().Msgf("Inventory data validation errors encountered")
+		log.Error().Msgf("Inventory data validation errors encountered")
 		for id, failedValidation := range passback.ProviderValidationErrors {
-			log.Info().Msgf("  %s: %s", id, failedValidation.Hardware.LocationPath.String())
+			log.Error().Msgf("  %s: %s", id, failedValidation.Hardware.LocationPath.String())
 			sort.Strings(failedValidation.Errors)
 			for _, validationError := range failedValidation.Errors {
-				log.Info().Msgf("    - %s", validationError)
+				log.Error().Msgf("    - %s", validationError)
 			}
 		}
+
+		return err
 	} else if err != nil {
 		return err
 	}

--- a/cmd/node/update_node.go
+++ b/cmd/node/update_node.go
@@ -37,25 +37,25 @@ func updateNode(cmd *cobra.Command, args []string) error {
 	// Right now the build metadata function in the CSM provider will
 	// unset options if nil is passed in.
 	nodeMeta := map[string]interface{}{}
-	if role != "" {
+	if cmd.Flags().Changed("role") {
 		nodeMeta["role"] = role
 	}
-	if subrole != "" {
+	if cmd.Flags().Changed("subrole") {
 		nodeMeta["subrole"] = subrole
 	}
-	if alias != "" {
+	if cmd.Flags().Changed("alias") {
 		nodeMeta["alias"] = alias
 	}
-	if nid != 0 {
+	if cmd.Flags().Changed("alias") {
 		nodeMeta["nid"] = nid
 	}
 
 	// Remove the node from the inventory using domain methods
-	passback, err := d.UpdateNode(cmd.Context(), cabinet, chassis, slot, bmc, node, nodeMeta)
+	result, err := d.UpdateNode(cmd.Context(), cabinet, chassis, slot, bmc, node, nodeMeta)
 	if errors.Is(err, provider.ErrDataValidationFailure) {
 		// TODO the following should probably suggest commands to fix the issue?
 		log.Error().Msgf("Inventory data validation errors encountered")
-		for id, failedValidation := range passback.ProviderValidationErrors {
+		for id, failedValidation := range result.ProviderValidationErrors {
 			log.Error().Msgf("  %s: %s", id, failedValidation.Hardware.LocationPath.String())
 			sort.Strings(failedValidation.Errors)
 			for _, validationError := range failedValidation.Errors {

--- a/cmd/session/session_start.go
+++ b/cmd/session/session_start.go
@@ -28,8 +28,8 @@ var SessionStartCmd = &cobra.Command{
 }
 
 var (
-	provider  string
-	validArgs = []string{"csm"}
+	providerName string
+	validArgs    = []string{"csm"}
 )
 
 // startSession starts a session if one does not exist
@@ -79,7 +79,7 @@ func startSession(cmd *cobra.Command, args []string) error {
 
 		// For now just use the defaults
 		root.Conf.Session.DomainOptions.CsmOptions.ValidRoles = csm.DefaultValidRoles
-		root.Conf.Session.DomainOptions.CsmOptions.ValidRoles = csm.DefaultValidSubRolesRoles
+		root.Conf.Session.DomainOptions.CsmOptions.ValidSubRoles = csm.DefaultValidSubRolesRoles
 	}
 
 	// Validate the external inventory

--- a/cmd/session/session_start.go
+++ b/cmd/session/session_start.go
@@ -8,6 +8,8 @@ import (
 	root "github.com/Cray-HPE/cani/cmd"
 	"github.com/Cray-HPE/cani/cmd/config"
 	"github.com/Cray-HPE/cani/internal/domain"
+	"github.com/Cray-HPE/cani/internal/inventory"
+	"github.com/Cray-HPE/cani/internal/provider/csm"
 	"github.com/manifoldco/promptui"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -67,6 +69,17 @@ func startSession(cmd *cobra.Command, args []string) error {
 	root.Conf.Session.Domain, err = domain.New(root.Conf.Session.DomainOptions)
 	if err != nil {
 		return err
+	}
+
+	// Perform provider plugin specific logic at session start
+	switch root.Conf.Session.DomainOptions.Provider {
+	case string(inventory.CSMProvider):
+		// Need to get the systems Roles/SubRole data from the system
+		// TODO CASMINST-6417
+
+		// For now just use the defaults
+		root.Conf.Session.DomainOptions.CsmOptions.ValidRoles = csm.DefaultValidRoles
+		root.Conf.Session.DomainOptions.CsmOptions.ValidRoles = csm.DefaultValidSubRolesRoles
 	}
 
 	// Validate the external inventory

--- a/cmd/session/session_start.go
+++ b/cmd/session/session_start.go
@@ -85,11 +85,11 @@ func startSession(cmd *cobra.Command, args []string) error {
 	}
 
 	// Validate the external inventory
-	passback, err := root.Conf.Session.Domain.Validate(cmd.Context())
+	result, err := root.Conf.Session.Domain.Validate(cmd.Context())
 	if errors.Is(err, provider.ErrDataValidationFailure) {
 		// TODO the following should probably suggest commands to fix the issue?
 		log.Error().Msgf("Inventory data validation errors encountered")
-		for id, failedValidation := range passback.ProviderValidationErrors {
+		for id, failedValidation := range result.ProviderValidationErrors {
 			log.Error().Msgf("  %s: %s", id, failedValidation.Hardware.LocationPath.String())
 			sort.Strings(failedValidation.Errors)
 			for _, validationError := range failedValidation.Errors {

--- a/cmd/session/session_stop.go
+++ b/cmd/session/session_stop.go
@@ -57,6 +57,7 @@ func stopSession(cmd *cobra.Command, args []string) error {
 		// Commit the external inventory
 		passback, err := d.Commit(cmd.Context())
 		if errors.Is(err, provider.ErrDataValidationFailure) {
+			// TODO the following should probablty suggest commands to fix the issue?
 			log.Info().Msgf("Inventory data validation errors encountered")
 			for id, failedValidation := range passback.FailedValidations {
 				log.Info().Msgf("  %s: %s", id, failedValidation.Hardware.LocationPath.String())

--- a/cmd/session/session_stop.go
+++ b/cmd/session/session_stop.go
@@ -55,11 +55,11 @@ func stopSession(cmd *cobra.Command, args []string) error {
 		log.Info().Msgf("Committing changes to session")
 
 		// Commit the external inventory
-		passback, err := d.Commit(cmd.Context())
+		result, err := d.Commit(cmd.Context())
 		if errors.Is(err, provider.ErrDataValidationFailure) {
 			// TODO the following should probably suggest commands to fix the issue?
 			log.Error().Msgf("Inventory data validation errors encountered")
-			for id, failedValidation := range passback.ProviderValidationErrors {
+			for id, failedValidation := range result.ProviderValidationErrors {
 				log.Error().Msgf("  %s: %s", id, failedValidation.Hardware.LocationPath.String())
 				sort.Strings(failedValidation.Errors)
 				for _, validationError := range failedValidation.Errors {

--- a/cmd/session/session_stop.go
+++ b/cmd/session/session_stop.go
@@ -57,18 +57,16 @@ func stopSession(cmd *cobra.Command, args []string) error {
 		// Commit the external inventory
 		passback, err := d.Commit(cmd.Context())
 		if errors.Is(err, provider.ErrDataValidationFailure) {
-			// TODO the following should probablty suggest commands to fix the issue?
+			// TODO the following should probably suggest commands to fix the issue?
 			log.Info().Msgf("Inventory data validation errors encountered")
-			for id, failedValidation := range passback.FailedValidations {
+			for id, failedValidation := range passback.ProviderValidationErrors {
 				log.Info().Msgf("  %s: %s", id, failedValidation.Hardware.LocationPath.String())
 				sort.Strings(failedValidation.Errors)
 				for _, validationError := range failedValidation.Errors {
 					log.Info().Msgf("    - %s", validationError)
 				}
 			}
-
-		}
-		if err != nil {
+		} else if err != nil {
 			return err
 		}
 	}

--- a/cmd/session/session_stop.go
+++ b/cmd/session/session_stop.go
@@ -1,11 +1,14 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"sort"
 
 	root "github.com/Cray-HPE/cani/cmd"
 	"github.com/Cray-HPE/cani/internal/domain"
+	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/manifoldco/promptui"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -24,7 +27,7 @@ var SessionStopCmd = &cobra.Command{
 // stopSession stops a session if one exists
 func stopSession(cmd *cobra.Command, args []string) error {
 	ds := root.Conf.Session.DomainOptions.DatastorePath
-	provider := root.Conf.Session.DomainOptions.Provider
+	providerName := root.Conf.Session.DomainOptions.Provider
 	d, err := domain.New(root.Conf.Session.DomainOptions)
 	if err != nil {
 		return err
@@ -34,11 +37,11 @@ func stopSession(cmd *cobra.Command, args []string) error {
 		// Check that the datastore exists before proceeding since we cannot continue without it
 		_, err := os.Stat(ds)
 		if err != nil {
-			return fmt.Errorf("Session is STOPPED with provider '%s' but datastore '%s' does not exist", provider, ds)
+			return fmt.Errorf("Session is STOPPED with provider '%s' but datastore '%s' does not exist", providerName, ds)
 		}
 		log.Info().Msgf("Session is STOPPED")
 	} else {
-		log.Info().Msgf("Session with provider '%s' and datastore '%s' is already STOPPED", provider, ds)
+		log.Info().Msgf("Session with provider '%s' and datastore '%s' is already STOPPED", providerName, ds)
 	}
 
 	if !commit {
@@ -52,7 +55,18 @@ func stopSession(cmd *cobra.Command, args []string) error {
 		log.Info().Msgf("Committing changes to session")
 
 		// Commit the external inventory
-		err = d.Commit(cmd.Context())
+		passback, err := d.Commit(cmd.Context())
+		if errors.Is(err, provider.ErrDataValidationFailure) {
+			log.Info().Msgf("Inventory data validation errors encountered")
+			for id, failedValidation := range passback.FailedValidations {
+				log.Info().Msgf("  %s: %s", id, failedValidation.Hardware.LocationPath.String())
+				sort.Strings(failedValidation.Errors)
+				for _, validationError := range failedValidation.Errors {
+					log.Info().Msgf("    - %s", validationError)
+				}
+			}
+
+		}
 		if err != nil {
 			return err
 		}

--- a/cmd/session/session_stop.go
+++ b/cmd/session/session_stop.go
@@ -58,14 +58,16 @@ func stopSession(cmd *cobra.Command, args []string) error {
 		passback, err := d.Commit(cmd.Context())
 		if errors.Is(err, provider.ErrDataValidationFailure) {
 			// TODO the following should probably suggest commands to fix the issue?
-			log.Info().Msgf("Inventory data validation errors encountered")
+			log.Error().Msgf("Inventory data validation errors encountered")
 			for id, failedValidation := range passback.ProviderValidationErrors {
-				log.Info().Msgf("  %s: %s", id, failedValidation.Hardware.LocationPath.String())
+				log.Error().Msgf("  %s: %s", id, failedValidation.Hardware.LocationPath.String())
 				sort.Strings(failedValidation.Errors)
 				for _, validationError := range failedValidation.Errors {
-					log.Info().Msgf("    - %s", validationError)
+					log.Error().Msgf("    - %s", validationError)
 				}
 			}
+
+			return err
 		} else if err != nil {
 			return err
 		}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -51,11 +51,11 @@ func validateInventory(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		// Validate the external inventory
-		passback, err := d.Validate(cmd.Context())
+		result, err := d.Validate(cmd.Context())
 		if errors.Is(err, provider.ErrDataValidationFailure) {
 			// TODO the following should probably suggest commands to fix the issue?
 			log.Error().Msgf("Inventory data validation errors encountered")
-			for id, failedValidation := range passback.ProviderValidationErrors {
+			for id, failedValidation := range result.ProviderValidationErrors {
 				log.Error().Msgf("  %s: %s", id, failedValidation.Hardware.LocationPath.String())
 				sort.Strings(failedValidation.Errors)
 				for _, validationError := range failedValidation.Errors {

--- a/internal/domain/blade.go
+++ b/internal/domain/blade.go
@@ -1,21 +1,18 @@
 package domain
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/Cray-HPE/cani/internal/inventory"
+	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
 
-type AddHardwareResult struct {
-	Hardware inventory.Hardware
-	Location inventory.LocationPath
-}
-
-func (d *Domain) AddBlade(deviceTypeSlug string, cabinetOrdinal, chassisOrdinal, slotOrdinal int) ([]AddHardwareResult, error) {
+func (d *Domain) AddBlade(ctx context.Context, deviceTypeSlug string, cabinetOrdinal, chassisOrdinal, slotOrdinal int) (AddHardwarePassback, error) {
 	// Validate provided cabinet exists
 	// TODO
 
@@ -29,7 +26,7 @@ func (d *Domain) AddBlade(deviceTypeSlug string, cabinetOrdinal, chassisOrdinal,
 		LocationOrdinal: &cabinetOrdinal,
 	}
 	if err := d.datastore.Add(&cabinet); err != nil {
-		return nil, errors.Join(
+		return AddHardwarePassback{}, errors.Join(
 			fmt.Errorf("unable to add cabinet hardware"),
 			err,
 		)
@@ -45,7 +42,7 @@ func (d *Domain) AddBlade(deviceTypeSlug string, cabinetOrdinal, chassisOrdinal,
 		LocationOrdinal: &slotOrdinal,
 	}
 	if err := d.datastore.Add(&chassis); err != nil {
-		return nil, errors.Join(
+		return AddHardwarePassback{}, errors.Join(
 			fmt.Errorf("unable to add chassis hardware"),
 			err,
 		)
@@ -60,22 +57,22 @@ func (d *Domain) AddBlade(deviceTypeSlug string, cabinetOrdinal, chassisOrdinal,
 	// Verify the provided device type slug is a node blade
 	deviceType, err := d.hardwareTypeLibrary.GetDeviceType(deviceTypeSlug)
 	if err != nil {
-		return nil, err
+		return AddHardwarePassback{}, err
 	}
 	if deviceType.HardwareType != hardwaretypes.NodeBlade {
-		return nil, fmt.Errorf("provided device hardware type (%s) is not a node blade", deviceTypeSlug) // TODO better error message
+		return AddHardwarePassback{}, fmt.Errorf("provided device hardware type (%s) is not a node blade", deviceTypeSlug) // TODO better error message
 	}
 
 	// Generate a hardware build out
 	hardwareBuildOutItems, err := d.hardwareTypeLibrary.GetDefaultHardwareBuildOut(deviceTypeSlug, slotOrdinal, chassis.ID)
 	if err != nil {
-		return nil, errors.Join(
+		return AddHardwarePassback{}, errors.Join(
 			fmt.Errorf("unable to build default hardware build out for %s", deviceTypeSlug),
 			err,
 		)
 	}
 
-	var results []AddHardwareResult
+	var passback AddHardwarePassback
 
 	for _, hardwareBuildOut := range hardwareBuildOutItems {
 		// Generate the CANI hardware inventory version of the hardware build out data
@@ -103,7 +100,7 @@ func (d *Domain) AddBlade(deviceTypeSlug string, cabinetOrdinal, chassisOrdinal,
 		// Not sure how hard it would be to specify at this point in time.
 		// This command creates the physical information for a node, have another command for the logical part of the data
 		if err := d.datastore.Add(&hardware); err != nil {
-			return nil, errors.Join(
+			return AddHardwarePassback{}, errors.Join(
 				fmt.Errorf("unable to add hardware to inventory datastore"),
 				err,
 			)
@@ -114,7 +111,7 @@ func (d *Domain) AddBlade(deviceTypeSlug string, cabinetOrdinal, chassisOrdinal,
 			panic(err)
 		}
 
-		results = append(results, AddHardwareResult{
+		passback.AddedHardware = append(passback.AddedHardware, HardwareLocationPair{
 			Hardware: hardware,
 			Location: hardwareLocation,
 		})
@@ -122,7 +119,18 @@ func (d *Domain) AddBlade(deviceTypeSlug string, cabinetOrdinal, chassisOrdinal,
 
 	}
 
-	return results, d.datastore.Flush()
+	// Validate the current state of CANI's inventory data against the provider plugin
+	// for provider specific data
+	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(ctx, d.datastore, true); len(failedValidations) > 0 {
+		passback.ProviderValidationErrors = failedValidations
+		return passback, provider.ErrDataValidationFailure
+	} else if err != nil {
+		return AddHardwarePassback{}, errors.Join(
+			fmt.Errorf("failed to validate inventory against inventory provider plugin"),
+			err,
+		)
+	}
+	return passback, d.datastore.Flush()
 }
 
 func (d *Domain) RemoveBlade(u uuid.UUID, recursion bool) error {

--- a/internal/domain/blade.go
+++ b/internal/domain/blade.go
@@ -121,7 +121,7 @@ func (d *Domain) AddBlade(ctx context.Context, deviceTypeSlug string, cabinetOrd
 
 	// Validate the current state of CANI's inventory data against the provider plugin
 	// for provider specific data.
-	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(ctx, d.datastore, true); len(failedValidations) > 0 {
+	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(ctx, d.datastore, false); len(failedValidations) > 0 {
 		passback.ProviderValidationErrors = failedValidations
 		return passback, provider.ErrDataValidationFailure
 	} else if err != nil {

--- a/internal/domain/blade.go
+++ b/internal/domain/blade.go
@@ -120,7 +120,7 @@ func (d *Domain) AddBlade(ctx context.Context, deviceTypeSlug string, cabinetOrd
 	}
 
 	// Validate the current state of CANI's inventory data against the provider plugin
-	// for provider specific data
+	// for provider specific data.
 	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(ctx, d.datastore, true); len(failedValidations) > 0 {
 		passback.ProviderValidationErrors = failedValidations
 		return passback, provider.ErrDataValidationFailure
@@ -130,6 +130,7 @@ func (d *Domain) AddBlade(ctx context.Context, deviceTypeSlug string, cabinetOrd
 			err,
 		)
 	}
+
 	return passback, d.datastore.Flush()
 }
 

--- a/internal/domain/cabinet.go
+++ b/internal/domain/cabinet.go
@@ -100,7 +100,7 @@ func (d *Domain) AddCabinet(ctx context.Context, deviceTypeSlug string, cabinetO
 
 	// Validate the current state of CANI's inventory data against the provider plugin
 	// for provider specific data.
-	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(ctx, d.datastore, true); len(failedValidations) > 0 {
+	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(ctx, d.datastore, false); len(failedValidations) > 0 {
 		passback.ProviderValidationErrors = failedValidations
 		return passback, provider.ErrDataValidationFailure
 	} else if err != nil {

--- a/internal/domain/commit.go
+++ b/internal/domain/commit.go
@@ -9,10 +9,19 @@ import (
 func (d *Domain) Commit(ctx context.Context) error {
 	inventoryProvider := d.externalInventoryProvider
 
-	// Perform validation of CANI's inventory data
+	// Perform validation integrity of CANI's inventory data
 	if err := d.datastore.Validate(); err != nil {
 		return errors.Join(
-			fmt.Errorf("failed to validate inventory"),
+			fmt.Errorf("failed to validate inventory datastore"),
+			err,
+		)
+	}
+
+	// Validate the current state of CANI's inventory data against the provider plugin
+	// for provider specific data
+	if _, err := inventoryProvider.ValidateInternal(ctx, d.datastore); err != nil {
+		return errors.Join(
+			fmt.Errorf("failed to validate inventory against inventory provider plugin"),
 			err,
 		)
 	}

--- a/internal/domain/commit.go
+++ b/internal/domain/commit.go
@@ -4,14 +4,21 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/Cray-HPE/cani/internal/provider"
+	"github.com/google/uuid"
 )
 
-func (d *Domain) Commit(ctx context.Context) error {
+type CommitPassback struct {
+	FailedValidations map[uuid.UUID]provider.HardwareValidationResult
+}
+
+func (d *Domain) Commit(ctx context.Context) (CommitPassback, error) {
 	inventoryProvider := d.externalInventoryProvider
 
 	// Perform validation integrity of CANI's inventory data
 	if err := d.datastore.Validate(); err != nil {
-		return errors.Join(
+		return CommitPassback{}, errors.Join(
 			fmt.Errorf("failed to validate inventory datastore"),
 			err,
 		)
@@ -19,8 +26,12 @@ func (d *Domain) Commit(ctx context.Context) error {
 
 	// Validate the current state of CANI's inventory data against the provider plugin
 	// for provider specific data
-	if _, err := inventoryProvider.ValidateInternal(ctx, d.datastore); err != nil {
-		return errors.Join(
+	if failedValidations, err := inventoryProvider.ValidateInternal(ctx, d.datastore); len(failedValidations) > 0 {
+		return CommitPassback{
+			FailedValidations: failedValidations,
+		}, err
+	} else if err != nil {
+		return CommitPassback{}, errors.Join(
 			fmt.Errorf("failed to validate inventory against inventory provider plugin"),
 			err,
 		)
@@ -28,13 +39,13 @@ func (d *Domain) Commit(ctx context.Context) error {
 
 	// Validate the current state of the external inventory
 	if err := inventoryProvider.ValidateExternal(ctx); err != nil {
-		return errors.Join(
+		return CommitPassback{}, errors.Join(
 			fmt.Errorf("failed to validate external inventory provider"),
 			err,
 		)
 	}
 
 	// Reconcile our inventory with the external inventory system
-	return inventoryProvider.Reconcile(ctx, d.datastore)
+	return CommitPassback{}, inventoryProvider.Reconcile(ctx, d.datastore)
 
 }

--- a/internal/domain/commit.go
+++ b/internal/domain/commit.go
@@ -10,7 +10,7 @@ import (
 )
 
 type CommitPassback struct {
-	FailedValidations map[uuid.UUID]provider.HardwareValidationResult
+	ProviderValidationErrors map[uuid.UUID]provider.HardwareValidationResult
 }
 
 func (d *Domain) Commit(ctx context.Context) (CommitPassback, error) {
@@ -28,7 +28,7 @@ func (d *Domain) Commit(ctx context.Context) (CommitPassback, error) {
 	// for provider specific data
 	if failedValidations, err := inventoryProvider.ValidateInternal(ctx, d.datastore, true); len(failedValidations) > 0 {
 		return CommitPassback{
-			FailedValidations: failedValidations,
+			ProviderValidationErrors: failedValidations,
 		}, err
 	} else if err != nil {
 		return CommitPassback{}, errors.Join(

--- a/internal/domain/commit.go
+++ b/internal/domain/commit.go
@@ -26,7 +26,7 @@ func (d *Domain) Commit(ctx context.Context) (CommitPassback, error) {
 
 	// Validate the current state of CANI's inventory data against the provider plugin
 	// for provider specific data
-	if failedValidations, err := inventoryProvider.ValidateInternal(ctx, d.datastore); len(failedValidations) > 0 {
+	if failedValidations, err := inventoryProvider.ValidateInternal(ctx, d.datastore, true); len(failedValidations) > 0 {
 		return CommitPassback{
 			FailedValidations: failedValidations,
 		}, err

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -76,12 +76,17 @@ func New(opts *NewOpts) (*Domain, error) {
 	return domain, nil
 }
 
+type HardwareLocationPair struct {
+	Hardware inventory.Hardware
+	Location inventory.LocationPath
+}
+
 type AddHardwarePassback struct {
 	AddedHardware            []HardwareLocationPair
 	ProviderValidationErrors map[uuid.UUID]provider.HardwareValidationResult
 }
 
-type HardwareLocationPair struct {
-	Hardware inventory.Hardware
-	Location inventory.LocationPath
+type UpdatedHardwarePassback struct {
+	// UpdatedHardware          []HardwareLocationPair
+	ProviderValidationErrors map[uuid.UUID]provider.HardwareValidationResult
 }

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -81,7 +81,7 @@ type HardwareLocationPair struct {
 	Location inventory.LocationPath
 }
 
-type AddHardwarePassback struct {
+type AddHardwareResult struct {
 	AddedHardware            []HardwareLocationPair
 	ProviderValidationErrors map[uuid.UUID]provider.HardwareValidationResult
 }

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/Cray-HPE/cani/internal/provider/csm"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
+	"github.com/google/uuid"
 )
 
 // Domain is the logic that drives the application
@@ -73,4 +74,14 @@ func New(opts *NewOpts) (*Domain, error) {
 		return nil, fmt.Errorf("unknown external inventory provider provided (%s)", inventoryProvider)
 	}
 	return domain, nil
+}
+
+type AddHardwarePassback struct {
+	AddedHardware            []HardwareLocationPair
+	ProviderValidationErrors map[uuid.UUID]provider.HardwareValidationResult
+}
+
+type HardwareLocationPair struct {
+	Hardware inventory.Hardware
+	Location inventory.LocationPath
 }

--- a/internal/domain/misc.go
+++ b/internal/domain/misc.go
@@ -39,6 +39,8 @@ func (d *Domain) Validate(ctx context.Context) (ValidatePassback, error) {
 			err,
 		)
 	}
+	log.Info().Msg("Validated CANI inventory")
+
 	// Validate external inventory data
 	err := d.externalInventoryProvider.ValidateExternal(ctx)
 	if err != nil {

--- a/internal/domain/misc.go
+++ b/internal/domain/misc.go
@@ -2,8 +2,12 @@ package domain
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/Cray-HPE/cani/internal/inventory"
+	"github.com/Cray-HPE/cani/internal/provider"
+	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
 
@@ -17,12 +21,30 @@ func (d *Domain) List() (inventory.Inventory, error) {
 	return inv, nil
 }
 
-func (d *Domain) Validate() error {
-	err := d.externalInventoryProvider.ValidateExternal(context.Background())
+type ValidatePassback struct {
+	ProviderValidationErrors map[uuid.UUID]provider.HardwareValidationResult
+}
+
+func (d *Domain) Validate(ctx context.Context) (ValidatePassback, error) {
+	var passback ValidatePassback
+
+	// Validate the current state of CANI's inventory data against the provider plugin
+	// for provider specific data.
+	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(ctx, d.datastore, true); len(failedValidations) > 0 {
+		passback.ProviderValidationErrors = failedValidations
+		return passback, provider.ErrDataValidationFailure
+	} else if err != nil {
+		return ValidatePassback{}, errors.Join(
+			fmt.Errorf("failed to validate inventory against inventory provider plugin"),
+			err,
+		)
+	}
+	// Validate external inventory data
+	err := d.externalInventoryProvider.ValidateExternal(ctx)
 	if err != nil {
-		return err
+		return ValidatePassback{}, err
 	}
 
 	log.Info().Msg("Validated external inventory provider")
-	return nil
+	return passback, nil
 }

--- a/internal/domain/misc.go
+++ b/internal/domain/misc.go
@@ -21,20 +21,20 @@ func (d *Domain) List() (inventory.Inventory, error) {
 	return inv, nil
 }
 
-type ValidatePassback struct {
+type ValidateResult struct {
 	ProviderValidationErrors map[uuid.UUID]provider.HardwareValidationResult
 }
 
-func (d *Domain) Validate(ctx context.Context) (ValidatePassback, error) {
-	var passback ValidatePassback
+func (d *Domain) Validate(ctx context.Context) (ValidateResult, error) {
+	var result ValidateResult
 
 	// Validate the current state of CANI's inventory data against the provider plugin
 	// for provider specific data.
 	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(ctx, d.datastore, true); len(failedValidations) > 0 {
-		passback.ProviderValidationErrors = failedValidations
-		return passback, provider.ErrDataValidationFailure
+		result.ProviderValidationErrors = failedValidations
+		return result, provider.ErrDataValidationFailure
 	} else if err != nil {
-		return ValidatePassback{}, errors.Join(
+		return ValidateResult{}, errors.Join(
 			fmt.Errorf("failed to validate inventory against inventory provider plugin"),
 			err,
 		)
@@ -44,9 +44,9 @@ func (d *Domain) Validate(ctx context.Context) (ValidatePassback, error) {
 	// Validate external inventory data
 	err := d.externalInventoryProvider.ValidateExternal(ctx)
 	if err != nil {
-		return ValidatePassback{}, err
+		return ValidateResult{}, err
 	}
 
 	log.Info().Msg("Validated external inventory provider")
-	return passback, nil
+	return result, nil
 }

--- a/internal/domain/node.go
+++ b/internal/domain/node.go
@@ -42,7 +42,7 @@ func (d *Domain) UpdateNode(ctx context.Context, cabinet, chassis, slot, bmc, no
 	// Validate the current state of CANI's inventory data against the provider plugin
 	// for provider specific data.
 	var passback AddHardwarePassback
-	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(ctx, d.datastore, true); len(failedValidations) > 0 {
+	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(ctx, d.datastore, false); len(failedValidations) > 0 {
 		passback.ProviderValidationErrors = failedValidations
 		return passback, provider.ErrDataValidationFailure
 	} else if err != nil {

--- a/internal/domain/node.go
+++ b/internal/domain/node.go
@@ -1,12 +1,17 @@
 package domain
 
 import (
+	"context"
+	"errors"
+	"fmt"
+
 	"github.com/Cray-HPE/cani/internal/inventory"
+	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/rs/zerolog/log"
 )
 
-func (d *Domain) UpdateNode(cabinet, chassis, slot, bmc, node int, metadata map[string]interface{}) error {
+func (d *Domain) UpdateNode(ctx context.Context, cabinet, chassis, slot, bmc, node int, metadata map[string]interface{}) (AddHardwarePassback, error) {
 	// Get the node object from the datastore
 	locationPath := inventory.LocationPath{
 		{HardwareType: hardwaretypes.Cabinet, Ordinal: cabinet},
@@ -17,22 +22,35 @@ func (d *Domain) UpdateNode(cabinet, chassis, slot, bmc, node int, metadata map[
 	}
 	hw, err := d.datastore.GetAtLocation(locationPath)
 	if err != nil {
-		return err
+		return AddHardwarePassback{}, err
 	}
 
 	log.Debug().Msgf("Found node at: %s with ID (%s)", locationPath, hw.ID)
 
 	// Ask the inventory provider to craft a metadata object for this information
 	if err := d.externalInventoryProvider.BuildHardwareMetadata(&hw, metadata); err != nil {
-		return err
+		return AddHardwarePassback{}, err
 	}
 
 	log.Debug().Any("metadata", hw.ProviderProperties).Msg("Provider Properties")
 
 	// Push it back into the data store
 	if err := d.datastore.Update(&hw); err != nil {
-		return err
+		return AddHardwarePassback{}, err
 	}
 
-	return d.datastore.Flush()
+	// Validate the current state of CANI's inventory data against the provider plugin
+	// for provider specific data.
+	var passback AddHardwarePassback
+	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(ctx, d.datastore, true); len(failedValidations) > 0 {
+		passback.ProviderValidationErrors = failedValidations
+		return passback, provider.ErrDataValidationFailure
+	} else if err != nil {
+		return AddHardwarePassback{}, errors.Join(
+			fmt.Errorf("failed to validate inventory against inventory provider plugin"),
+			err,
+		)
+	}
+
+	return passback, d.datastore.Flush()
 }

--- a/internal/provider/csm/csm.go
+++ b/internal/provider/csm/csm.go
@@ -177,7 +177,7 @@ func (csm *CSM) ValidateInternal(ctx context.Context, datastore inventory.Datast
 	nodeNIDLookup := map[int][]uuid.UUID{}
 	nodeAliasLookup := map[string][]uuid.UUID{}
 	for _, cHardware := range allHardware.Hardware {
-		if cHardware.Type != hardwaretypes.HardwareTypeNode {
+		if cHardware.Type != hardwaretypes.Node {
 			continue
 		}
 

--- a/internal/provider/csm/csm.go
+++ b/internal/provider/csm/csm.go
@@ -317,10 +317,6 @@ func (csm *CSM) BuildHardwareMetadata(cHardware *inventory.Hardware, rawProperti
 		properties := NodeMetadata{} // Create an empty one
 		if _, exists := cHardware.ProviderProperties["csm"]; exists {
 			// If one exists set it.
-			// TODO Depending on how the data is stored/unmarshalled this might be a map[string]interface{}, so using the mapstructure library might be required to get it into the struct form
-			// https://github.com/Cray-HPE/cani/blob/develop/internal/provider/csm/sls/hardware.go
-			// https://github.com/mitchellh/mapstructure
-
 			if err := mapstructure.Decode(cHardware.ProviderProperties["csm"], &properties); err != nil {
 				return err
 			}
@@ -328,16 +324,32 @@ func (csm *CSM) BuildHardwareMetadata(cHardware *inventory.Hardware, rawProperti
 		// Make changes to the node metadata
 		// The keys of rawProperties need to match what is defined in ./cmd/node/update_node.go
 		if roleRaw, exists := rawProperties["role"]; exists {
-			properties.Role = StringPtr(roleRaw.(string))
+			if roleRaw == nil {
+				properties.Role = nil
+			} else {
+				properties.Role = StringPtr(roleRaw.(string))
+			}
 		}
 		if subroleRaw, exists := rawProperties["subrole"]; exists {
-			properties.SubRole = StringPtr(subroleRaw.(string))
+			if subroleRaw == nil {
+				properties.SubRole = nil
+			} else {
+				properties.SubRole = StringPtr(subroleRaw.(string))
+			}
 		}
 		if nidRaw, exists := rawProperties["nid"]; exists {
-			properties.Nid = IntPtr(nidRaw.(int))
+			if nidRaw == nil {
+				properties.Nid = nil
+			} else {
+				properties.Nid = IntPtr(nidRaw.(int))
+			}
 		}
 		if aliasRaw, exists := rawProperties["alias"]; exists {
-			properties.Alias = StringPtr(aliasRaw.(string))
+			if aliasRaw == nil {
+				properties.Alias = nil
+			} else {
+				properties.Alias = StringPtr(aliasRaw.(string))
+			}
 		}
 
 		cHardware.ProviderProperties["csm"] = properties

--- a/internal/provider/csm/csm.go
+++ b/internal/provider/csm/csm.go
@@ -3,22 +3,15 @@ package csm
 import (
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"net/http"
-	"sort"
-	"strings"
 
 	"github.com/Cray-HPE/cani/internal/inventory"
-	"github.com/Cray-HPE/cani/internal/provider"
-	"github.com/Cray-HPE/cani/internal/provider/csm/validate"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	hsm_client "github.com/Cray-HPE/cani/pkg/hsm-client"
 	sls_client "github.com/Cray-HPE/cani/pkg/sls-client"
-	"github.com/google/uuid"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/mitchellh/mapstructure"
-	"github.com/rs/zerolog/log"
 )
 
 type NewOpts struct {
@@ -107,197 +100,6 @@ func New(opts NewOpts) (*CSM, error) {
 	csm.ValidSubRoles = opts.ValidSubRoles
 
 	return csm, nil
-}
-
-// Validate the external services of the inventory provider are correct
-func (csm *CSM) ValidateExternal(ctx context.Context) error {
-	// Get the dumpate from SLS
-	slsState, reps, err := csm.slsClient.DumpstateApi.DumpstateGet(context.Background())
-	if err != nil {
-		return fmt.Errorf("SLS dumpstate failed. %v\n", err)
-	}
-
-	// Validate the dumpstate returned from SLS
-	err = validate.Validate(&slsState, reps)
-	if err != nil {
-		return fmt.Errorf("Validation failed. %v\n", err)
-	}
-	return nil
-}
-
-func joinUUIDs(ids []uuid.UUID, ignoreID uuid.UUID, sep string) string {
-	idStrs := []string{}
-	for _, id := range ids {
-		if id == ignoreID {
-			continue
-		}
-
-		idStrs = append(idStrs, id.String())
-	}
-
-	sort.Strings(idStrs)
-
-	return strings.Join(idStrs, sep)
-}
-
-// Validate the representation of the inventory data into the destination inventory system
-// is consistent.
-// TODO perhaps this should just happen during Reconcile
-func (csm *CSM) ValidateInternal(ctx context.Context, datastore inventory.Datastore) (map[uuid.UUID]provider.HardwareValidationResult, error) {
-	log.Debug().Msg("Validating datastore contents against the CSM Provider")
-
-	allHardware, err := datastore.List()
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to list hardware from the datastore"),
-			err,
-		)
-	}
-
-	// Build up the validation results map
-	results := map[uuid.UUID]provider.HardwareValidationResult{}
-	for _, cHardware := range allHardware.Hardware {
-		results[cHardware.ID] = provider.HardwareValidationResult{
-			Hardware: cHardware,
-		}
-	}
-
-	validRoles := map[string]bool{}
-	for _, role := range csm.ValidRoles {
-		validRoles[role] = true
-	}
-	validSubRoles := map[string]bool{}
-	for _, subRole := range csm.ValidSubRoles {
-		validSubRoles[subRole] = true
-	}
-
-	//
-	// Uniques checks
-	// The following are checks that can be performed all the time
-	// as it just verifies that the data being added is unique.
-	// Ideally should be ran as early as possible
-	//
-
-	// Verify all specified Node metadata is valid
-	nodeNIDLookup := map[int][]uuid.UUID{}
-	nodeAliasLookup := map[string][]uuid.UUID{}
-	for _, cHardware := range allHardware.Hardware {
-		if cHardware.Type != hardwaretypes.Node {
-			continue
-		}
-
-		log.Debug().Msgf("Validating %s: %v", cHardware.ID, cHardware)
-
-		metadata, err := GetProviderMetadataT[NodeMetadata](cHardware)
-		if err != nil {
-			return nil, errors.Join(
-				fmt.Errorf("failed to get provider metadata from hardware (%s)", cHardware.ID),
-				err,
-			)
-		}
-
-		// There is no metadata for this node
-		if metadata == nil {
-			log.Debug().Msgf("No metadata found for %s", cHardware.ID)
-			continue
-		}
-
-		validationResult := results[cHardware.ID]
-
-		// Verify all specified Roles are valid
-		if metadata.Role != nil {
-			if !validRoles[*metadata.Role] {
-				validationResult.Errors = append(validationResult.Errors,
-					fmt.Sprintf("Specified role (%s) is invalid, choose from: %s", *metadata.Role, strings.Join(csm.ValidRoles, ", ")),
-				)
-			}
-		}
-
-		// Verify all specified SubRoles are valid
-		if metadata.SubRole != nil {
-			if !validRoles[*metadata.SubRole] {
-				validationResult.Errors = append(validationResult.Errors,
-					fmt.Sprintf("Specified sub-role (%s) is invalid, choose from: %s", *metadata.SubRole, strings.Join(csm.ValidSubRoles, ", ")),
-				)
-			}
-		}
-
-		// Verify NID is valid
-		if metadata.Nid != nil {
-			nodeNIDLookup[*metadata.Nid] = append(nodeNIDLookup[*metadata.Nid], cHardware.ID)
-			if *metadata.Nid <= 0 {
-				validationResult.Errors = append(validationResult.Errors,
-					fmt.Sprintf("Specified NID (%d) invalid, needs to be positive integer", *metadata.Nid),
-				)
-			}
-		}
-
-		// Verify Alias is valid
-		if metadata.Alias != nil {
-			nodeAliasLookup[*metadata.Alias] = append(nodeAliasLookup[*metadata.Alias], cHardware.ID)
-
-			// TODO a regex here might be better
-			if strings.Contains(*metadata.Alias, " ") {
-				validationResult.Errors = append(validationResult.Errors,
-					fmt.Sprintf("Specified alias (%d) is invalid, alias contains spaces", *metadata.Nid),
-				)
-			}
-		}
-
-		results[cHardware.ID] = validationResult
-	}
-
-	// Verify all specified NIDs are unique
-	for nid, matchingHardware := range nodeNIDLookup {
-		if len(matchingHardware) > 1 {
-			// We found hardware with duplicate NIDs
-			for _, id := range matchingHardware {
-				validationResult := results[id]
-				validationResult.Errors = append(validationResult.Errors,
-					fmt.Sprintf("Specified NID (%d) is not unique, shared by: %s", nid, joinUUIDs(matchingHardware, id, ", ")),
-				)
-				results[id] = validationResult
-			}
-		}
-	}
-
-	// Verify all specified Aliases are unique
-	for alias, matchingHardware := range nodeAliasLookup {
-		if len(matchingHardware) > 1 {
-			// We found hardware with duplicate NIDs
-			for _, id := range matchingHardware {
-				validationResult := results[id]
-				validationResult.Errors = append(validationResult.Errors,
-					fmt.Sprintf("Specified alias (%s) is not unique, shared by: %s", alias, joinUUIDs(matchingHardware, id, ", ")),
-				)
-				results[id] = validationResult
-			}
-		}
-	}
-
-	//
-	// Missing data checks
-	// These checks should be ran at reconcile time or via a command line options
-	// to ensure all of the required data is present in the datastore before
-	//
-
-	// TODO
-
-	//
-	// Build results
-	//
-	resultsWithErrors := map[uuid.UUID]provider.HardwareValidationResult{}
-	for id, result := range results {
-		if len(result.Errors) > 0 {
-			resultsWithErrors[id] = result
-		}
-	}
-
-	if len(resultsWithErrors) > 0 {
-		return resultsWithErrors, provider.ErrDataValidationFailure
-	}
-
-	return nil, nil
 }
 
 // Import external inventory data into CANI's inventory format

--- a/internal/provider/csm/metadata.go
+++ b/internal/provider/csm/metadata.go
@@ -1,9 +1,7 @@
 package csm
 
 import (
-	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
@@ -19,40 +17,40 @@ type NodeMetadata struct {
 	AdditionalProperties map[string]interface{}
 }
 
-func (nm *NodeMetadata) Validate() error {
-	var validationErrs []error
-	// Role checks
-	if nm.Role == nil {
-		validationErrs = append(validationErrs, fmt.Errorf("no role set"))
-	}
+// func (nm *NodeMetadata) Validate() error {
+// 	var validationErrs []error
+// 	// Role checks
+// 	if nm.Role == nil {
+// 		validationErrs = append(validationErrs, fmt.Errorf("no role set"))
+// 	}
 
-	// Check to see if the role matches what is allowed by HSM
-	// TODO
+// 	// Check to see if the role matches what is allowed by HSM
+// 	// TODO
 
-	// Check to see if the sub-role matches what is allowed by HSM
+// 	// Check to see if the sub-role matches what is allowed by HSM
 
-	// NID checks
-	if nm.Nid == nil {
-		validationErrs = append(validationErrs, fmt.Errorf("no nid set"))
-	}
-	if *nm.Nid < 0 {
-		validationErrs = append(validationErrs, fmt.Errorf("a non-positive NID is set: %d", *nm.Nid))
-	}
+// 	// NID checks
+// 	if nm.Nid == nil {
+// 		validationErrs = append(validationErrs, fmt.Errorf("no nid set"))
+// 	}
+// 	if *nm.Nid < 0 {
+// 		validationErrs = append(validationErrs, fmt.Errorf("a non-positive NID is set: %d", *nm.Nid))
+// 	}
 
-	// Alias checks
-	if nm.Alias == nil {
-		validationErrs = append(validationErrs, fmt.Errorf("no alias set"))
-	}
-	if strings.Contains(*nm.Alias, " ") {
-		validationErrs = append(validationErrs, fmt.Errorf("alias contains spaces"))
-	}
+// 	// Alias checks
+// 	if nm.Alias == nil {
+// 		validationErrs = append(validationErrs, fmt.Errorf("no alias set"))
+// 	}
+// 	if strings.Contains(*nm.Alias, " ") {
+// 		validationErrs = append(validationErrs, fmt.Errorf("alias contains spaces"))
+// 	}
 
-	if len(validationErrs) == 0 {
-		return nil
-	}
+// 	if len(validationErrs) == 0 {
+// 		return nil
+// 	}
 
-	return errors.Join(validationErrs...)
-}
+// 	return errors.Join(validationErrs...)
+// }
 
 // TODO this might need a better home
 func StringPtr(s string) *string {

--- a/internal/provider/csm/metadata.go
+++ b/internal/provider/csm/metadata.go
@@ -1,7 +1,9 @@
 package csm
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
@@ -15,6 +17,41 @@ type NodeMetadata struct {
 	Nid                  *int
 	Alias                *string
 	AdditionalProperties map[string]interface{}
+}
+
+func (nm *NodeMetadata) Validate() error {
+	var validationErrs []error
+	// Role checks
+	if nm.Role == nil {
+		validationErrs = append(validationErrs, fmt.Errorf("no role set"))
+	}
+
+	// Check to see if the role matches what is allowed by HSM
+	// TODO
+
+	// Check to see if the sub-role matches what is allowed by HSM
+
+	// NID checks
+	if nm.Nid == nil {
+		validationErrs = append(validationErrs, fmt.Errorf("no nid set"))
+	}
+	if *nm.Nid < 0 {
+		validationErrs = append(validationErrs, fmt.Errorf("a non-positive NID is set: %d", *nm.Nid))
+	}
+
+	// Alias checks
+	if nm.Alias == nil {
+		validationErrs = append(validationErrs, fmt.Errorf("no alias set"))
+	}
+	if strings.Contains(*nm.Alias, " ") {
+		validationErrs = append(validationErrs, fmt.Errorf("alias contains spaces"))
+	}
+
+	if len(validationErrs) == 0 {
+		return nil
+	}
+
+	return errors.Join(validationErrs...)
 }
 
 // TODO this might need a better home

--- a/internal/provider/csm/metadata.go
+++ b/internal/provider/csm/metadata.go
@@ -17,40 +17,9 @@ type NodeMetadata struct {
 	AdditionalProperties map[string]interface{}
 }
 
-// func (nm *NodeMetadata) Validate() error {
-// 	var validationErrs []error
-// 	// Role checks
-// 	if nm.Role == nil {
-// 		validationErrs = append(validationErrs, fmt.Errorf("no role set"))
-// 	}
-
-// 	// Check to see if the role matches what is allowed by HSM
-// 	// TODO
-
-// 	// Check to see if the sub-role matches what is allowed by HSM
-
-// 	// NID checks
-// 	if nm.Nid == nil {
-// 		validationErrs = append(validationErrs, fmt.Errorf("no nid set"))
-// 	}
-// 	if *nm.Nid < 0 {
-// 		validationErrs = append(validationErrs, fmt.Errorf("a non-positive NID is set: %d", *nm.Nid))
-// 	}
-
-// 	// Alias checks
-// 	if nm.Alias == nil {
-// 		validationErrs = append(validationErrs, fmt.Errorf("no alias set"))
-// 	}
-// 	if strings.Contains(*nm.Alias, " ") {
-// 		validationErrs = append(validationErrs, fmt.Errorf("alias contains spaces"))
-// 	}
-
-// 	if len(validationErrs) == 0 {
-// 		return nil
-// 	}
-
-// 	return errors.Join(validationErrs...)
-// }
+type CabinetMetadata struct {
+	HMNVlan *int
+}
 
 // TODO this might need a better home
 func StringPtr(s string) *string {

--- a/internal/provider/csm/reconcile.go
+++ b/internal/provider/csm/reconcile.go
@@ -76,7 +76,8 @@ func (csm *CSM) Reconcile(ctx context.Context, datastore inventory.Datastore) (e
 	}
 
 	//
-	// Verify expected hardware actions are taking place
+	// Verify expected hardware actions are taking place.
+	// This can detect drift from when hardware was removed/added outside of CANI after the session was started
 	//
 	unexpectedHardwareRemoval := []sls_client.Hardware{}
 	for _, hardware := range hardwareRemoved {

--- a/internal/provider/csm/reconcile.go
+++ b/internal/provider/csm/reconcile.go
@@ -258,28 +258,28 @@ func displayHardwareComparisonReport(hardwareRemoved, hardwareAdded, identicalHa
 
 func displayUnwantedChanges(unwantedHardwareRemoved, unwantedHardwareAdded []sls_client.Hardware) error {
 	if len(unwantedHardwareAdded) != 0 {
-		log.Info().Msgf("")
-		log.Info().Msgf("Unexpected Hardware detected added to the system")
+		log.Error().Msgf("")
+		log.Error().Msgf("Unexpected Hardware detected added to the system")
 		for _, hardware := range unwantedHardwareAdded {
 			hardwareRaw, err := buildHardwareString(hardware)
 			if err != nil {
 				return err
 			}
 
-			log.Info().Msgf("  %-16s - %s", hardware.Xname, hardwareRaw)
+			log.Error().Msgf("  %-16s - %s", hardware.Xname, hardwareRaw)
 		}
 	}
 
 	if len(unwantedHardwareRemoved) != 0 {
-		log.Info().Msgf("")
-		log.Info().Msgf("Unexpected Hardware detected removed from the system")
+		log.Error().Msgf("")
+		log.Error().Msgf("Unexpected Hardware detected removed from the system")
 		for _, hardware := range unwantedHardwareRemoved {
 			hardwareRaw, err := buildHardwareString(hardware)
 			if err != nil {
 				return err
 			}
 
-			log.Info().Msgf("  %-16s - %s", hardware.Xname, hardwareRaw)
+			log.Error().Msgf("  %-16s - %s", hardware.Xname, hardwareRaw)
 		}
 	}
 

--- a/internal/provider/csm/reconcile.go
+++ b/internal/provider/csm/reconcile.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/internal/provider/csm/sls"
 	sls_client "github.com/Cray-HPE/cani/pkg/sls-client"
-	sls_common "github.com/Cray-HPE/hms-sls/v2/pkg/sls-common"
 	"github.com/Cray-HPE/hms-xname/xnametypes"
 	"github.com/rs/zerolog/log"
 )
@@ -83,7 +82,7 @@ func (csm *CSM) Reconcile(ctx context.Context, datastore inventory.Datastore) (e
 	// TODO simulate changes to the SLS state and validate them, and then make the changes
 
 	// Sort hardware so children are deleted before their parents
-	sls.SortHardware(hardwareRemoved)
+	sls.SortHardwareReverse(hardwareRemoved)
 	// Remove hardware that no longer exists
 	for _, hardware := range hardwareRemoved {
 		log.Info().Str("xname", hardware.Xname).Msg("Removing")
@@ -111,7 +110,7 @@ func (csm *CSM) Reconcile(ctx context.Context, datastore inventory.Datastore) (e
 		_, r, err := csm.slsClient.HardwareApi.HardwarePost(ctx, sls.NewHardwarePostOpts(hardware))
 		if err != nil {
 			return errors.Join(
-				fmt.Errorf("failed to delete hardware (%s) from SLS", hardware.Xname),
+				fmt.Errorf("failed to add hardware (%s) to SLS", hardware.Xname),
 				err,
 			)
 		}
@@ -119,13 +118,21 @@ func (csm *CSM) Reconcile(ctx context.Context, datastore inventory.Datastore) (e
 	}
 
 	// Update existing hardware
-	for _, hardware := range hardwareWithDifferingValues {
-		log.Info().Str("xname", hardware.Xname).Msg("Updating")
+	for _, hardwarePair := range hardwareWithDifferingValues {
+		updatedHardware := hardwarePair.HardwareB
+		log.Info().Str("xname", updatedHardware.Xname).Msg("Updating")
 		// Put into transaction log with old and new value
 		// TODO
 
 		// Perform a PUT against SLS
-		// TODO
+		_, r, err := csm.slsClient.HardwareApi.HardwareXnamePut(ctx, updatedHardware.Xname, sls.NewHardwareXnamePutOpts(updatedHardware))
+		if err != nil {
+			return errors.Join(
+				fmt.Errorf("failed to update hardware (%s) from SLS", updatedHardware.Xname),
+				err,
+			)
+		}
+		log.Info().Int("status", r.StatusCode).Msg("Updated hardware to SLS")
 	}
 
 	return nil
@@ -147,7 +154,7 @@ func displayHardwareComparisonReport(hardwareRemoved, hardwareAdded, identicalHa
 			return err
 		}
 
-		log.Info().Msgf("  %-16s - %s\n", hardware.Xname, hardwareRaw)
+		log.Info().Msgf("  %-16s - %s", hardware.Xname, hardwareRaw)
 	}
 
 	log.Info().Msgf("")
@@ -156,7 +163,7 @@ func displayHardwareComparisonReport(hardwareRemoved, hardwareAdded, identicalHa
 		log.Info().Msg("  None")
 	}
 	for _, pair := range hardwareWithDifferingValues {
-		log.Info().Msgf("  %s\n", pair.Xname)
+		log.Info().Msgf("  %s", pair.Xname)
 
 		// Expected Hardware json
 		pair.HardwareA.LastUpdated = 0
@@ -165,7 +172,7 @@ func displayHardwareComparisonReport(hardwareRemoved, hardwareAdded, identicalHa
 		if err != nil {
 			return err
 		}
-		log.Info().Msgf("  - Expected: %-16s\n", hardwareRaw)
+		log.Info().Msgf("  - Expected: %-16s", hardwareRaw)
 
 		// Actual Hardware json
 		pair.HardwareB.LastUpdated = 0
@@ -174,7 +181,7 @@ func displayHardwareComparisonReport(hardwareRemoved, hardwareAdded, identicalHa
 		if err != nil {
 			return err
 		}
-		log.Info().Msgf("  - Actual:   %-16s\n", hardwareRaw)
+		log.Info().Msgf("  - Actual:   %-16s", hardwareRaw)
 	}
 
 	log.Info().Msgf("")
@@ -188,7 +195,7 @@ func displayHardwareComparisonReport(hardwareRemoved, hardwareAdded, identicalHa
 			return err
 		}
 
-		log.Info().Msgf("  %-16s - %s\n", hardware.Xname, hardwareRaw)
+		log.Info().Msgf("  %-16s - %s", hardware.Xname, hardwareRaw)
 	}
 
 	log.Info().Msgf("")
@@ -202,7 +209,7 @@ func displayHardwareComparisonReport(hardwareRemoved, hardwareAdded, identicalHa
 			return err
 		}
 
-		log.Info().Msgf("  %-16s - %s\n", hardware.Xname, hardwareRaw)
+		log.Info().Msgf("  %-16s - %s", hardware.Xname, hardwareRaw)
 	}
 
 	log.Info().Msgf("")
@@ -228,7 +235,7 @@ func buildHardwareString(hardware sls_client.Hardware) (string, error) {
 	case xnametypes.NodeBMC:
 		// Nothing to do
 	case xnametypes.Node:
-		if extraProperties, ok := extraPropertiesRaw.(sls_common.ComptypeNode); ok {
+		if extraProperties, ok := extraPropertiesRaw.(sls_client.HardwareExtraPropertiesNode); ok {
 			tokens = append(tokens, fmt.Sprintf("Aliases: [%s]", strings.Join(extraProperties.Aliases, ",")))
 			if extraProperties.Role != "" {
 				tokens = append(tokens, fmt.Sprintf("Role: %s", extraProperties.Role))
@@ -241,7 +248,7 @@ func buildHardwareString(hardware sls_client.Hardware) (string, error) {
 			}
 		}
 	case xnametypes.MgmtSwitch:
-		if extraProperties, ok := extraPropertiesRaw.(sls_common.ComptypeMgmtSwitch); ok {
+		if extraProperties, ok := extraPropertiesRaw.(sls_client.HardwareExtraPropertiesMgmtSwitch); ok {
 			tokens = append(tokens,
 				fmt.Sprintf("Aliases: [%s]", strings.Join(extraProperties.Aliases, ",")),
 				fmt.Sprintf("Brand: %s", extraProperties.Brand),
@@ -250,11 +257,11 @@ func buildHardwareString(hardware sls_client.Hardware) (string, error) {
 			if extraProperties.Model != "" {
 				tokens = append(tokens, fmt.Sprintf("Model: %s", extraProperties.Model))
 			}
-			if extraProperties.IP4Addr != "" {
-				tokens = append(tokens, fmt.Sprintf("IP4Addr: %s", extraProperties.IP4Addr))
+			if extraProperties.IP4addr != "" {
+				tokens = append(tokens, fmt.Sprintf("IP4addr: %s", extraProperties.IP4addr))
 			}
-			if extraProperties.IP6Addr != "" {
-				tokens = append(tokens, fmt.Sprintf("IP6Addr: %s", extraProperties.IP6Addr))
+			if extraProperties.IP6addr != "" {
+				tokens = append(tokens, fmt.Sprintf("IP6addr: %s", extraProperties.IP6addr))
 			}
 
 			tokens = append(tokens,
@@ -266,7 +273,7 @@ func buildHardwareString(hardware sls_client.Hardware) (string, error) {
 			)
 		}
 	case xnametypes.MgmtHLSwitch:
-		if extraProperties, ok := extraPropertiesRaw.(sls_common.ComptypeMgmtHLSwitch); ok {
+		if extraProperties, ok := extraPropertiesRaw.(sls_client.HardwareExtraPropertiesMgmtHlSwitch); ok {
 			tokens = append(tokens,
 				fmt.Sprintf("Aliases: [%s]", strings.Join(extraProperties.Aliases, ",")),
 				fmt.Sprintf("Brand: %s", extraProperties.Brand),
@@ -275,15 +282,15 @@ func buildHardwareString(hardware sls_client.Hardware) (string, error) {
 			if extraProperties.Model != "" {
 				tokens = append(tokens, fmt.Sprintf("Model: %s", extraProperties.Model))
 			}
-			if extraProperties.IP4Addr != "" {
-				tokens = append(tokens, fmt.Sprintf("IP4Addr: %s", extraProperties.IP4Addr))
+			if extraProperties.IP4addr != "" {
+				tokens = append(tokens, fmt.Sprintf("IP4addr: %s", extraProperties.IP4addr))
 			}
-			if extraProperties.IP6Addr != "" {
-				tokens = append(tokens, fmt.Sprintf("IP6Addr: %s", extraProperties.IP6Addr))
+			if extraProperties.IP6addr != "" {
+				tokens = append(tokens, fmt.Sprintf("IP6addr: %s", extraProperties.IP6addr))
 			}
 		}
 	case xnametypes.MgmtSwitchConnector:
-		if extraProperties, ok := extraPropertiesRaw.(sls_common.ComptypeMgmtSwitchConnector); ok {
+		if extraProperties, ok := extraPropertiesRaw.(sls_client.HardwareExtraPropertiesMgmtSwitchConnector); ok {
 			tokens = append(tokens,
 				fmt.Sprintf("VendorName: %s", extraProperties.VendorName),
 				fmt.Sprintf("NodeNics: [%s]", strings.Join(extraProperties.NodeNics, ",")),

--- a/internal/provider/csm/sls/hardware.go
+++ b/internal/provider/csm/sls/hardware.go
@@ -74,3 +74,21 @@ func SortHardwareReverse(hardware []sls_client.Hardware) {
 		return hardware[i].Xname > hardware[j].Xname
 	})
 }
+
+// FilterHardware will apply the given filter to a map of generic hardware
+func FilterHardware(allHardware map[string]sls_client.Hardware, filter func(sls_client.Hardware) (bool, error)) (map[string]sls_client.Hardware, error) {
+	result := map[string]sls_client.Hardware{}
+
+	for xname, hardware := range allHardware {
+		ok, err := filter(hardware)
+		if err != nil {
+			return nil, err
+		}
+
+		if ok {
+			result[xname] = hardware
+		}
+	}
+
+	return result, nil
+}

--- a/internal/provider/csm/sls/hardware.go
+++ b/internal/provider/csm/sls/hardware.go
@@ -54,8 +54,23 @@ func NewHardwarePostOpts(hardware sls_client.Hardware) *sls_client.HardwareApiHa
 	}
 }
 
+func NewHardwareXnamePutOpts(hardware sls_client.Hardware) *sls_client.HardwareApiHardwareXnamePutOpts {
+	return &sls_client.HardwareApiHardwareXnamePutOpts{
+		Body: optional.NewInterface(sls_client.HardwarePut{
+			Class:           &hardware.Class,
+			ExtraProperties: &hardware.ExtraProperties,
+		}),
+	}
+}
+
 func SortHardware(hardware []sls_client.Hardware) {
 	sort.Slice(hardware, func(i, j int) bool {
 		return hardware[i].Xname < hardware[j].Xname
+	})
+}
+
+func SortHardwareReverse(hardware []sls_client.Hardware) {
+	sort.Slice(hardware, func(i, j int) bool {
+		return hardware[i].Xname > hardware[j].Xname
 	})
 }

--- a/internal/provider/csm/validation.go
+++ b/internal/provider/csm/validation.go
@@ -164,6 +164,10 @@ func (csm *CSM) validateInternalNode(allHardware map[uuid.UUID]inventory.Hardwar
 		if metadata.Alias != nil {
 			nodeAliasLookup[*metadata.Alias] = append(nodeAliasLookup[*metadata.Alias], cHardware.ID)
 
+			if metadata.Alias != nil && len(*metadata.Alias) == 0 {
+				validationResult.Errors = append(validationResult.Errors, "Specified Alias is empty")
+			}
+
 			// TODO a regex here might be better
 			if strings.Contains(*metadata.Alias, " ") {
 				validationResult.Errors = append(validationResult.Errors,

--- a/internal/provider/csm/validation.go
+++ b/internal/provider/csm/validation.go
@@ -120,7 +120,7 @@ func (csm *CSM) validateInternalNode(allHardware map[uuid.UUID]inventory.Hardwar
 		// There is no metadata for this node
 		if metadata == nil {
 			log.Debug().Msgf("No metadata found for %s", cHardware.ID)
-			continue
+			metadata = &NodeMetadata{}
 		}
 
 		//

--- a/internal/provider/csm/validation.go
+++ b/internal/provider/csm/validation.go
@@ -1,0 +1,230 @@
+package csm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Cray-HPE/cani/internal/inventory"
+	"github.com/Cray-HPE/cani/internal/provider"
+	"github.com/Cray-HPE/cani/internal/provider/csm/validate"
+	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+)
+
+func joinUUIDs(ids []uuid.UUID, ignoreID uuid.UUID, sep string) string {
+	idStrs := []string{}
+	for _, id := range ids {
+		if id == ignoreID {
+			continue
+		}
+
+		idStrs = append(idStrs, id.String())
+	}
+
+	sort.Strings(idStrs)
+
+	return strings.Join(idStrs, sep)
+}
+
+// Validate the external services of the inventory provider are correct
+func (csm *CSM) ValidateExternal(ctx context.Context) error {
+	// Get the dumpate from SLS
+	slsState, reps, err := csm.slsClient.DumpstateApi.DumpstateGet(context.Background())
+	if err != nil {
+		return fmt.Errorf("SLS dumpstate failed. %v\n", err)
+	}
+
+	// Validate the dumpstate returned from SLS
+	err = validate.Validate(&slsState, reps)
+	if err != nil {
+		return fmt.Errorf("Validation failed. %v\n", err)
+	}
+	return nil
+}
+
+// Validate the representation of the inventory data into the destination inventory system
+// is consistent. The default set of checks will verify all currently provided data is valid.
+// If enableRequiredDataChecks is set to true, additional checks focusing on missing data will be ran.
+func (csm *CSM) ValidateInternal(ctx context.Context, datastore inventory.Datastore, enableRequiredDataChecks bool) (map[uuid.UUID]provider.HardwareValidationResult, error) {
+	log.Debug().Msg("Validating datastore contents against the CSM Provider")
+
+	allHardware, err := datastore.List()
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("failed to list hardware from the datastore"),
+			err,
+		)
+	}
+
+	// Build up the validation results map
+	results := map[uuid.UUID]provider.HardwareValidationResult{}
+	for _, cHardware := range allHardware.Hardware {
+		results[cHardware.ID] = provider.HardwareValidationResult{
+			Hardware: cHardware,
+		}
+	}
+
+	// Perform validations
+	if err := csm.validateInternalNode(allHardware.Hardware, enableRequiredDataChecks, results); err != nil {
+		return nil, err
+	}
+
+	//
+	// Build results
+	//
+	resultsWithErrors := map[uuid.UUID]provider.HardwareValidationResult{}
+	for id, result := range results {
+		if len(result.Errors) > 0 {
+			resultsWithErrors[id] = result
+		}
+	}
+
+	if len(resultsWithErrors) > 0 {
+		return resultsWithErrors, provider.ErrDataValidationFailure
+	}
+
+	return nil, nil
+}
+
+func (csm *CSM) validateInternalNode(allHardware map[uuid.UUID]inventory.Hardware, enableRequiredDataChecks bool, results map[uuid.UUID]provider.HardwareValidationResult) error {
+	validRoles := map[string]bool{}
+	for _, role := range csm.ValidRoles {
+		validRoles[role] = true
+	}
+	validSubRoles := map[string]bool{}
+	for _, subRole := range csm.ValidSubRoles {
+		validSubRoles[subRole] = true
+	}
+
+	// Verify all specified Node metadata is valid
+	nodeNIDLookup := map[int][]uuid.UUID{}
+	nodeAliasLookup := map[string][]uuid.UUID{}
+	for _, cHardware := range allHardware {
+		if cHardware.Type != hardwaretypes.Node {
+			continue
+		}
+		log.Debug().Msgf("Validating %s: %v", cHardware.ID, cHardware)
+
+		metadata, err := GetProviderMetadataT[NodeMetadata](cHardware)
+		if err != nil {
+			return errors.Join(
+				fmt.Errorf("failed to get provider metadata from hardware (%s)", cHardware.ID),
+				err,
+			)
+		}
+
+		// There is no metadata for this node
+		if metadata == nil {
+			log.Debug().Msgf("No metadata found for %s", cHardware.ID)
+			continue
+		}
+
+		//
+		// Uniques checks
+		// The following are checks that can be performed all the time
+		// as it just verifies that the data being added is unique.
+		// Ideally should be ran as early as possible
+		//
+
+		validationResult := results[cHardware.ID]
+
+		// Verify all specified Roles are valid
+		if metadata.Role != nil {
+			if !validRoles[*metadata.Role] {
+				validationResult.Errors = append(validationResult.Errors,
+					fmt.Sprintf("Specified role (%s) is invalid, choose from: %s", *metadata.Role, strings.Join(csm.ValidRoles, ", ")),
+				)
+			}
+		}
+
+		// Verify all specified SubRoles are valid
+		if metadata.SubRole != nil {
+			if !validRoles[*metadata.SubRole] {
+				validationResult.Errors = append(validationResult.Errors,
+					fmt.Sprintf("Specified sub-role (%s) is invalid, choose from: %s", *metadata.SubRole, strings.Join(csm.ValidSubRoles, ", ")),
+				)
+			}
+		}
+
+		// Verify NID is valid
+		if metadata.Nid != nil {
+			nodeNIDLookup[*metadata.Nid] = append(nodeNIDLookup[*metadata.Nid], cHardware.ID)
+			if *metadata.Nid <= 0 {
+				validationResult.Errors = append(validationResult.Errors,
+					fmt.Sprintf("Specified NID (%d) invalid, needs to be positive integer", *metadata.Nid),
+				)
+			}
+		}
+
+		// Verify Alias is valid
+		if metadata.Alias != nil {
+			nodeAliasLookup[*metadata.Alias] = append(nodeAliasLookup[*metadata.Alias], cHardware.ID)
+
+			// TODO a regex here might be better
+			if strings.Contains(*metadata.Alias, " ") {
+				validationResult.Errors = append(validationResult.Errors,
+					fmt.Sprintf("Specified alias (%d) is invalid, alias contains spaces", *metadata.Nid),
+				)
+			}
+		}
+
+		if enableRequiredDataChecks {
+			//
+			// Missing data checks
+			// These checks should be ran at reconcile time or via a command line options
+			// to ensure all of the required data is present in the datastore before
+			//
+
+			// Required Node data checks. All nodes require
+			// - Alias
+			// - NID
+			// - Role
+			if metadata.Role == nil {
+				validationResult.Errors = append(validationResult.Errors, "Missing required information: Role is not set")
+			}
+			if metadata.Nid == nil {
+				validationResult.Errors = append(validationResult.Errors, "Missing required information: NID is not set")
+			}
+			if metadata.Alias == nil {
+				validationResult.Errors = append(validationResult.Errors, "Missing required information: Alias is not set")
+			}
+
+		}
+
+		results[cHardware.ID] = validationResult
+	}
+
+	// Verify all specified NIDs are unique
+	for nid, matchingHardware := range nodeNIDLookup {
+		if len(matchingHardware) > 1 {
+			// We found hardware with duplicate NIDs
+			for _, id := range matchingHardware {
+				validationResult := results[id]
+				validationResult.Errors = append(validationResult.Errors,
+					fmt.Sprintf("Specified NID (%d) is not unique, shared by: %s", nid, joinUUIDs(matchingHardware, id, ", ")),
+				)
+				results[id] = validationResult
+			}
+		}
+	}
+
+	// Verify all specified Aliases are unique
+	for alias, matchingHardware := range nodeAliasLookup {
+		if len(matchingHardware) > 1 {
+			// We found hardware with duplicate NIDs
+			for _, id := range matchingHardware {
+				validationResult := results[id]
+				validationResult.Errors = append(validationResult.Errors,
+					fmt.Sprintf("Specified alias (%s) is not unique, shared by: %s", alias, joinUUIDs(matchingHardware, id, ", ")),
+				)
+				results[id] = validationResult
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/Cray-HPE/cani/internal/inventory"
+	"github.com/google/uuid"
 )
 
 // TODO Need to think about how internal data structures should be supplied to the Inventory Provider
@@ -14,7 +15,7 @@ type InventoryProvider interface {
 	// Validate the representation of the inventory data into the destination inventory system
 	// is consistent.
 	// TODO perhaps this should just happen during Reconcile
-	ValidateInternal(ctx context.Context) error
+	ValidateInternal(ctx context.Context, datastore inventory.Datastore) (map[uuid.UUID]HardwareValidationResult, error)
 
 	// Import external inventory data into CANI's inventory format
 	Import(ctx context.Context, datastore inventory.Datastore) error
@@ -25,4 +26,9 @@ type InventoryProvider interface {
 	// Build metadata, and add ito the hardware object
 	// This function could return the data to put into object
 	BuildHardwareMetadata(hw *inventory.Hardware, rawProperties map[string]interface{}) error
+}
+
+type HardwareValidationResult struct {
+	Hardware inventory.Hardware
+	Errors   []string
 }

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -2,10 +2,13 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/google/uuid"
 )
+
+var ErrDataValidationFailure = fmt.Errorf("data validation failure")
 
 // TODO Need to think about how internal data structures should be supplied to the Inventory Provider
 type InventoryProvider interface {

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -16,9 +16,9 @@ type InventoryProvider interface {
 	ValidateExternal(ctx context.Context) error
 
 	// Validate the representation of the inventory data into the destination inventory system
-	// is consistent.
-	// TODO perhaps this should just happen during Reconcile
-	ValidateInternal(ctx context.Context, datastore inventory.Datastore) (map[uuid.UUID]HardwareValidationResult, error)
+	// is consistent. The default set of checks will verify all currently provided data is valid.
+	// If enableRequiredDataChecks is set to true, additional checks focusing on missing data will be ran.
+	ValidateInternal(ctx context.Context, datastore inventory.Datastore, enableRequiredDataChecks bool) (map[uuid.UUID]HardwareValidationResult, error)
 
 	// Import external inventory data into CANI's inventory format
 	Import(ctx context.Context, datastore inventory.Datastore) error


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->
## CSM Provider changes
- SLS State generator now returns a mapping of xnames to CANI Hardware UUIDs/hardware objects, so we can easily figure out what CANI hardware object created what SLS Hardware object 
- Changes to reconcile
   - Added first pass at adding data validation logic to verify all required data is present in the CANI hardware inventory to properly build up the SLS representation.
   - Verify hardware that was detected as being removed/added has a matching CANI hardware status. If hardware is being detected of being removed/added that doesn't match the CANI status then an error will be raised, and no changes to the system will be performed.
   - Right now as a stop gap due to the lack of a data import, hardware that does not exist in the CANI hardware inventory on the system is removed consideration, do not trigger the validation check about. Once we have a data import this hack can be removed.
   - Added an initial CabinetMetadata struct, but nothing is done with it yet
   - Added a list of default HSM Roles and SubRoles, they get stored in the cani.yaml file when a session is started, and loaded from it when adjusting the CANI inventory.

## Domain changes 
- Created/updated Passback structs to pass information back up the command line layer so it can be presented in a niced way.  The passback structs now contain the validation errors that were created by the provider plugin.
- Validation function also now calls the provider's ValidateInternal 

## Command package changes
Add some simple logic to display the various passbacks. These are in a rough form right now, but something to display something is wrong.  


```
[~/Documents/Github/cani]$ rm -rv  ~/.cani/                    *[validate-required-data-is-present-and-reconcile-improvements]

/Users/ryansjostrand/.cani//canidb.json
/Users/ryansjostrand/.cani//cani.yml
/Users/ryansjostrand/.cani//canidb.log
/Users/ryansjostrand/.cani/
[~/Documents/Github/cani]$ curl -X POST -F "sls_dump=@/Users/ryansjostrand/Documents/GithubHPE/hpc-shasta-system-configs//fenrir/1.4/sls_input_file.json" http://localhost:8376/v1/loadstate -i 
HTTP/1.1 100 Continue

HTTP/1.1 204 No Content
Date: Tue, 30 May 2023 21:02:35 GMT

[~/Documents/Github/cani]$ go run . alpha session start csm --csm-sim-urls

{"level":"info","time":1685480577,"message":"/Users/ryansjostrand/.cani/cani.yml does not exist, creating default config file"}
4:02PM INF /Users/ryansjostrand/.cani/canidb.json does not exist, creating default datastore
4:02PM INF Validated CANI inventory
2023/05/30 16:02:57 [DEBUG] GET https://localhost:8443/apis/sls/v1/dumpstate
4:02PM INF Validated external inventory provider
4:02PM INF Session is now ACTIVE with provider csm and datastore /Users/ryansjostrand/.cani/canidb.json
[~/Documents/Github/cani]$ go run . alpha add blade hpe-crayex-ex235a-compute-blade --cabinet 1001 --chassis 1 --slot 1

4:03PM INF Added blade hpe-crayex-ex235a-compute-blade
4:03PM INF For provider 'csm', additional metadata is needed for each Node in the NodeBlade:


[~/Documents/Github/cani]$ go run . alpha validate             *[validate-required-data-is-present-and-reconcile-improvements]

4:03PM WRN This may fail in the HMS Simulator without Network information.
4:03PM ERR Inventory data validation errors encountered
4:03PM ERR   da2a61ec-0d2e-4996-aad4-3d4da1a6ab1d: Cabinet:1001->Chassis:1->NodeBlade:1->NodeCard:1->Node:0
4:03PM ERR     - Missing required information: Alias is not set
4:03PM ERR     - Missing required information: NID is not set
4:03PM ERR     - Missing required information: Role is not set
4:03PM ERR   a37df0f1-ee6e-45cc-8121-d7ebbf3272e3: Cabinet:1001->Chassis:1->NodeBlade:1->NodeCard:0->Node:0
4:03PM ERR     - Missing required information: Alias is not set
4:03PM ERR     - Missing required information: NID is not set
4:03PM ERR     - Missing required information: Role is not set
Error: data validation failure
exit status 1

[~/Documents/Github/cani]$ go run . alpha update node --cabinet "1001" --chassis "1" --slot "1" --bmc "0" --node "0" --role "Compute" --alias "nid000001" --nid 1

4:03PM INF Updated node
[~/Documents/Github/cani]$ go run . alpha validate             *[validate-required-data-is-present-and-reconcile-improvements]

4:03PM WRN This may fail in the HMS Simulator without Network information.
4:03PM ERR Inventory data validation errors encountered
4:03PM ERR   da2a61ec-0d2e-4996-aad4-3d4da1a6ab1d: Cabinet:1001->Chassis:1->NodeBlade:1->NodeCard:1->Node:0
4:03PM ERR     - Missing required information: Alias is not set
4:03PM ERR     - Missing required information: NID is not set
4:03PM ERR     - Missing required information: Role is not set
Error: data validation failure
exit status 1

[~/Documents/Github/cani]$ go run . alpha update node --cabinet "1001" --chassis "1" --slot "1" --bmc "1" --node "0" --role "Compute" --alias "nid00002" --nid 2

4:03PM INF Updated node
[~/Documents/Github/cani]$ go run . alpha validate             *[validate-required-data-is-present-and-reconcile-improvements]

4:03PM WRN This may fail in the HMS Simulator without Network information.
4:03PM INF Validated CANI inventory
2023/05/30 16:03:57 [DEBUG] GET https://localhost:8443/apis/sls/v1/dumpstate
4:03PM INF Validated external inventory provider

[~/Documents/Github/cani]$ go run . alpha update node --cabinet "1001" --chassis "1" --slot "1" --bmc "1" --node "0" --role "Compute2" --alias "" --nid 2

4:09PM ERR Inventory data validation errors encountered
4:09PM ERR   da2a61ec-0d2e-4996-aad4-3d4da1a6ab1d: Cabinet:1001->Chassis:1->NodeBlade:1->NodeCard:1->Node:0
4:09PM ERR     - Specified Alias is empty
4:09PM ERR     - Specified role (Compute2) is invalid, choose from: Compute, Service, System, Application, Storage, Management
Error: data validation failure
exit status 1

[~/Documents/Github/cani]$ go run . alpha session stop                                                  *[validate-required-data-is-present-and-reconcile-improvements]

4:10PM INF Session is STOPPED
Would you like to reconcile and commit /Users/ryansjostrand/.cani/canidb.json: y
4:11PM INF Committing changes to session
4:11PM WRN DatastoreJSON's Validate was called. This is not currently implemented
2023/05/30 16:11:02 [DEBUG] GET https://localhost:8443/apis/sls/v1/dumpstate
4:11PM INF Starting CSM reconcile process
2023/05/30 16:11:03 [DEBUG] GET https://localhost:8443/apis/sls/v1/dumpstate
4:11PM INF Generated Extra Properties for x1001c1s1b0n0 nodeEp={"Aliases":["nid000001"],"NID":1,"Role":"Compute"}
4:11PM INF Generated Extra Properties for x1001c1s1b1n0 nodeEp={"Aliases":["nid00002"],"NID":2,"Role":"Compute"}
4:11PM INF
4:11PM INF Identical hardware between current and expected states
4:11PM INF   None
4:11PM INF
4:11PM INF Common hardware between current and expected states with differing class or extra properties
4:11PM INF   None
4:11PM INF
4:11PM INF Hardware added to the system
4:11PM INF   x1001c1s1b0n0    - Type: Node, Aliases: [nid000001], Role: Compute, NID: 1
4:11PM INF   x1001c1s1b1n0    - Type: Node, Aliases: [nid00002], Role: Compute, NID: 2
4:11PM INF
4:11PM INF Hardware removed from system
4:11PM INF   None
4:11PM INF
4:11PM INF Adding xname=x1001c1s1b0n0
2023/05/30 16:11:03 [DEBUG] POST https://localhost:8443/apis/sls/v1/hardware
4:11PM INF Added hardware to SLS status=201
4:11PM INF Adding xname=x1001c1s1b1n0
2023/05/30 16:11:03 [DEBUG] POST https://localhost:8443/apis/sls/v1/hardware
4:11PM INF Added hardware to SLS status=201
Summary:
--------
ID                                             TYPE            STATUS
b5ed1d37-37ea-450d-bb9b-a1636e54047c      NodeController  (staged)
da2a61ec-0d2e-4996-aad4-3d4da1a6ab1d  Node            (staged)
da8d5849-e54a-4752-94dc-363474f29d7d  NodeCard        (staged)
0566210b-3441-4686-aa93-03c7d7b66718  NodeBlade       (staged)
2ec39cd4-e9b3-47db-ab97-73ca8a827b86  NodeController  (staged)
a37df0f1-ee6e-45cc-8121-d7ebbf3272e3  Node            (staged)
1e3dcf96-9ab1-4220-b721-c8daa7d6d86a  NodeCard        (staged)

7 new hardware item(s) are in the inventory:
```

Commands I used:
```
# Start session
go run . alpha session start csm --csm-sim-urls

go run . alpha add blade hpe-crayex-ex235a-compute-blade --cabinet 1001 --chassis 1 --slot 1
go run . alpha validate

go run . alpha update node --cabinet "1001" --chassis "1" --slot "1" --bmc "0" --node "0" --role "Compute" --alias "nid000001" --nid 1
go run . alpha validate


go run . alpha update node --cabinet "1001" --chassis "1" --slot "1" --bmc "1" --node "0" --role "Compute" --alias "nid00002" --nid 2
go run . alpha validate


go run . alpha update node --cabinet "1001" --chassis "1" --slot "1" --bmc "1" --node "0" --role "Compute2" --alias "" --nid 2


```

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

