### PR TITLE
add vlan suggestions to add cabinet when --auto is passed

### DIFF
--- a/cmd/cabinet/init.go
+++ b/cmd/cabinet/init.go
@@ -46,9 +46,10 @@ func init() {
 
 	// Cabinets
 	AddCabinetCmd.Flags().IntVar(&cabinetNumber, "cabinet", 1001, "Cabinet number.")
-	AddCabinetCmd.MarkFlagRequired("cabinet")
+	// AddCabinetCmd.MarkFlagRequired("cabinet")
 	AddCabinetCmd.Flags().IntVar(&vlanId, "vlan-id", -1, "Vlan ID for the cabinet.")
-	AddCabinetCmd.MarkFlagRequired("vlan-id")
+	// AddCabinetCmd.MarkFlagRequired("vlan-id")
 	AddCabinetCmd.MarkFlagsRequiredTogether("cabinet", "vlan-id")
 	AddCabinetCmd.Flags().BoolVar(&auto, "auto", false, "Automatically recommend and assign required flags.")
+	AddCabinetCmd.MarkFlagsMutuallyExclusive("auto")
 }

--- a/docs/development/simulator.md
+++ b/docs/development/simulator.md
@@ -24,6 +24,6 @@ rm -rf ~/.cani && go run . alpha session start csm -S -k
 # wipe out SLS
 echo '{}' > /tmp/sls_empty.json; curl -X POST -F "sls_dump=@/tmp/sls_empty.json" https://localhost:8443/apis/sls/v1/loadstate -ik
 # put in a known good-config (this could be any valid SLS file)
