### PR TITLE
re-enable simulator

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -28,7 +28,6 @@ func init() {
 	// Global root command flags
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", cfgFile, "Path to the configuration file")
 	RootCmd.PersistentFlags().BoolVarP(&Debug, "debug", "D", false, "additional debug output")
-	RootCmd.PersistentFlags().BoolVarP(&Simulation, "simulation", "S", false, "Use simulation mode for hsm-simulation-environment")
 
 	// Global add flags
 	AddCmd.PersistentFlags().StringVarP(&vendor, "vendor", "m", "HPE", "Vendor")

--- a/cmd/session/init.go
+++ b/cmd/session/init.go
@@ -15,6 +15,7 @@ var (
 	tokenUrl      string
 	tokenUsername string
 	tokenPassword string
+	useSimulation bool
 )
 
 func init() {
@@ -29,15 +30,15 @@ func init() {
 	SessionStartCmd.Flags().String("csm-url-sls", "https://api-gw-service-nmn.local/apis/sls/v1", "(CSM Provider) Base URL for the System Layout Service (SLS)")
 	SessionStartCmd.Flags().String("csm-url-hsm", "https://api-gw-service-nmn.local/apis/smd/hsm/v2", "(CSM Provider) Base URL for the Hardware State Manager (HSM)")
 	SessionStartCmd.Flags().BoolVarP(&insecure, "csm-insecure-https", "k", false, "(CSM Provider) Allow insecure connections when using HTTPS to CSM services")
-	SessionStartCmd.Flags().Bool("csm-sim-urls", false, "(CSM Provider) Use simulation environment URLs")
+	SessionStartCmd.Flags().BoolVarP(&useSimulation, "csm-simulator", "S", false, "(CSM Provider) Use simulation environment URLs")
 
 	// These three pieces are needed for the CSM provider to get a token
 	SessionStartCmd.Flags().StringVar(&tokenUrl, "csm-base-auth-url", "", "(CSM Provider) Base URL for the CSM authentication")
-	SessionStartCmd.MarkFlagRequired("csm-base-auth-url")
+	// SessionStartCmd.MarkFlagRequired("csm-base-auth-url")
 	SessionStartCmd.Flags().StringVar(&tokenUsername, "csm-keycloak-username", "", "(CSM Provider) Keycloak username")
-	SessionStartCmd.MarkFlagRequired("csm-keycloak-username")
+	// SessionStartCmd.MarkFlagRequired("csm-keycloak-username")
 	SessionStartCmd.Flags().StringVar(&tokenPassword, "csm-keycloak-password", "", "(CSM Provider) Keycloak password")
-	SessionStartCmd.MarkFlagRequired("csm-keycloak-password")
+	// SessionStartCmd.MarkFlagRequired("csm-keycloak-password")
 	SessionStartCmd.MarkFlagsRequiredTogether("csm-base-auth-url", "csm-keycloak-username", "csm-keycloak-password")
 	// TODO the API token, do we save ito the file?
 

--- a/cmd/session/session_start.go
+++ b/cmd/session/session_start.go
@@ -39,10 +39,9 @@ var (
 func startSession(cmd *cobra.Command, args []string) error {
 	// TODO This is probably not the right way todo this, but hopefully this will be easy way...
 	// Sorry Jacob
-	if useSimURLs, _ := cmd.Flags().GetBool("csm-sim-urls"); useSimURLs {
-		root.Conf.Session.DomainOptions.CsmOptions.BaseUrlSLS = "https://localhost:8443/apis/sls/v1"
-		root.Conf.Session.DomainOptions.CsmOptions.BaseUrlHSM = "https://localhost:8443/apis/smd/hsm/v2"
-		root.Conf.Session.DomainOptions.CsmOptions.InsecureSkipVerify = true
+	if useSimulation {
+		log.Warn().Msg("Using simulation mode")
+		root.Conf.Session.DomainOptions.CsmOptions.UseSimulation = true
 	} else {
 		root.Conf.Session.DomainOptions.CsmOptions.BaseUrlSLS, _ = cmd.Flags().GetString("csm-url-sls")
 		root.Conf.Session.DomainOptions.CsmOptions.BaseUrlHSM, _ = cmd.Flags().GetString("csm-url-hsm")

--- a/internal/provider/csm/auth.go
+++ b/internal/provider/csm/auth.go
@@ -56,7 +56,8 @@ func (opts *NewOpts) newClient() (httpClient *retryablehttp.Client, ctx context.
 	ctx = context.Background()
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient.StandardClient())
 
-	if opts.APIGatewayToken == "" {
+	if opts.APIGatewayToken == "" && !opts.UseSimulation {
+		log.Info().Msgf("No API Gateway token provided, getting one from provider %s", opts.BaseUrlSLS)
 		// Get the auth token from keycloak
 		token, err := opts.getAuthToken(ctx)
 		if err != nil {
@@ -82,7 +83,7 @@ func (opts *NewOpts) getAuthToken(ctx context.Context) (*oauth2.Token, error) {
 	// Get the token
 	token, err := conf.PasswordCredentialsToken(ctx, opts.TokenUsername, string(opts.TokenPassword))
 	if err != nil {
-		log.Error().Msgf("Failed to get token, %s, %s %s", opts.TokenHost, opts.TokenUsername, opts.TokenPassword)
+		log.Error().Msgf("Failed to get token.  Check if the token host is reachable and the credentials are correct. %s", err)
 		return nil, err
 	}
 

--- a/internal/provider/csm/csm.go
+++ b/internal/provider/csm/csm.go
@@ -13,6 +13,7 @@ import (
 )
 
 type NewOpts struct {
+	UseSimulation      bool
 	InsecureSkipVerify bool
 	APIGatewayToken    string
 	BaseUrlSLS         string
@@ -63,6 +64,15 @@ func New(opts *NewOpts) (*CSM, error) {
 	httpClient, _, err := opts.newClient()
 	if err != nil {
 		return nil, err
+	}
+
+	if opts.UseSimulation {
+		if opts.BaseUrlSLS == "" {
+			opts.BaseUrlSLS = "https://localhost:8443/apis/sls/v1"
+		}
+		if opts.BaseUrlHSM == "" {
+			opts.BaseUrlHSM = "https://localhost:8443/apis/smd/hsm/v2"
+		}
 	}
 
 	slsClientConfiguration := &sls_client.Configuration{


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

Re-enables the use of the simulator, which was incidentally affected after adding auth.

Just run with `-S` and `-k`

```
go run . alpha session start csm -S -k
```
# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

