### PR TITLE
add cabinet with getSystemZero

### DIFF
--- a/cmd/cabinet/add_cabinet.go
+++ b/cmd/cabinet/add_cabinet.go
@@ -79,12 +79,7 @@ func addCabinet(cmd *cobra.Command, args []string) error {
 	for _, result := range result.AddedHardware {
 		// If the type is a Node
 		if result.Hardware.Type == hardwaretypes.Cabinet {
-			log.Debug().Msg(result.Location.String())
-			log.Debug().Msgf("This %s also contains a %s (%s) added at %s",
-				hardwaretypes.NodeBlade,
-				hardwaretypes.Node,
-				result.Hardware.ID.String(),
-				result.Location)
+			log.Debug().Msgf("%s added at %s with parent %s (%s)", result.Hardware.Type, result.Location.String(), hardwaretypes.System, result.Hardware.Parent)
 			// Add the node to the map
 			newNodes = append(newNodes, result)
 		}

--- a/internal/domain/cabinet.go
+++ b/internal/domain/cabinet.go
@@ -17,19 +17,12 @@ func (d *Domain) AddCabinet(ctx context.Context, deviceTypeSlug string, cabinetO
 	// Validate provided cabinet exists
 	// TODO
 
-	// TODO this is just a stand in, just for testing
-	cabinet := inventory.Hardware{
-		ID:              uuid.New(),
-		Type:            hardwaretypes.Cabinet,
-		Status:          inventory.HardwareStatusProvisioned,
-		LocationOrdinal: &cabinetOrdinal,
-	}
-	if err := d.datastore.Add(&cabinet); err != nil {
+	system, err := d.datastore.GetSystemZero()
+	if err != nil {
 		return AddHardwareResult{}, errors.Join(
-			fmt.Errorf("unable to add cabinet hardware"),
+			fmt.Errorf("unable to get system zero"),
 			err,
 		)
-
 	}
 
 	// Verify the provided device type slug is a node blade
@@ -41,9 +34,8 @@ func (d *Domain) AddCabinet(ctx context.Context, deviceTypeSlug string, cabinetO
 		return AddHardwareResult{}, fmt.Errorf("provided device hardware type (%s) is not a %s", deviceTypeSlug, hardwaretypes.Cabinet) // TODO better error message
 	}
 
-	// Generate a hardware build out
-	// FIXME: no parent
-	hardwareBuildOutItems, err := d.hardwareTypeLibrary.GetDefaultHardwareBuildOut(deviceTypeSlug, 0, uuid.UUID{})
+	// Generate a hardware build out using the system as a parent
+	hardwareBuildOutItems, err := d.hardwareTypeLibrary.GetDefaultHardwareBuildOut(deviceTypeSlug, 0, system.ID)
 	if err != nil {
 		return AddHardwareResult{}, errors.Join(
 			fmt.Errorf("unable to build default hardware build out for %s", deviceTypeSlug),

--- a/internal/inventory/datastore.go
+++ b/internal/inventory/datastore.go
@@ -30,6 +30,8 @@ type Datastore interface {
 	GetLocation(hardware Hardware) (LocationPath, error)
 	GetAtLocation(path LocationPath) (Hardware, error)
 	GetChildren(id uuid.UUID) ([]Hardware, error)
+	GetSystemZero() (Hardware, error)              // TODO replace this when multiple systems are supported
+	GetSystem(hardware Hardware) (Hardware, error) // Not yet implemented until multiple systems are supported
 
 	// TODO for search properties
 }

--- a/pkg/hardwaretypes/types.go
+++ b/pkg/hardwaretypes/types.go
@@ -28,6 +28,7 @@ type HardwareType string
 
 // TODO should give a description of each of these
 const (
+	System                         HardwareType = "System" // Serves as a top-level object, not a child of anything, though there can be multiple systems in a domain that hardware can move between
 	Cabinet                        HardwareType = "Cabinet"
 	Chassis                        HardwareType = "Chassis"
 	ChassisManagementModule        HardwareType = "ChassisManagementModule"


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- Adds a cabinet with a parent System
- this assumes one system exists, which is setup during a new session
- 

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Low.

```
rm -rf ~/.cani && go run . alpha session start csm --csm-sim-urls -D && ls -l ~/.cani
go run main.go alpha add cabinet hpe-ex2000 -D
# verified cabinet types had the system set as their parent
```