-curl -X POST -F "sls_dump=@testdata/fixtures/sls/mug-dumpstate.json" https://localhost:8443/apis/sls/v1/loadstate -ik
+curl -X POST -F "sls_dump=@testdata/fixtures/sls/valid-mug.json" https://localhost:8443/apis/sls/v1/loadstate -ik
 # run cani commands...
 ```

--- a/internal/domain/cabinet.go
+++ b/internal/domain/cabinet.go
@@ -71,7 +71,7 @@ func (d *Domain) AddCabinet(ctx context.Context, deviceTypeSlug string, cabinetO
 		)
 	}
 
-	// Verify the provided device type slug is a node blade
+	// Verify the provided device type slug is a cabinet
 	deviceType, err := d.hardwareTypeLibrary.GetDeviceType(deviceTypeSlug)
 	if err != nil {
 		return AddHardwareResult{}, err
@@ -167,4 +167,18 @@ func (d *Domain) RemoveCabinet(u uuid.UUID, recursion bool) error {
 	}
 
 	return d.datastore.Flush()
+}
+
+func (d *Domain) Recommend(deviceTypeSlug string) (recommendations provider.HardwareRecommendations, err error) {
+	// Get the existing inventory
+	inv, err := d.List()
+	if err != nil {
+		return recommendations, err
+	}
+	// Get recommendations from the CSM provider for the cabinet
+	recommendations, err = d.externalInventoryProvider.RecommendCabinet(inv, deviceTypeSlug)
+	if err != nil {
+		return recommendations, err
+	}
+	return recommendations, nil
 }

--- a/internal/provider/csm/metadata.go
+++ b/internal/provider/csm/metadata.go
@@ -27,11 +27,18 @@ package csm
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/Cray-HPE/cani/internal/inventory"
+	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
+	sls_client "github.com/Cray-HPE/cani/pkg/sls-client"
 	"github.com/mitchellh/mapstructure"
 	"github.com/rs/zerolog/log"
+)
+
+const (
+	ProviderPropertyVlanId = "vlanID"
 )
 
 type NodeMetadata struct {
@@ -120,7 +127,7 @@ func (csm *CSM) BuildHardwareMetadata(cHardware *inventory.Hardware, rawProperti
 
 		// Make changes to the node metadata
 		// The keys of rawProperties need to match what is defined in ./cmd/cabinet/add_cabinet.go
-		if vlanIDRaw, exists := rawProperties["vlanID"]; exists {
+		if vlanIDRaw, exists := rawProperties[ProviderPropertyVlanId]; exists {
 			if vlanIDRaw == nil {
 				properties.HMNVlan = nil
 			} else {
@@ -179,4 +186,132 @@ func (csm *CSM) BuildHardwareMetadata(cHardware *inventory.Hardware, rawProperti
 		return nil
 	}
 
+}
+
+func (csm *CSM) RecommendCabinet(inv inventory.Inventory, deviceTypeSlug string) (recommended provider.HardwareRecommendations, err error) {
+	// defined by csi
+	const riverStartingVlan = 1513
+	const riverEndingVlan = 1769
+	// var riverVlanRange = []int16{riverStartingVlan, riverEndingVlan}
+	// defined by csi
+	const mountainStartingVlan = 3000
+	const mountainEndingVlan = 3999
+	// var mountainVlanRange = []int16{mountainStartingVlan, mountainEndingVlan}
+
+	// slice to track existing vlans
+	var existingVlans = []int{}
+	// slice to track existing cabinets
+	var existingCabinets = []int{}
+
+	// loop through the existing inventory to check for vlans
+	log.Debug().Msg("Checking existing hardware to find recommendations")
+	for _, cHardware := range inv.Hardware {
+		if cHardware.ProviderProperties == nil {
+			cHardware.ProviderProperties = map[string]interface{}{}
+		}
+
+		switch cHardware.Type {
+		case hardwaretypes.Cabinet:
+			log.Debug().Msgf("Checking %s (%s)", cHardware.Type, cHardware.ID.String())
+			properties := CabinetMetadata{}
+			if _, exists := cHardware.ProviderProperties[string(inventory.CSMProvider)]; exists {
+				// If one exists set it.
+				log.Debug().Msgf("Decoding csm properties %+v", cHardware.ProviderProperties)
+				if err := mapstructure.Decode(cHardware.ProviderProperties[string(inventory.CSMProvider)], &properties); err != nil {
+					return recommended, err
+				}
+			}
+
+			// Make changes to the node metadata
+			// The keys of rawProperties need to match what is defined in ./cmd/cabinet/add_cabinet.go
+			if properties.HMNVlan != nil {
+				// add it to the slice that tracks existing vlans
+				existingVlans = append(existingVlans, *properties.HMNVlan)
+			}
+
+			// add the ordinal to the existing cabinets slice for choosing a new one later
+			existingCabinets = append(existingCabinets, *cHardware.LocationOrdinal)
+
+		default:
+			// This function only handles cabinets
+			continue
+		}
+	}
+
+	var chosenOrdinal int
+	chosenOrdinal, err = DetermineStartingOrdinalFromSlug(deviceTypeSlug, *csm.hardwareLibrary)
+	if err != nil {
+		return recommended, err
+	}
+	log.Debug().Msgf("chosenOrdinal %d (%s)", chosenOrdinal, deviceTypeSlug)
+	// Set the cabinet location
+	if len(existingCabinets) == 0 {
+		// there are no cabinets yet, so set it to the provider default
+		recommended.LocationOrdinal = chosenOrdinal
+		log.Debug().Msgf("No cabinets found, using %d", recommended.LocationOrdinal)
+	} else {
+		// set the recommended cabinet number
+		recommended.LocationOrdinal = nextAvailableInt(existingCabinets, chosenOrdinal)
+		log.Debug().Msgf("Existing cabinets found (%v), using %d", existingCabinets, recommended.LocationOrdinal)
+	}
+
+	// Determine the hardware class based off the slug
+	// This is needed to assign an approriate VLAN from the ranges defined above
+	class, err := DetermineHardwareClassFromSlug(deviceTypeSlug, *csm.hardwareLibrary)
+	if err != nil {
+		return recommended, err
+	}
+
+	// Set the metadata vlan
+	var chosenVlan int
+	if len(existingCabinets) == 0 {
+		// choose a starting vlan based on the class
+		if class == sls_client.HardwareClassMountain || class == sls_client.HardwareClassHill {
+			chosenVlan = mountainStartingVlan
+		}
+		if class == sls_client.HardwareClassRiver {
+			chosenVlan = riverStartingVlan
+		}
+		log.Debug().Msgf("No cabinet VLANs found, using %d for %s %s", chosenVlan, class, hardwaretypes.Cabinet)
+	} else {
+		// set the recommended vlan by finding an available one from the existing
+		if class == sls_client.HardwareClassMountain || class == sls_client.HardwareClassHill {
+			chosenVlan = nextAvailableInt(existingVlans, mountainStartingVlan)
+		}
+		if class == sls_client.HardwareClassRiver {
+			chosenVlan = nextAvailableInt(existingVlans, riverStartingVlan)
+		}
+
+	}
+
+	// set the provider metadata
+	recommended.ProviderMetadata = map[string]interface{}{
+		// there are no vlans yet, and presumably no cabinets, so set it to 1
+		ProviderPropertyVlanId: chosenVlan,
+	}
+
+	// return the recommendations
+	return recommended, nil
+}
+
+func nextAvailableInt(s []int, offset int) int {
+	// slice must be sorted in order to work properly
+	sort.Ints(s)
+
+	// If the slice is empty, return the offset
+	if len(s) == 0 || offset < s[0] {
+		return offset
+	}
+	// Check if the offset is in the slice
+	i := sort.Search(len(s), func(i int) bool { return s[i] >= offset })
+	if i < len(s) && s[i] == offset {
+		for ; i < len(s); i++ {
+			// if it is the last element or there is a gap to the next one
+			if i == len(s)-1 || s[i+1]-s[i] > 1 {
+				return s[i] + 1
+			}
+		}
+	}
+	// the offset is not in the slice, so return it
+	return offset
 }

--- a/internal/provider/csm/sls_state_generator.go
+++ b/internal/provider/csm/sls_state_generator.go
@@ -76,6 +76,47 @@ func DetermineHardwareClass(hardware inventory.Hardware, data inventory.Inventor
 	return "", fmt.Errorf("unable to determine CSM Class of (%s)", hardware.ID)
 }
 
+func DetermineHardwareClassFromSlug(deviceTypeSlug string, hardwareTypeLibrary hardwaretypes.Library) (sls_client.HardwareClass, error) {
+	deviceType, exists := hardwareTypeLibrary.DeviceTypes[deviceTypeSlug]
+	if !exists {
+		return "", errors.Join(
+			fmt.Errorf("unable to find device type (%s)", deviceTypeSlug),
+		)
+	}
+
+	if deviceType.ProviderDefaults != nil && deviceType.ProviderDefaults.CSM != nil && deviceType.ProviderDefaults.CSM.Class != nil {
+		classRaw := *deviceType.ProviderDefaults.CSM.Class
+		switch classRaw {
+		case "River":
+			return sls_client.HardwareClassRiver, nil
+		case "Mountain":
+			return sls_client.HardwareClassMountain, nil
+		case "Hill":
+			return sls_client.HardwareClassHill, nil
+		default:
+			return "", fmt.Errorf("encountered unknown CSM hardware class (%s)", classRaw)
+		}
+	}
+
+	return "", fmt.Errorf("unable to determine CSM Class of (%s)", deviceTypeSlug)
+}
+
+func DetermineStartingOrdinalFromSlug(deviceTypeSlug string, hardwareTypeLibrary hardwaretypes.Library) (int, error) {
+	deviceType, exists := hardwareTypeLibrary.DeviceTypes[deviceTypeSlug]
+	if !exists {
+		return 0, errors.Join(
+			fmt.Errorf("unable to find device type (%s)", deviceTypeSlug),
+		)
+	}
+
+	if deviceType.ProviderDefaults != nil && deviceType.ProviderDefaults.CSM != nil {
+		log.Debug().Msgf("kj %+v", deviceType.ProviderDefaults.CSM)
+		return deviceType.ProviderDefaults.CSM.Ordinal, nil
+	}
+
+	return 0, fmt.Errorf("unable to determine CSM starting ordinal of (%s) %+v", deviceTypeSlug, deviceType.ProviderDefaults.CSM)
+}
+
 func BuildExpectedHardwareState(hardwareTypeLibrary hardwaretypes.Library, datastore inventory.Datastore, slsNetworks map[string]sls_client.Network) (sls_client.SlsState, map[string]inventory.Hardware, error) {
 	// Retrieve the CANI inventory data
 	data, err := datastore.List()

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -54,9 +54,17 @@ type InventoryProvider interface {
 	// Build metadata, and add ito the hardware object
 	// This function could return the data to put into object
 	BuildHardwareMetadata(hw *inventory.Hardware, rawProperties map[string]interface{}) error
+
+	// RecommendCabinet returns recommended settings for adding a cabinet
+	RecommendCabinet(inv inventory.Inventory, deviceTypeSlug string) (HardwareRecommendations, error)
 }
 
 type HardwareValidationResult struct {
 	Hardware inventory.Hardware
 	Errors   []string
+}
+
+type HardwareRecommendations struct {
+	LocationOrdinal  int
+	ProviderMetadata map[string]interface{}
 }

--- a/pkg/hardwaretypes/hardware-types/hpe-cabinet-eia-common.yaml
+++ b/pkg/hardwaretypes/hardware-types/hpe-cabinet-eia-common.yaml
@@ -37,6 +37,7 @@ device-bays:
 provider_defaults:
   csm:
     Class: River
+    Ordinal: 3000
 
 ---
 manufacturer: HPE
@@ -47,3 +48,4 @@ slug: hpe-eia-chassis
 provider_defaults:
   csm:
     Class: River
+    starting_cabinet: 3000

--- a/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex2000.yaml
+++ b/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex2000.yaml
@@ -48,3 +48,4 @@ device-bays:
 provider_defaults:
   csm:
     Class: Hill
+    Ordinal: 9000

--- a/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex2500-1-liquid-cooled-chassis.yaml
+++ b/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex2500-1-liquid-cooled-chassis.yaml
@@ -48,3 +48,4 @@ device-bays:
 provider_defaults:
   csm:
     Class: Hill
+    Ordinal: 8000

--- a/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex2500-2-liquid-cooled.yaml
+++ b/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex2500-2-liquid-cooled.yaml
@@ -48,3 +48,4 @@ device-bays:
 provider_defaults:
   csm:
     Class: Hill
+    Ordinal: 8000

--- a/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex2500-3-liquid-cooled.yaml
+++ b/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex2500-3-liquid-cooled.yaml
@@ -53,3 +53,4 @@ device-bays:
 provider_defaults:
   csm:
     Class: Hill
+    Ordinal: 8000

--- a/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex3000.yaml
+++ b/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex3000.yaml
@@ -83,3 +83,4 @@ device-bays:
 provider_defaults:
   csm:
     Class: Mountain
+    Ordinal: 1000

--- a/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex4000.yaml
+++ b/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex4000.yaml
@@ -83,3 +83,4 @@ device-bays:
 provider_defaults:
   csm:
     Class: Mountain
+    Ordinal: 1000

--- a/pkg/hardwaretypes/hardware-types/schema/devicetype.json
+++ b/pkg/hardwaretypes/hardware-types/schema/devicetype.json
@@ -139,7 +139,10 @@
                     "properties": {
                         "Class": {
                             "type": "string"
-                        }
+                        },
+                        "Ordinal": {
+                          "type": "integer"
+                      }
                     }  
                 }
             }

--- a/pkg/hardwaretypes/types.go
+++ b/pkg/hardwaretypes/types.go
@@ -143,7 +143,8 @@ type ProviderDefaults struct {
 }
 
 type ProviderDefaultsCSM struct {
-	Class *string `yaml:"Class"`
+	Class   *string `yaml:"Class"`
+	Ordinal int     `yaml:"Ordinal"`
 }
 
 // TODO

--- a/spec/functional_spec.sh
+++ b/spec/functional_spec.sh
@@ -21,31 +21,3 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-Describe 'Hardware types'
-  Parameters
-    'Liquid-cooled cabinet'
-    'Air-cooled cabinet'
-    'Management network switch'
-  End
-
-  It "The user interface must allow for the addition and removal of $1"  
-  End
-  
-End
-
-It 'Users must be able to add a single unit of hardware'
-End
-It 'Users must be able to bulk add several units of hardware'
-End
-It 'Users must be able to remove a single unit of hardware'
-End
-It 'Users must be able to bulk remove several units of hardware'
-End
-It 'Users must be able to extract the inventory on a running CSM machine to a portable format (the long term goal being that this inventory can be ingested to make reinstallation easier) (stretch goal)'
-End
-It 'For phase 1, only hardware added after CSM install is in scope'
-End
-It 'The user interface solution should not directly parse SHCD documents, but it must be assumed that admins may be using an SHCD when adding or removing hardware'
-End
-It 'Development must consider that while admins will ultimately have a need to query hardware inventory, system role/classification (e.g. return all management storage nodes or return all UAN nodes), system network information, or cabling/connectivity information, this data will likely not be a part of hardware inventory.  The design of future data structure changes and APIs should consider this carefully.'
-End

--- a/spec/nonfunctional_spec.sh
+++ b/spec/nonfunctional_spec.sh
@@ -20,13 +20,3 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-
-
-It 'The interface for adding and removing hardware must have a versioned schema/CLI signature'
-End
-It 'The interface for adding and removing hardware should be reasonably stable when it ships in CSM 1.5, meaning it should not change in future versions, even as we change the backend system(s)'
-End
-It 'If a change is necessary, the old CLI signature should be supported'
-End
-It 'The first release of the hardware add/remove CLI should only plan to work with existing APIs and data structures'
-End


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

Auto-suggest cabinet and vlan when adding a cabinet with `--auto`

- finds the next available vlan by looping through the existing inventory, finding any vlans, adding them to a slice, sorting it, and picking the next available number
- if  no vlans exist, it starts from a pre-defined range (same as what `csi` uses)
- updated the command to run if you decline the auto suggestions to match the current cani flags
- removed filler tests from shellspec that we have defined elsewhere now
- moved flag validation for `add cabinet` to a new function in order to override the `MarkFlagRequired` when passing `--auto` (as far as I could find, doing it this custom way seemed to be the only way.  I could not find something built into cobra to allow both)
- added cabinet ordinal as a provider default since it varies dependent upon the type of cabinet.  these defaults are used when no cabinet exists

**Validated recommendations increment with each successive cabinet add**

```
rm -rf ~/.cani && go run . alpha session start csm -S -k
go run main.go alpha add cabinet hpe-ex2000 --auto
2:53PM INF Querying inventory to suggest cabinet number and VLAN ID
2:53PM INF Suggested cabinet number: 1
2:53PM INF Suggested VLAN ID: 3000
Would you like to accept the recommendations and add the Cabinet: y
2:53PM INF Cabinet 1 was successfully staged to be added to the system status=SUCCESS
2:53PM INF UUID: 738e7da0-a07a-465b-8be4-7f95564e9f22
2:53PM INF Cabinet Number: 1
2:53PM INF VLAN ID: 3000

