### PR TITLE
move default vlan ranges to hardwaretypes defaults

### DIFF
--- a/internal/provider/csm/sls_state_generator.go
+++ b/internal/provider/csm/sls_state_generator.go
@@ -110,11 +110,25 @@ func DetermineStartingOrdinalFromSlug(deviceTypeSlug string, hardwareTypeLibrary
 	}
 
 	if deviceType.ProviderDefaults != nil && deviceType.ProviderDefaults.CSM != nil {
-		log.Debug().Msgf("kj %+v", deviceType.ProviderDefaults.CSM)
 		return deviceType.ProviderDefaults.CSM.Ordinal, nil
 	}
 
 	return 0, fmt.Errorf("unable to determine CSM starting ordinal of (%s) %+v", deviceTypeSlug, deviceType.ProviderDefaults.CSM)
+}
+
+func DetermineStartingVlanFromSlug(deviceTypeSlug string, hardwareTypeLibrary hardwaretypes.Library) (int, error) {
+	deviceType, exists := hardwareTypeLibrary.DeviceTypes[deviceTypeSlug]
+	if !exists {
+		return 0, errors.Join(
+			fmt.Errorf("unable to find device type (%s)", deviceTypeSlug),
+		)
+	}
+
+	if deviceType.ProviderDefaults != nil && deviceType.ProviderDefaults.CSM != nil {
+		return deviceType.ProviderDefaults.CSM.StartingHmnVlan, nil
+	}
+
+	return 0, fmt.Errorf("unable to determine CSM starting VLAN of (%s) %+v", deviceTypeSlug, deviceType.ProviderDefaults.CSM)
 }
 
 func BuildExpectedHardwareState(hardwareTypeLibrary hardwaretypes.Library, datastore inventory.Datastore, slsNetworks map[string]sls_client.Network) (sls_client.SlsState, map[string]inventory.Hardware, error) {

--- a/pkg/hardwaretypes/hardware-types/hpe-cabinet-eia-common.yaml
+++ b/pkg/hardwaretypes/hardware-types/hpe-cabinet-eia-common.yaml
@@ -38,6 +38,8 @@ provider_defaults:
   csm:
     Class: River
     Ordinal: 3000
+    StartingHmnVlan: 1513
+    EndingHmnVlan: 1769
 
 ---
 manufacturer: HPE
@@ -49,3 +51,5 @@ provider_defaults:
   csm:
     Class: River
     starting_cabinet: 3000
+    StartingHmnVlan: 1513
+    EndingHmnVlan: 1769

--- a/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex2000.yaml
+++ b/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex2000.yaml
@@ -49,3 +49,5 @@ provider_defaults:
   csm:
     Class: Hill
     Ordinal: 9000
+    StartingHmnVlan: 3000
+    EndingHmnVlan: 3999

--- a/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex2500-1-liquid-cooled-chassis.yaml
+++ b/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex2500-1-liquid-cooled-chassis.yaml
@@ -49,3 +49,5 @@ provider_defaults:
   csm:
     Class: Hill
     Ordinal: 8000
+    StartingHmnVlan: 3000
+    EndingHmnVlan: 3999

--- a/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex2500-2-liquid-cooled.yaml
+++ b/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex2500-2-liquid-cooled.yaml
@@ -49,3 +49,5 @@ provider_defaults:
   csm:
     Class: Hill
     Ordinal: 8000
+    StartingHmnVlan: 3000
+    EndingHmnVlan: 3999

--- a/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex2500-3-liquid-cooled.yaml
+++ b/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex2500-3-liquid-cooled.yaml
@@ -54,3 +54,5 @@ provider_defaults:
   csm:
     Class: Hill
     Ordinal: 8000
+    StartingHmnVlan: 3000
+    EndingHmnVlan: 3999

--- a/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex3000.yaml
+++ b/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex3000.yaml
@@ -84,3 +84,5 @@ provider_defaults:
   csm:
     Class: Mountain
     Ordinal: 1000
+    StartingHmnVlan: 3000
+    EndingHmnVlan: 3999

--- a/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex4000.yaml
+++ b/pkg/hardwaretypes/hardware-types/hpe-cabinet-ex4000.yaml
@@ -84,3 +84,5 @@ provider_defaults:
   csm:
     Class: Mountain
     Ordinal: 1000
+    StartingHmnVlan: 3000
+    EndingHmnVlan: 3999

--- a/pkg/hardwaretypes/hardware-types/schema/devicetype.json
+++ b/pkg/hardwaretypes/hardware-types/schema/devicetype.json
@@ -142,7 +142,13 @@
                         },
                         "Ordinal": {
                           "type": "integer"
-                      }
+                        },
+                        "StartingHmnVlan": {
+                          "type": "integer"
+                        },
+                        "EndingHmnVlan": {
+                          "type": "integer"
+                        }
                     }  
                 }
             }

--- a/pkg/hardwaretypes/types.go
+++ b/pkg/hardwaretypes/types.go
@@ -143,8 +143,10 @@ type ProviderDefaults struct {
 }
 
 type ProviderDefaultsCSM struct {
-	Class   *string `yaml:"Class"`
-	Ordinal int     `yaml:"Ordinal"`
+	Class           *string `yaml:"Class"`
+	Ordinal         int     `yaml:"Ordinal"`
+	StartingHmnVlan int     `yaml:"StartingHmnVlan"`
+	EndingHmnVlan   int     `yaml:"EndingHmnVlan"`
 }
 
 // TODO


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- moves default starting vlans to the hardwaretypes definitions
- adds a function to find the starting vlan using the slug
- adjusts the `RecommendCabinet` function as needed

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Low