### PR TITLE
update add blade with prompts and more info

### DIFF
--- a/cmd/blade/init.go
+++ b/cmd/blade/init.go
@@ -5,12 +5,11 @@ import (
 )
 
 var (
-	cabinet     int
-	chassis     int
-	slot        int
-	hwType      string
-	supportedHw []string
-	recursion   bool
+	auto      bool
+	cabinet   int
+	chassis   int
+	blade     int
+	recursion bool
 )
 
 func init() {
@@ -24,19 +23,15 @@ func init() {
 
 	// Blades have several parents, so we need to add flags for each
 	AddBladeCmd.Flags().IntVar(&cabinet, "cabinet", 1001, "Parent cabinet")
-	// cobra.MarkFlagRequired(AddBladeCmd.Flags(), "cabinet")
-
-	AddBladeCmd.Flags().IntVar(&chassis, "chassis", 7, "Parent chassis")
-	// cobra.MarkFlagRequired(AddBladeCmd.Flags(), "chassis")
-
-	AddBladeCmd.Flags().IntVar(&slot, "slot", 1, "Parent slot")
-	// cobra.MarkFlagRequired(AddBladeCmd.Flags(), "slot")
-
-	AddBladeCmd.MarkFlagsRequiredTogether("list-supported-types")
-	AddBladeCmd.MarkFlagsRequiredTogether("cabinet", "chassis", "slot")
 	AddBladeCmd.MarkFlagRequired("cabinet")
+	AddBladeCmd.Flags().IntVar(&chassis, "chassis", 7, "Parent chassis")
 	AddBladeCmd.MarkFlagRequired("chassis")
-	AddBladeCmd.MarkFlagRequired("slot")
+	AddBladeCmd.Flags().IntVar(&blade, "blade", 1, "Blade")
+	AddBladeCmd.MarkFlagRequired("blade")
+	AddBladeCmd.MarkFlagsRequiredTogether("cabinet", "chassis", "blade")
+
+	AddBladeCmd.Flags().BoolVar(&auto, "auto", false, "Automatically recommend values for parent hardware")
+	AddBladeCmd.MarkFlagsRequiredTogether("list-supported-types")
 
 	RemoveBladeCmd.Flags().BoolVarP(&recursion, "recursive", "R", false, "Recursively delete child hardware")
 

--- a/cmd/cabinet/add_cabinet.go
+++ b/cmd/cabinet/add_cabinet.go
@@ -32,8 +32,8 @@ import (
 	"github.com/Cray-HPE/cani/cmd/session"
 	"github.com/Cray-HPE/cani/internal/domain"
 	"github.com/Cray-HPE/cani/internal/provider"
+	"github.com/Cray-HPE/cani/internal/tui"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
-	"github.com/manifoldco/promptui"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -60,10 +60,11 @@ func addCabinet(cmd *cobra.Command, args []string) error {
 	if auto {
 		log.Info().Msgf("Automatically assigning cabinet number and VLAN ID")
 		// TODO: Need to auto-generate a VLAN ID and cabinet number from existing provider
-		log.Info().Msgf("Suggested VLAN ID: %d", vlanId)
-		log.Info().Msgf("Suggested cabinet number: %d", cabinetNumber)
+		log.Warn().Msgf("Suggested VLAN ID: %d (not implemented)", vlanId)
+		log.Warn().Msgf("Suggested cabinet number: %d (not implemented)", cabinetNumber)
 		// Prompt the user to confirm the suggestions
-		auto, err = promptToConfimSuggestions()
+		auto, err = tui.CustomConfirmation(
+			fmt.Sprintf("Would you like to accept the recommendations and add the %s", hardwaretypes.Cabinet))
 		if err != nil {
 			return err
 		}
@@ -72,7 +73,7 @@ func addCabinet(cmd *cobra.Command, args []string) error {
 		if !auto {
 			log.Warn().Msgf("Aborted %s add", hardwaretypes.Cabinet)
 			fmt.Printf("\nAuto-generated values can be overridden by re-running the command with explicit values:\n")
-			fmt.Printf("\n\tcani alpha add cabinet %s --vlan %d --cabinet-number %d\n\n", args[0], vlanId, cabinetNumber)
+			fmt.Printf("\n\tcani alpha add %s %s --vlan %d --cabinet-number %d\n\n", cmd.Name(), args[0], vlanId, cabinetNumber)
 
 			return nil
 		}
@@ -114,25 +115,4 @@ func addCabinet(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-func promptToConfimSuggestions() (bool, error) {
-	prompt := promptui.Prompt{
-		Label:     fmt.Sprintf("Would you like to accept the recommendations and add the %s", hardwaretypes.Cabinet),
-		IsConfirm: true,
-	}
-
-	_, err := prompt.Run()
-
-	if err != nil {
-		if err == promptui.ErrAbort {
-			// User chose not to accept the suggestions
-			return false, nil
-		}
-		// An error occurred
-		return false, err
-	}
-
-	// User chose to continue
-	return true, nil
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -28,6 +28,7 @@ func init() {
 	// Global root command flags
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", cfgFile, "Path to the configuration file")
 	RootCmd.PersistentFlags().BoolVarP(&Debug, "debug", "D", false, "additional debug output")
+	RootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "additional verbose output")
 
 	// Global add flags
 	AddCmd.PersistentFlags().StringVarP(&vendor, "vendor", "m", "HPE", "Vendor")
@@ -46,7 +47,9 @@ func setupLogging() {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 		log.Debug().Msg("Debug logging enabled")
 		// include file and line number in debug output
-		//log.Logger = log.With().Caller().Logger()
+		if Verbose {
+			log.Logger = log.With().Caller().Logger()
+		}
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,8 @@ var (
 	cfgFile string
 	// Debug is a global flag that enables debug logging
 	Debug bool
+	// Verbose is a global flag that enables verbose logging
+	Verbose bool
 	// Simulation is a global flag that enables simulation mode
 	Simulation bool
 	// Conf is the global configuration read from cani.yml (or from --config)

--- a/internal/domain/cabinet.go
+++ b/internal/domain/cabinet.go
@@ -25,7 +25,7 @@ func (d *Domain) AddCabinet(ctx context.Context, deviceTypeSlug string, cabinetO
 	exists, err := cabinetLocationPath.Exists(d.datastore)
 	if err != nil {
 		return AddHardwareResult{}, errors.Join(
-			fmt.Errorf("unable to check if cabinet exists"),
+			fmt.Errorf("unable to check if %s exists", hardwaretypes.Cabinet),
 			err,
 		)
 	}
@@ -130,7 +130,7 @@ func (d *Domain) RemoveCabinet(u uuid.UUID, recursion bool) error {
 	err := d.datastore.Remove(u, recursion)
 	if err != nil {
 		return errors.Join(
-			fmt.Errorf("unable to remove hardware from inventory datastore"),
+			fmt.Errorf("unable to remove %s from inventory datastore", hardwaretypes.Cabinet),
 			err,
 		)
 	}

--- a/internal/inventory/model.go
+++ b/internal/inventory/model.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/google/uuid"
-	"github.com/rs/zerolog/log"
 )
 
 // Inventory is the top level object that represents the entire inventory
@@ -95,6 +94,21 @@ func (lp LocationPath) GetHardwareTypePath() hardwaretypes.HardwareTypePath {
 	return result
 }
 
+// GetUUID returns the UUID of the location path
+func (lp LocationPath) GetUUID(ds Datastore) (uuid.UUID, error) {
+	hw, err := ds.GetAtLocation(lp)
+	if err == nil {
+		// Hardware found
+		return hw.ID, nil
+	} else if errors.Is(err, ErrHardwareNotFound) {
+		// Hardware not found
+		return uuid.Nil, ErrHardwareNotFound
+	} else {
+		// Oops something happened
+		return uuid.Nil, err
+	}
+}
+
 // GetOrdinalPath returns the ordinal of the location path
 func (lp LocationPath) GetOrdinalPath() []int {
 	result := []int{}
@@ -107,10 +121,8 @@ func (lp LocationPath) GetOrdinalPath() []int {
 
 // Exists returns true if the hardware exists in the datastore
 func (lp LocationPath) Exists(ds Datastore) (bool, error) {
-	log.Debug().Msgf("Checking if hardware exists at location %s", lp.String())
-	hw, err := ds.GetAtLocation(lp)
+	_, err := ds.GetAtLocation(lp)
 	if err == nil {
-		log.Warn().Msgf("%s %s exists at location %s", hw.Type, hw.ID.String(), lp.String())
 		// Hardware found
 		return true, nil
 	} else if errors.Is(err, ErrHardwareNotFound) {

--- a/internal/tui/prompts.go
+++ b/internal/tui/prompts.go
@@ -1,0 +1,27 @@
+package tui
+
+import (
+	"github.com/manifoldco/promptui"
+)
+
+// CustomConfirmation prompts the user for confirmation
+func CustomConfirmation(message string) (bool, error) {
+	prompt := promptui.Prompt{
+		Label:     message,
+		IsConfirm: true,
+	}
+
+	_, err := prompt.Run()
+
+	if err != nil {
+		if err == promptui.ErrAbort {
+			// User chose not to accept the suggestions
+			return false, nil
+		}
+		// An error occurred
+		return false, err
+	}
+
+	// User chose to continue
+	return true, nil
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1,0 +1,1 @@
+package tui


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- Update blade workflow same as #53 
- checks child components for existence per miro board wireframing
- changed "slot" verbiage to "blade" for better continuity and to make adding a blade a thing instead of thing to add it into
- creates a `tui` package for handling prompts and de-duplicating code
- reduces debug output of `GetAtLocation` in favor of hierarchical log messages with some colored output
- adds a `-v` flag for verbosity.  Pairs with `-D`ebug to also show file and line numbers allowing users to toggle between more or less output

```
% rm -rf ~/.cani && go run . alpha session start csm -S  -k                                     13:51
1:52PM WRN Using simulation mode
1:52PM INF /Users/jsalmela/.cani/canidb.json does not exist, creating default datastore
1:52PM INF Validated CANI inventory
2023/06/12 13:52:14 [DEBUG] GET https://localhost:8443/apis/sls/v1/dumpstate
1:52PM INF Validated external inventory provider
1:52PM INF Session is now ACTIVE with provider csm and datastore /Users/jsalmela/.cani/canidb.json
enhanced-redwing                                                                         ~/git/csminv
% go run main.go alpha add cabinet hpe-ex2000 --vlan-id 1 --cabinet 1                           13:52
1:52PM INF Cabinet 1 was successfully staged to be added to the system status=SUCCESS
1:52PM INF UUID: 41d4762d-a025-4e75-9a8c-b276584d8245
1:52PM INF Cabinet Number: 1
1:52PM INF VLAN ID: 1
enhanced-redwing                                                                         ~/git/csminv
% go run main.go alpha add blade hpe-crayex-ex420-compute-blade --cabinet 1 --chassis 1 --blade 1
1:53PM INF NodeBlade was successfully staged to be added to the system status=SUCCESS
1:53PM INF UUID: 3768b21c-a834-4784-85fa-883cca085317
1:53PM INF Cabinet: 1
1:53PM INF Chassis: 1
1:53PM INF Blade: 1
enhanced-redwing                                                                         ~/git/csminv
% go run main.go alpha add blade hpe-crayex-ex420-compute-blade --cabinet 1 --chassis 1 --blade 1
Error: NodeBlade number 1 is already in use
please re-run the command with an available NodeBlade number
try 'cani alpha list blade'
exit status 1
```

![Screen Shot 2023-06-12 at 1 57 07 PM](https://github.com/Cray-HPE/cani/assets/3843505/6825eaca-bf1f-4161-972f-247be2de1a2c)


Example of nodecard existing when the blade doesn't.

```
1:48PM DBG Hardware Build out path=NodeBlade:1->NodeCard:0
1:48PM DBG  |  |  |  --NodeCard (0) exists=true uuid=97c219f2-156b-46b4-b43c-f4f997526fd6
Error: NodeCard already exists at System:0->Cabinet:1->Chassis:1->NodeBlade:1->NodeCard:0
exit status 1
```

# Risks and Mitigations


<!-- What is the risk level of this change? -->

Low
