### PR TITLE
update add cabinet flags for vlan and cabinet number

### DIFF
--- a/cmd/cabinet/init.go
+++ b/cmd/cabinet/init.go
@@ -5,9 +5,9 @@ import (
 )
 
 var (
-	hwType      string
-	supportedHw []string
-	cabinet     int
+	cabinetNumber int
+	vlanId        int
+	auto          bool
 )
 
 func init() {
@@ -19,8 +19,9 @@ func init() {
 	// Add a flag to show supported types
 	AddCabinetCmd.Flags().BoolP("list-supported-types", "L", false, "List supported hardware types.")
 
-	// Blades have several parents, so we need to add flags for each
-	AddCabinetCmd.Flags().IntVar(&cabinet, "cabinet", 1001, "Cabinet ordinal.")
-	// AddCabinetCmd.Flags().IntVar(&hmnVlan, "hmn-vlan", -1, "Optional: HMN Vlan ")
-
+	// Cabinets
+	AddCabinetCmd.Flags().IntVar(&cabinetNumber, "cabinet", 1001, "Cabinet number.")
+	AddCabinetCmd.Flags().IntVar(&vlanId, "vlan-id", -1, "Vlan ID for the cabinet.")
+	AddCabinetCmd.MarkFlagsRequiredTogether("cabinet", "vlan-id")
+	AddCabinetCmd.Flags().BoolVar(&auto, "auto", false, "Automatically recommend and assign required flags.")
 }


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

Adds `add cabinet` flags that conform to our upcoming plans

```
% go run main.go alpha add cabinet hpe-ex2000 --auto                                                                                                                                                                       13:34
1:35PM INF Automatically assigning cabinet number and VLAN ID
1:35PM INF Suggested VLAN ID: -1
1:35PM INF Suggested cabinet number: 1001
✗ Would you like to accept the recommendations and add the Cabinet: 
1:35PM WRN Cabinet hpe-ex2000 was NOT added to the inventory                                                                                                                                                                                      ~/git/csminv
% go run main.go alpha add cabinet hpe-ex2000 --auto                                                                                                                                                                       13:35
1:35PM INF Automatically assigning cabinet number and VLAN ID
1:35PM INF Suggested VLAN ID: -1
1:35PM INF Suggested cabinet number: 1001
Would you like to accept the recommendations and add the Cabinet: y
1:35PM INF Added cabinet hpe-ex2000
1:35PM INF UUID: 204e297d-a51f-4863-b2a5-85b84c771cc5
1:35PM INF Cabinet Number: 1001
1:35PM INF VLAN ID: -1                                                                                                                                                                                               ~/git/csminv
% go run main.go alpha add cabinet hpe-ex2000 --vlan-id 1                                                                                                                                                                  13:35
Error: if any flags in the group [cabinet vlan-id] are set they must all be set; missing [cabinet]
exit status 1                                                                                                                                                                                                   ~/git/csminv
% go run main.go alpha add cabinet hpe-ex2000 --cabinet 1                                                                                                                                                                  13:35
Error: if any flags in the group [cabinet vlan-id] are set they must all be set; missing [vlan-id]
exit status 1                                                                                                                                                                                          ~/git/csminv
% go run main.go alpha add cabinet hpe-ex2000 --cabinet 1 --vlan-id 4                                                                                                                                                      13:35
1:35PM INF Added cabinet hpe-ex2000
1:35PM INF UUID: 7ad129c1-cca6-492a-bb00-86e13bbdf59f
1:35PM INF Cabinet Number: 1
1:35PM INF VLAN ID: 4
```

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Low.