go run main.go alpha add cabinet hpe-ex2000 --auto                                                                                                                                                                                                                              14:53
2:54PM INF Querying inventory to suggest cabinet number and VLAN ID
2:54PM INF Suggested cabinet number: 2
2:54PM INF Suggested VLAN ID: 3001
Would you like to accept the recommendations and add the Cabinet: y
2:54PM INF Cabinet 2 was successfully staged to be added to the system status=SUCCESS
2:54PM INF UUID: 62b283bb-84dd-40c1-bf7a-75f4cf915243
2:54PM INF Cabinet Number: 2
2:54PM INF VLAN ID: 3001

go run main.go alpha add cabinet hpe-ex2000 --auto                                                                                                                                                                                                                              14:54
2:54PM INF Querying inventory to suggest cabinet number and VLAN ID
2:54PM INF Suggested cabinet number: 3
2:54PM INF Suggested VLAN ID: 3002
Would you like to accept the recommendations and add the Cabinet: y
2:54PM INF Cabinet 3 was successfully staged to be added to the system status=SUCCESS
2:54PM INF UUID: ed456377-5d8e-4ce7-ba84-90a5678d0497
2:54PM INF Cabinet Number: 3
2:54PM INF VLAN ID: 3002
```

**I changed cabinet 2's vlan to 3009 to see if it would pick vlan 3001 again, it did.**

```
go run main.go alpha add cabinet hpe-ex2000 --auto                                                                                                                                                                                                                              14:55
2:55PM INF Querying inventory to suggest cabinet number and VLAN ID
2:55PM INF Suggested cabinet number: 4
2:55PM INF Suggested VLAN ID: 3001
Would you like to accept the recommendations and add the Cabinet: y
2:55PM INF Cabinet 4 was successfully staged to be added to the system status=SUCCESS
2:55PM INF UUID: 6a5a1527-b4e4-4ede-8513-cb55ee907311
2:55PM INF Cabinet Number: 4
2:55PM INF VLAN ID: 3001
```

**Validated the cani command printed out works if suggestions are declined.**

```
go run main.go alpha add cabinet hpe-ex2000 --auto                                                                                                                                                                                                                              14:55
2:56PM INF Querying inventory to suggest cabinet number and VLAN ID
2:56PM INF Suggested cabinet number: 5
2:56PM INF Suggested VLAN ID: 3003
✗ Would you like to accept the recommendations and add the Cabinet: 
2:56PM WRN Aborted Cabinet add

