### PR TITLE
add accept option to add cabinet; adjust tests accordingly

### DIFF
--- a/cmd/cabinet/add_cabinet.go
+++ b/cmd/cabinet/add_cabinet.go
@@ -71,11 +71,15 @@ func addCabinet(cmd *cobra.Command, args []string) error {
 		log.Debug().Msgf("Provider recommendations: %+v", recommendations)
 		log.Info().Msgf("Suggested cabinet number: %d", cabinetNumber)
 		log.Info().Msgf("Suggested VLAN ID: %d", vlanId)
-		// Prompt the user to confirm the suggestions
-		auto, err = tui.CustomConfirmation(
-			fmt.Sprintf("Would you like to accept the recommendations and add the %s", hardwaretypes.Cabinet))
-		if err != nil {
-			return err
+		if accept {
+			auto = true
+		} else {
+			// Prompt the user to confirm the suggestions
+			auto, err = tui.CustomConfirmation(
+				fmt.Sprintf("Would you like to accept the recommendations and add the %s", hardwaretypes.Cabinet))
+			if err != nil {
+				return err
+			}
 		}
 
 		// If the user chose not to accept the suggestions, exit

--- a/cmd/cabinet/init.go
+++ b/cmd/cabinet/init.go
@@ -33,6 +33,7 @@ var (
 	cabinetNumber int
 	vlanId        int
 	auto          bool
+	accept        bool
 )
 
 func init() {
@@ -52,4 +53,5 @@ func init() {
 	AddCabinetCmd.MarkFlagsRequiredTogether("cabinet", "vlan-id")
 	AddCabinetCmd.Flags().BoolVar(&auto, "auto", false, "Automatically recommend and assign required flags.")
 	AddCabinetCmd.MarkFlagsMutuallyExclusive("auto")
+	AddCabinetCmd.Flags().BoolVarP(&accept, "accept", "y", false, "Automatically accept recommended values.")
 }

--- a/cmd/session/init.go
+++ b/cmd/session/init.go
@@ -59,7 +59,7 @@ func init() {
 	SessionStartCmd.Flags().BoolVarP(&useSimulation, "csm-simulator", "S", false, "(CSM Provider) Use simulation environment URLs")
 
 	// These three pieces are needed for the CSM provider to get a token
-	SessionStartCmd.Flags().StringVar(&providerHost, "csm-api-host", "api-gw-service-nmn.local", "(CSM Provider) Host or FQDN for authentation and APIs")
+	SessionStartCmd.Flags().StringVar(&providerHost, "csm-api-host", "", "(CSM Provider) Host or FQDN for authentation and APIs")
 	// SessionStartCmd.MarkFlagRequired("csm-api-host")
 	SessionStartCmd.Flags().StringVar(&tokenUsername, "csm-keycloak-username", "", "(CSM Provider) Keycloak username")
 	// SessionStartCmd.MarkFlagRequired("csm-keycloak-username")

--- a/spec/cani_add_cabinet_spec.sh
+++ b/spec/cani_add_cabinet_spec.sh
@@ -202,4 +202,340 @@ It '--config canitest.yml hpe-ex2000 --cabinet 4321 --vlan-id 1234'
   The stderr should include "    - Specified HMN Vlan (1234) is not unique, shared by: "
 End
 
+# Adding a cabinet should fail if:
+#   - a session is active
+#   - a datastore exists
+#   - auto flag is set
+#   - cabinet flag is set
+#   - vlan-id flag is not set 
+It '--config canitest.yml hpe-ex2000 --auto --vlan-id 1234'
+  BeforeCall use_active_session # session is active
+  When call bin/cani alpha add cabinet --config canitest.yml hpe-ex2000 --auto --vlan-id 1234
+  The status should equal 1
+  The line 1 of stderr should equal "Error: if any flags in the group [cabinet vlan-id] are set they must all be set; missing [cabinet]"
+End
+
+# Adding a cabinet should fail if:
+#   - a session is active
+#   - a datastore exists
+#   - auto flag is set
+#   - cabinet flag is not set
+#   - vlan-id flag is set 
+It '--config canitest.yml hpe-ex2000 --auto --cabinet 4321'
+  BeforeCall use_active_session # session is active
+  When call bin/cani alpha add cabinet --config canitest.yml hpe-ex2000 --auto --cabinet 4321 
+  The status should equal 1
+  The line 1 of stderr should equal "Error: if any flags in the group [cabinet vlan-id] are set they must all be set; missing [vlan-id]"
+End
+
+# Adding a cabinet should succeed if:
+#   - a session is active
+#   - a datastore exists
+#   - auto flag is set
+#   - accept flag is set
+It '--config canitest.yml hpe-ex2000 --auto --accept'
+  BeforeCall use_active_session # session is active
+  When call bin/cani alpha add cabinet --config canitest.yml hpe-ex2000 --auto --accept 
+  The status should equal 0
+  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 2 of stderr should include " Suggested cabinet number: "
+  The line 3 of stderr should include " Suggested VLAN ID: "
+  The line 4 of stderr should include " was successfully staged to be added to the system"
+  The line 5 of stderr should include " UUID: "
+  The line 6 of stderr should include " Cabinet Number: "
+  The line 7 of stderr should include " VLAN ID: "
+End
+
+# Adding a hpe-eia-cabinet should succeed if:
+#   - a session is active
+#   - a datastore exists
+#   - auto flag is set
+#   - accept flag is set
+# given a system with zero cabinets, the added cabinet should have:
+#   - cabinet number 3000
+#   - vlan id 1513
+It '--config canitest.yml hpe-eia-cabinet --auto --accept'
+  BeforeCall use_active_session # session is active
+  BeforeCall use_valid_datastore_system_only # deploy a valid datastore
+  When call bin/cani alpha add cabinet --config canitest.yml hpe-eia-cabinet --auto --accept 
+  The status should equal 0
+  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 2 of stderr should include " Suggested cabinet number: "
+  The line 3 of stderr should include " Suggested VLAN ID: "
+  The line 4 of stderr should include " was successfully staged to be added to the system"
+  The line 5 of stderr should include " UUID: "
+  The line 6 of stderr should include " Cabinet Number: 3000"
+  The line 7 of stderr should include " VLAN ID: 1513"
+End
+
+# Adding another hpe-eia-cabinet should succeed if:
+#   - a session is active
+#   - a datastore exists
+#   - auto flag is set
+#   - accept flag is set
+# given a system with zero cabinets, the added cabinet should have:
+#   - cabinet number 3001 (incremented by one)
+#   - vlan id 1514 (incremented by one)
+It '--config canitest.yml hpe-eia-cabinet --auto --accept'
+  When call bin/cani alpha add cabinet --config canitest.yml hpe-eia-cabinet --auto --accept 
+  The status should equal 0
+  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 2 of stderr should include " Suggested cabinet number: "
+  The line 3 of stderr should include " Suggested VLAN ID: "
+  The line 4 of stderr should include " was successfully staged to be added to the system"
+  The line 5 of stderr should include " UUID: "
+  The line 6 of stderr should include " Cabinet Number: 3001"
+  The line 7 of stderr should include " VLAN ID: 1514"
+End
+
+# Adding a hpe-ex2000 should succeed if:
+#   - a session is active
+#   - a datastore exists
+#   - auto flag is set
+#   - accept flag is set
+# given a system with zero cabinets, the added cabinet should have:
+#   - cabinet number 9000
+#   - vlan id 3000
+It '--config canitest.yml hpe-ex2000 --auto --accept'
+  BeforeCall use_active_session # session is active
+  BeforeCall use_valid_datastore_system_only # deploy a valid datastore
+  When call bin/cani alpha add cabinet --config canitest.yml hpe-ex2000 --auto --accept 
+  The status should equal 0
+  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 2 of stderr should include " Suggested cabinet number: "
+  The line 3 of stderr should include " Suggested VLAN ID: "
+  The line 4 of stderr should include " was successfully staged to be added to the system"
+  The line 5 of stderr should include " UUID: "
+  The line 6 of stderr should include " Cabinet Number: 9000"
+  The line 7 of stderr should include " VLAN ID: 3000"
+End
+
+# Adding another hpe-ex2000 should succeed if:
+#   - a session is active
+#   - a datastore exists
+#   - auto flag is set
+#   - accept flag is set
+# given a system with zero cabinets, the added cabinet should have:
+#   - cabinet number 9001 (incremented by one)
+#   - vlan id 3001 (incremented by one)
+It '--config canitest.yml hpe-ex2000 --auto --accept'
+  When call bin/cani alpha add cabinet --config canitest.yml hpe-ex2000 --auto --accept 
+  The status should equal 0
+  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 2 of stderr should include " Suggested cabinet number: "
+  The line 3 of stderr should include " Suggested VLAN ID: "
+  The line 4 of stderr should include " was successfully staged to be added to the system"
+  The line 5 of stderr should include " UUID: "
+  The line 6 of stderr should include " Cabinet Number: 9001"
+  The line 7 of stderr should include " VLAN ID: 3001"
+End
+
+# Adding a hpe-ex2500-1-liquid-cooled-chassis should succeed if:
+#   - a session is active
+#   - a datastore exists
+#   - auto flag is set
+#   - accept flag is set
+# given a system with zero cabinets, the added cabinet should have:
+#   - cabinet number 8000
+#   - vlan id 3000
+It '--config canitest.yml hpe-ex2500-1-liquid-cooled-chassis --auto --accept'
+  BeforeCall use_active_session # session is active
+  BeforeCall use_valid_datastore_system_only # deploy a valid datastore
+  When call bin/cani alpha add cabinet --config canitest.yml hpe-ex2500-1-liquid-cooled-chassis --auto --accept 
+  The status should equal 0
+  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 2 of stderr should include " Suggested cabinet number: "
+  The line 3 of stderr should include " Suggested VLAN ID: "
+  The line 4 of stderr should include " was successfully staged to be added to the system"
+  The line 5 of stderr should include " UUID: "
+  The line 6 of stderr should include " Cabinet Number: 8000"
+  The line 7 of stderr should include " VLAN ID: 3000"
+End
+
+# Adding another hpe-ex2500-1-liquid-cooled-chassis should succeed if:
+#   - a session is active
+#   - a datastore exists
+#   - auto flag is set
+#   - accept flag is set
+# given a system with zero cabinets, the added cabinet should have:
+#   - cabinet number 8001 (incremented by one)
+#   - vlan id 3001 (incremented by one)
+It '--config canitest.yml hpe-ex2500-1-liquid-cooled-chassis --auto --accept'
+  When call bin/cani alpha add cabinet --config canitest.yml hpe-ex2500-1-liquid-cooled-chassis --auto --accept 
+  The status should equal 0
+  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 2 of stderr should include " Suggested cabinet number: "
+  The line 3 of stderr should include " Suggested VLAN ID: "
+  The line 4 of stderr should include " was successfully staged to be added to the system"
+  The line 5 of stderr should include " UUID: "
+  The line 6 of stderr should include " Cabinet Number: 8001"
+  The line 7 of stderr should include " VLAN ID: 3001"
+End
+
+# Adding a hpe-ex2500-2-liquid-cooled-chassis should succeed if:
+#   - a session is active
+#   - a datastore exists
+#   - auto flag is set
+#   - accept flag is set
+# given a system with zero cabinets, the added cabinet should have:
+#   - cabinet number 8000
+#   - vlan id 3000
+It '--config canitest.yml hpe-ex2500-2-liquid-cooled-chassis --auto --accept'
+  BeforeCall use_active_session # session is active
+  BeforeCall use_valid_datastore_system_only # deploy a valid datastore
+  When call bin/cani alpha add cabinet --config canitest.yml hpe-ex2500-2-liquid-cooled-chassis --auto --accept 
+  The status should equal 0
+  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 2 of stderr should include " Suggested cabinet number: "
+  The line 3 of stderr should include " Suggested VLAN ID: "
+  The line 4 of stderr should include " was successfully staged to be added to the system"
+  The line 5 of stderr should include " UUID: "
+  The line 6 of stderr should include " Cabinet Number: 8000"
+  The line 7 of stderr should include " VLAN ID: 3000"
+End
+
+# Adding another hpe-ex2500-2-liquid-cooled-chassis should succeed if:
+#   - a session is active
+#   - a datastore exists
+#   - auto flag is set
+#   - accept flag is set
+# given a system with zero cabinets, the added cabinet should have:
+#   - cabinet number 8001 (incremented by one)
+#   - vlan id 3000 (incremented by one)
+It '--config canitest.yml hpe-ex2500-2-liquid-cooled-chassis --auto --accept'
+  When call bin/cani alpha add cabinet --config canitest.yml hpe-ex2500-2-liquid-cooled-chassis --auto --accept 
+  The status should equal 0
+  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 2 of stderr should include " Suggested cabinet number: "
+  The line 3 of stderr should include " Suggested VLAN ID: "
+  The line 4 of stderr should include " was successfully staged to be added to the system"
+  The line 5 of stderr should include " UUID: "
+  The line 6 of stderr should include " Cabinet Number: 8001"
+  The line 7 of stderr should include " VLAN ID: 3001"
+End
+
+# Adding a hpe-ex2500-3-liquid-cooled-chassis should succeed if:
+#   - a session is active
+#   - a datastore exists
+#   - auto flag is set
+#   - accept flag is set
+# given a system with zero cabinets, the added cabinet should have:
+#   - cabinet number 8000
+#   - vlan id 3000
+It '--config canitest.yml hpe-ex2500-3-liquid-cooled-chassis --auto --accept'
+  BeforeCall use_active_session # session is active
+  BeforeCall use_valid_datastore_system_only # deploy a valid datastore
+  When call bin/cani alpha add cabinet --config canitest.yml hpe-ex2500-3-liquid-cooled-chassis --auto --accept 
+  The status should equal 0
+  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 2 of stderr should include " Suggested cabinet number: "
+  The line 3 of stderr should include " Suggested VLAN ID: "
+  The line 4 of stderr should include " was successfully staged to be added to the system"
+  The line 5 of stderr should include " UUID: "
+  The line 6 of stderr should include " Cabinet Number: 8000"
+  The line 7 of stderr should include " VLAN ID: 3000"
+End
+
+# Adding another hpe-ex2500-3-liquid-cooled-chassis should succeed if:
+#   - a session is active
+#   - a datastore exists
+#   - auto flag is set
+#   - accept flag is set
+# given a system with zero cabinets, the added cabinet should have:
+#   - cabinet number 8001 (incremented by one)
+#   - vlan id 3001 (incremented by one)
+It '--config canitest.yml hpe-ex2500-3-liquid-cooled-chassis --auto --accept'
+  When call bin/cani alpha add cabinet --config canitest.yml hpe-ex2500-3-liquid-cooled-chassis --auto --accept 
+  The status should equal 0
+  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 2 of stderr should include " Suggested cabinet number: "
+  The line 3 of stderr should include " Suggested VLAN ID: "
+  The line 4 of stderr should include " was successfully staged to be added to the system"
+  The line 5 of stderr should include " UUID: "
+  The line 6 of stderr should include " Cabinet Number: 8001"
+  The line 7 of stderr should include " VLAN ID: 3001"
+End
+
+# Adding a hpe-ex3000 should succeed if:
+#   - a session is active
+#   - a datastore exists
+#   - auto flag is set
+#   - accept flag is set
+# given a system with zero cabinets, the added cabinet should have:
+#   - cabinet number 1000
+#   - vlan id 3000
+It '--config canitest.yml hpe-ex3000 --auto --accept'
+  BeforeCall use_active_session # session is active
+  BeforeCall use_valid_datastore_system_only # deploy a valid datastore
+  When call bin/cani alpha add cabinet --config canitest.yml hpe-ex3000 --auto --accept 
+  The status should equal 0
+  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 2 of stderr should include " Suggested cabinet number: "
+  The line 3 of stderr should include " Suggested VLAN ID: "
+  The line 4 of stderr should include " was successfully staged to be added to the system"
+  The line 5 of stderr should include " UUID: "
+  The line 6 of stderr should include " Cabinet Number: 1000"
+  The line 7 of stderr should include " VLAN ID: 3000"
+End
+
+# Adding another hpe-ex3000 should succeed if:
+#   - a session is active
+#   - a datastore exists
+#   - auto flag is set
+#   - accept flag is set
+# given a system with zero cabinets, the added cabinet should have:
+#   - cabinet number 1001 (incremented by one)
+#   - vlan id 3001 (incremented by one)
+It '--config canitest.yml hpe-ex3000 --auto --accept'
+  When call bin/cani alpha add cabinet --config canitest.yml hpe-ex3000 --auto --accept 
+  The status should equal 0
+  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 2 of stderr should include " Suggested cabinet number: "
+  The line 3 of stderr should include " Suggested VLAN ID: "
+  The line 4 of stderr should include " was successfully staged to be added to the system"
+  The line 5 of stderr should include " UUID: "
+  The line 6 of stderr should include " Cabinet Number: 1001"
+  The line 7 of stderr should include " VLAN ID: 3001"
+End
+
+# Adding a hpe-ex4000 should succeed if:
+#   - a session is active
+#   - a datastore exists
+#   - auto flag is set
+#   - accept flag is set
+# given a system with zero cabinets, the added cabinet should have:
+#   - cabinet number 1002
+#   - vlan id 3002
+It '--config canitest.yml hpe-ex4000 --auto --accept'
+  When call bin/cani alpha add cabinet --config canitest.yml hpe-ex4000 --auto --accept 
+  The status should equal 0
+  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 2 of stderr should include " Suggested cabinet number: "
+  The line 3 of stderr should include " Suggested VLAN ID: "
+  The line 4 of stderr should include " was successfully staged to be added to the system"
+  The line 5 of stderr should include " UUID: "
+  The line 6 of stderr should include " Cabinet Number: 1002"
+  The line 7 of stderr should include " VLAN ID: 3002"
+End
+
+# Adding another hpe-ex4000 should succeed if:
+#   - a session is active
+#   - a datastore exists
+#   - auto flag is set
+#   - accept flag is set
+# given a system with zero cabinets, the added cabinet should have:
+#   - cabinet number 1003 (incremented by one)
+#   - vlan id 3003 (incremented by one)
+It '--config canitest.yml hpe-ex4000 --auto --accept'
+  When call bin/cani alpha add cabinet --config canitest.yml hpe-ex4000 --auto --accept 
+  The status should equal 0
+  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 2 of stderr should include " Suggested cabinet number: "
+  The line 3 of stderr should include " Suggested VLAN ID: "
+  The line 4 of stderr should include " was successfully staged to be added to the system"
+  The line 5 of stderr should include " UUID: "
+  The line 6 of stderr should include " Cabinet Number: 1003"
+  The line 7 of stderr should include " VLAN ID: 3003"
+End
+
 End

--- a/testdata/fixtures/cani/add/cabinet/help
+++ b/testdata/fixtures/cani/add/cabinet/help
@@ -4,6 +4,7 @@ Usage:
   cani alpha add cabinet [flags]
 
 Flags:
+  -y, --accept                 Automatically accept recommended values.
       --auto                   Automatically recommend and assign required flags.
       --cabinet int            Cabinet number. (default 1001)
   -h, --help                   help for cabinet


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- Adds `--accept` to the add cabinet flow (for tests and automation)
- Updates the tests accordingly and checks each cabinet type and that the vlans and cabinet numbers are incremented

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Low