### PR TITLE
check for existing cabinet

### DIFF
--- a/cmd/cabinet/init.go
+++ b/cmd/cabinet/init.go
@@ -21,7 +21,9 @@ func init() {
 
 	// Cabinets
 	AddCabinetCmd.Flags().IntVar(&cabinetNumber, "cabinet", 1001, "Cabinet number.")
+	AddCabinetCmd.MarkFlagRequired("cabinet")
 	AddCabinetCmd.Flags().IntVar(&vlanId, "vlan-id", -1, "Vlan ID for the cabinet.")
+	AddCabinetCmd.MarkFlagRequired("vlan-id")
 	AddCabinetCmd.MarkFlagsRequiredTogether("cabinet", "vlan-id")
 	AddCabinetCmd.Flags().BoolVar(&auto, "auto", false, "Automatically recommend and assign required flags.")
 }

--- a/cmd/session/init.go
+++ b/cmd/session/init.go
@@ -38,6 +38,7 @@ func init() {
 	SessionStartCmd.MarkFlagRequired("csm-keycloak-username")
 	SessionStartCmd.Flags().StringVar(&tokenPassword, "csm-keycloak-password", "", "(CSM Provider) Keycloak password")
 	SessionStartCmd.MarkFlagRequired("csm-keycloak-password")
+	SessionStartCmd.MarkFlagsRequiredTogether("csm-base-auth-url", "csm-keycloak-username", "csm-keycloak-password")
 	// TODO the API token, do we save ito the file?
 
 	// Less secure auth methods for CSM that follow existing patterns, but to discourage use, mark them hidden

--- a/internal/domain/cabinet.go
+++ b/internal/domain/cabinet.go
@@ -15,7 +15,28 @@ import (
 // AddCabinet adds a cabinet to the inventory
 func (d *Domain) AddCabinet(ctx context.Context, deviceTypeSlug string, cabinetOrdinal int) (AddHardwareResult, error) {
 	// Validate provided cabinet exists
-	// TODO
+	// Craft the path to the cabinet
+	cabinetLocationPath := inventory.LocationPath{
+		{HardwareType: hardwaretypes.System, Ordinal: 0},
+		{HardwareType: hardwaretypes.Cabinet, Ordinal: cabinetOrdinal},
+	}
+
+	// Check if the cabinet already exists
+	exists, err := cabinetLocationPath.Exists(d.datastore)
+	if err != nil {
+		return AddHardwareResult{}, errors.Join(
+			fmt.Errorf("unable to check if cabinet exists"),
+			err,
+		)
+	}
+	// Fail if the cabinet already exists and provide actionable error message
+	if exists {
+		return AddHardwareResult{},
+			errors.Join(
+				fmt.Errorf("%s number %d is already in use", hardwaretypes.Cabinet, cabinetOrdinal),
+				fmt.Errorf("please re-run the command with an available %s number", hardwaretypes.Cabinet),
+			)
+	}
 
 	system, err := d.datastore.GetSystemZero()
 	if err != nil {

--- a/internal/inventory/model.go
+++ b/internal/inventory/model.go
@@ -1,11 +1,13 @@
 package inventory
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 )
 
 // Inventory is the top level object that represents the entire inventory
@@ -101,4 +103,21 @@ func (lp LocationPath) GetOrdinalPath() []int {
 	}
 
 	return result
+}
+
+// Exists returns true if the hardware exists in the datastore
+func (lp LocationPath) Exists(ds Datastore) (bool, error) {
+	log.Debug().Msgf("Checking if hardware exists at location %s", lp.String())
+	hw, err := ds.GetAtLocation(lp)
+	if err == nil {
+		log.Warn().Msgf("%s %s exists at location %s", hw.Type, hw.ID.String(), lp.String())
+		// Hardware found
+		return true, nil
+	} else if errors.Is(err, ErrHardwareNotFound) {
+		// Hardware not found
+		return false, nil
+	} else {
+		// Oops something happened
+		return false, err
+	}
 }


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

Checks for an existing cabinet before adding it.

```
pit:~/jsalmela/cani # rm -rf ~/.cani && go run . alpha session start csm \
>   --csm-keycloak-username vshasta \
>   --csm-keycloak-password vshasta \
>   --csm-base-auth-url https://api-gw-service-nmn.local/ \
>   --csm-url-sls https://api-gw-service-nmn.local/apis/sls/v1 \
>   --csm-ca-cert ../platform-ca-certs.crt
5:53PM INF /root/.cani/canidb.json does not exist, creating default datastore
2023/06/07 17:53:37 [DEBUG] POST https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token
5:53PM INF Validated CANI inventory
2023/06/07 17:53:37 [DEBUG] GET https://api-gw-service-nmn.local/apis/sls/v1/dumpstate
5:53PM INF Validated external inventory provider
5:53PM INF Session is now ACTIVE with provider csm and datastore /root/.cani/canidb.json
pit:~/jsalmela/cani # go run main.go alpha list | jq
{
  "d53eb44f-67ff-428a-8c25-c9f64a6c555b": {
    "ID": "d53eb44f-67ff-428a-8c25-c9f64a6c555b",
    "Type": "System",
    "Parent": "00000000-0000-0000-0000-000000000000",
    "LocationPath": [
      {
        "HardwareType": "System",
        "Ordinal": 0
      }
    ],
    "LocationOrdinal": 0
  }
}
pit:~/jsalmela/cani # go run main.go alpha add cabinet
Error: No hardware type provided: Choose from: hpe-ex2000", "hpe-ex2500-1-liquid-cooled-chassis", "hpe-ex2500-2-liquid-cooled-chassis", "hpe-ex2500-3-liquid-cooled-chassis", "hpe-ex3000", "hpe-ex4000
exit status 1
pit:~/jsalmela/cani # go run main.go alpha add cabinet hpe-ex2000
Error: required flag(s) "cabinet", "vlan-id" not set
exit status 1
pit:~/jsalmela/cani # go run main.go alpha add cabinet hpe-ex2000 --cabinet 1
Error: required flag(s) "vlan-id" not set
exit status 1
pit:~/jsalmela/cani # go run main.go alpha add cabinet hpe-ex2000 --vlan-id 1
Error: required flag(s) "cabinet" not set
exit status 1
pit:~/jsalmela/cani # go run main.go alpha add cabinet hpe-ex2000 --vlan-id 1 --cabinet 1
5:54PM INF Cabinet 1 was successfully staged to be added to the system status=SUCCESS
5:54PM INF UUID: 554c9010-5b00-4954-8b4d-8aed4ccec18b
5:54PM INF Cabinet Number: 1
5:54PM INF VLAN ID: 1
pit:~/jsalmela/cani # go run main.go alpha list cabinet | jq
{
  "554c9010-5b00-4954-8b4d-8aed4ccec18b": {
    "ID": "554c9010-5b00-4954-8b4d-8aed4ccec18b",
    "Type": "Cabinet",
    "Vendor": "HPE",
    "Model": "EX2000",
    "Status": "staged",
    "Parent": "d53eb44f-67ff-428a-8c25-c9f64a6c555b",
    "Children": [
      "416e857b-0b24-43cc-9e61-ea62afa40247",
      "60e6d8b8-7e5f-410c-ba00-949f22906e35",
      "ab8195e7-1769-48be-8c91-d34a618ee848"
    ],
    "LocationPath": [
      {
        "HardwareType": "System",
        "Ordinal": 0
      },
      {
        "HardwareType": "Cabinet",
        "Ordinal": 1
      }
    ],
    "LocationOrdinal": 1
  }
}
pit:~/jsalmela/cani # go run main.go alpha add cabinet hpe-ex2000 --vlan-id 2 --cabinet 1
5:54PM WRN Hardware 554c9010-5b00-4954-8b4d-8aed4ccec18b exists at location System:0->Cabinet:1
Error: Cabinet number 1 is already in use
please re-run the command with an available Cabinet number
exit status 1
```

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Low