Auto-generated values can be overridden by re-running the command with explicit values:

        cani alpha add cabinet hpe-ex2000 --vlan-id 3003 --cabinet 5

go run main.go alpha add cabinet hpe-ex2000 --vlan-id 3003 --cabinet 5                                                                                                                                                                                                          14:57
2:57PM INF Cabinet 5 was successfully staged to be added to the system status=SUCCESS
2:57PM INF UUID: 311afeee-d37d-4155-9792-eb28ed022b4a
2:57PM INF Cabinet Number: 5
2:57PM INF VLAN ID: 3003
```

**Validated provider defaults were suggested when no cabinet existed.**

```
% go run main.go alpha add cabinet -L                                                                                                                                                                                                                                             
- hpe-eia-cabinet
- hpe-ex2000
- hpe-ex2500-1-liquid-cooled-chassis
- hpe-ex2500-2-liquid-cooled-chassis
- hpe-ex2500-3-liquid-cooled-chassis
- hpe-ex3000
- hpe-ex4000

% go run main.go alpha add cabinet hpe-eia-cabinet --auto                                                                                                                                                                                                                         
7:27AM INF Querying inventory to suggest cabinet number and VLAN ID
7:27AM INF Suggested cabinet number: 3000
7:27AM INF Suggested VLAN ID: 1513

% go run main.go alpha add cabinet hpe-ex2000 --auto                                                                                                                                                                                                                              
7:27AM INF Querying inventory to suggest cabinet number and VLAN ID
7:27AM INF Suggested cabinet number: 9000
7:27AM INF Suggested VLAN ID: 3000

% go run main.go alpha add cabinet hpe-ex2500-1-liquid-cooled-chassis --auto                                                                                                                                                                                                      
7:27AM INF Querying inventory to suggest cabinet number and VLAN ID
7:27AM INF Suggested cabinet number: 8000
7:27AM INF Suggested VLAN ID: 3000

% go run main.go alpha add cabinet hpe-ex2500-2-liquid-cooled-chassis --auto                                                                                                                                                                                                      
7:28AM INF Querying inventory to suggest cabinet number and VLAN ID
7:28AM INF Suggested cabinet number: 8000
7:28AM INF Suggested VLAN ID: 3000

% go run main.go alpha add cabinet hpe-ex2500-3-liquid-cooled-chassis --auto                                                                                                                                                                                                      
7:28AM INF Querying inventory to suggest cabinet number and VLAN ID
7:28AM INF Suggested cabinet number: 8000
7:28AM INF Suggested VLAN ID: 3000

% go run main.go alpha add cabinet hpe-ex3000 --auto                                                                                                                                                                                                                              
7:28AM INF Querying inventory to suggest cabinet number and VLAN ID
7:28AM INF Suggested cabinet number: 1000
7:28AM INF Suggested VLAN ID: 3000

% go run main.go alpha add cabinet hpe-ex4000 --auto                                                                                                                                                                                                                              
7:28AM INF Querying inventory to suggest cabinet number and VLAN ID
7:28AM INF Suggested cabinet number: 1000
7:28AM INF Suggested VLAN ID: 3000
```


# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

