### PR TITLE
add cani schema check during import and warn of mismatches

### DIFF
--- a/.github/workflows/shellspec.yml
+++ b/.github/workflows/shellspec.yml
@@ -52,7 +52,7 @@ jobs:
         name: Install shellspec (macOS)
         run: |
           brew tap shellspec/shellspec
-          brew update
+          # brew update
           brew install shellspec ksh93 bash
 
       - if: ${{ matrix.os == 'macos-latest' }}

--- a/internal/provider/csm/import.go
+++ b/internal/provider/csm/import.go
@@ -72,6 +72,12 @@ func loadJSON(path string, dest interface{}) error {
 }
 
 func (csm *CSM) Import(ctx context.Context, datastore inventory.Datastore) error {
+	// Check the schema version defined in the datastore
+	datastoreSchema, err := datastore.GetSchemaVersion()
+	if err != nil {
+		return err
+	}
+	currentSchema := string(datastoreSchema)
 
 	//
 	// Retrieve current state from the system
@@ -297,6 +303,11 @@ func (csm *CSM) Import(ctx context.Context, datastore inventory.Datastore) error
 			return fmt.Errorf("failed to decode SLS hardware extra properties (%s)", slsCabinet.Xname)
 		}
 
+		// if a schema is present but does not match the current schema, warn but accept so the user can adjust as needed
+		if slsCabinetEP.CaniSlsSchemaVersion != "" && slsCabinetEP.CaniSlsSchemaVersion != currentSchema {
+			log.Warn().Msgf("Schema mismatch: expected %s but found %s for SLS %s %s (%s)", currentSchema, slsCabinetEP.CaniSlsSchemaVersion, cCabinet.Type, slsCabinet.Xname, cCabinet.ID)
+		}
+
 		if slsCabinetEP.CaniId != cCabinet.ID.String() {
 			if len(slsCabinetEP.CaniId) != 0 {
 				log.Warn().Msgf("Detected CANI hardware ID change from %s to %s for SLS Hardware %s", slsCabinetEP.CaniId, cCabinet.ID, slsCabinet.Xname)
@@ -339,6 +350,11 @@ func (csm *CSM) Import(ctx context.Context, datastore inventory.Datastore) error
 			return fmt.Errorf("failed to decode SLS hardware extra properties (%s)", slsHardware.Xname)
 		}
 
+		// if a schema is present but does not match the current schema, warn but accept so the user can adjust as needed
+		if slsEP.CaniSlsSchemaVersion != "" && slsEP.CaniSlsSchemaVersion != currentSchema {
+			log.Warn().Msgf("Schema mismatch: expected %s but found %s for SLS %s %s (%s)", currentSchema, slsEP.CaniSlsSchemaVersion, cHardware.Type, slsHardware.Xname, cHardware.ID)
+		}
+
 		if slsEP.CaniId != cHardware.ID.String() {
 			if len(slsEP.CaniId) != 0 {
 				log.Warn().Msgf("Detected CANI hardware ID change from %s to %s for SLS Hardware %s", slsEP.CaniId, cHardware.ID, slsHardware.Xname)
@@ -379,6 +395,11 @@ func (csm *CSM) Import(ctx context.Context, datastore inventory.Datastore) error
 		slsEP, err := sls.DecodeExtraProperties[sls_client.HardwareExtraPropertiesChassisBmc](slsHardware)
 		if err != nil {
 			return fmt.Errorf("failed to decode SLS hardware extra properties (%s)", slsHardware.Xname)
+		}
+
+		// if a schema is present but does not match the current schema, warn but accept so the user can adjust as needed
+		if slsEP.CaniSlsSchemaVersion != "" && slsEP.CaniSlsSchemaVersion != currentSchema {
+			log.Warn().Msgf("Schema mismatch: expected %s but found %s for SLS %s %s (%s)", currentSchema, slsEP.CaniSlsSchemaVersion, cHardware.Type, slsHardware.Xname, cHardware.ID)
 		}
 
 		if slsEP.CaniId != cHardware.ID.String() {
@@ -632,6 +653,11 @@ func (csm *CSM) Import(ctx context.Context, datastore inventory.Datastore) error
 		// Push updates into the datastore
 		if err := tempDatastore.Update(&cNode); err != nil {
 			return fmt.Errorf("failed to update hardware (%s) in memory datastore", cNode.ID)
+		}
+
+		// if a schema is present but does not match the current schema, warn but accept so the user can adjust as needed
+		if slsNodeEP.CaniSlsSchemaVersion != "" && slsNodeEP.CaniSlsSchemaVersion != currentSchema {
+			log.Warn().Msgf("Schema mismatch: expected %s but found %s for SLS %s %s (%s)", currentSchema, slsNodeEP.CaniSlsSchemaVersion, cNode.Type, slsNode.Xname, cNode.ID)
 		}
 
 		//

--- a/testdata/fixtures/sls/valid-vshasta-mountain.json
+++ b/testdata/fixtures/sls/valid-vshasta-mountain.json
@@ -1,0 +1,2412 @@
+{
+    "Hardware": {
+      "x1000": {
+        "Parent": "s0",
+        "Children": [
+          "x1000c0",
+          "x1000c1",
+          "x1000c2",
+          "x1000c3",
+          "x1000c4",
+          "x1000c5",
+          "x1000c6",
+          "x1000c7"
+        ],
+        "Xname": "x1000",
+        "Type": "comptype_cabinet",
+        "Class": "Mountain",
+        "TypeString": "Cabinet",
+        "LastUpdated": 1686924409,
+        "LastUpdatedTime": "2023-06-16 14:06:49.878162 +0000 +0000",
+        "ExtraProperties": {
+          "Networks": {
+            "cn": {
+              "HMN": {
+                "CIDR": "10.104.0.0/22",
+                "Gateway": "10.104.0.1",
+                "VLan": 3000
+              },
+              "NMN": {
+                "CIDR": "10.100.0.0/22",
+                "Gateway": "10.100.0.1",
+                "VLan": 2000
+              }
+            }
+          }
+        }
+      },
+      "x1000c0": {
+        "Parent": "x1000",
+        "Children": [
+          "x1000c0b0"
+        ],
+        "Xname": "x1000c0",
+        "Type": "comptype_chassis",
+        "Class": "Mountain",
+        "TypeString": "Chassis",
+        "LastUpdated": 1686924409,
+        "LastUpdatedTime": "2023-06-16 14:06:49.942535 +0000 +0000"
+      },
+      "x1000c0b0": {
+        "Parent": "x1000c0",
+        "Xname": "x1000c0b0",
+        "Type": "comptype_chassis_bmc",
+        "Class": "Mountain",
+        "TypeString": "ChassisBMC",
+        "LastUpdated": 1686924409,
+        "LastUpdatedTime": "2023-06-16 14:06:49.970322 +0000 +0000"
+      },
+      "x1000c0s0b0n0": {
+        "Parent": "x1000c0s0b0",
+        "Xname": "x1000c0s0b0n0",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.266586 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001001"
+          ],
+          "NID": 1001,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s0b0n1": {
+        "Parent": "x1000c0s0b0",
+        "Xname": "x1000c0s0b0n1",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.284219 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001002"
+          ],
+          "NID": 1002,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s0b1n0": {
+        "Parent": "x1000c0s0b1",
+        "Xname": "x1000c0s0b1n0",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.302758 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001003"
+          ],
+          "NID": 1003,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s0b1n1": {
+        "Parent": "x1000c0s0b1",
+        "Xname": "x1000c0s0b1n1",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.321275 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001004"
+          ],
+          "NID": 1004,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s1b0n0": {
+        "Parent": "x1000c0s1b0",
+        "Xname": "x1000c0s1b0n0",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.341497 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001005"
+          ],
+          "NID": 1005,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s1b0n1": {
+        "Parent": "x1000c0s1b0",
+        "Xname": "x1000c0s1b0n1",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.362862 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001006"
+          ],
+          "NID": 1006,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s1b1n0": {
+        "Parent": "x1000c0s1b1",
+        "Xname": "x1000c0s1b1n0",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.385057 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001007"
+          ],
+          "NID": 1007,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s1b1n1": {
+        "Parent": "x1000c0s1b1",
+        "Xname": "x1000c0s1b1n1",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.403415 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001008"
+          ],
+          "NID": 1008,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s2b0n0": {
+        "Parent": "x1000c0s2b0",
+        "Xname": "x1000c0s2b0n0",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.420833 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001009"
+          ],
+          "NID": 1009,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s2b0n1": {
+        "Parent": "x1000c0s2b0",
+        "Xname": "x1000c0s2b0n1",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.445396 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001010"
+          ],
+          "NID": 1010,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s2b1n0": {
+        "Parent": "x1000c0s2b1",
+        "Xname": "x1000c0s2b1n0",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.465249 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001011"
+          ],
+          "NID": 1011,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s2b1n1": {
+        "Parent": "x1000c0s2b1",
+        "Xname": "x1000c0s2b1n1",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.484055 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001012"
+          ],
+          "NID": 1012,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s3b0n0": {
+        "Parent": "x1000c0s3b0",
+        "Xname": "x1000c0s3b0n0",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.503439 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001013"
+          ],
+          "NID": 1013,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s3b0n1": {
+        "Parent": "x1000c0s3b0",
+        "Xname": "x1000c0s3b0n1",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.525818 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001014"
+          ],
+          "NID": 1014,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s3b1n0": {
+        "Parent": "x1000c0s3b1",
+        "Xname": "x1000c0s3b1n0",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.545357 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001015"
+          ],
+          "NID": 1015,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s3b1n1": {
+        "Parent": "x1000c0s3b1",
+        "Xname": "x1000c0s3b1n1",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.564266 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001016"
+          ],
+          "NID": 1016,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s4b0n0": {
+        "Parent": "x1000c0s4b0",
+        "Xname": "x1000c0s4b0n0",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.588455 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001017"
+          ],
+          "NID": 1017,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s4b0n1": {
+        "Parent": "x1000c0s4b0",
+        "Xname": "x1000c0s4b0n1",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.605626 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001018"
+          ],
+          "NID": 1018,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s4b1n0": {
+        "Parent": "x1000c0s4b1",
+        "Xname": "x1000c0s4b1n0",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.623731 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001019"
+          ],
+          "NID": 1019,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s4b1n1": {
+        "Parent": "x1000c0s4b1",
+        "Xname": "x1000c0s4b1n1",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.643469 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001020"
+          ],
+          "NID": 1020,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s5b0n0": {
+        "Parent": "x1000c0s5b0",
+        "Xname": "x1000c0s5b0n0",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.665781 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001021"
+          ],
+          "NID": 1021,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s5b0n1": {
+        "Parent": "x1000c0s5b0",
+        "Xname": "x1000c0s5b0n1",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.688249 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001022"
+          ],
+          "NID": 1022,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s5b1n0": {
+        "Parent": "x1000c0s5b1",
+        "Xname": "x1000c0s5b1n0",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.709182 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001023"
+          ],
+          "NID": 1023,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s5b1n1": {
+        "Parent": "x1000c0s5b1",
+        "Xname": "x1000c0s5b1n1",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.727872 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001024"
+          ],
+          "NID": 1024,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s6b0n0": {
+        "Parent": "x1000c0s6b0",
+        "Xname": "x1000c0s6b0n0",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.746357 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001025"
+          ],
+          "NID": 1025,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s6b0n1": {
+        "Parent": "x1000c0s6b0",
+        "Xname": "x1000c0s6b0n1",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.765354 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001026"
+          ],
+          "NID": 1026,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s6b1n0": {
+        "Parent": "x1000c0s6b1",
+        "Xname": "x1000c0s6b1n0",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.788314 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001027"
+          ],
+          "NID": 1027,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s6b1n1": {
+        "Parent": "x1000c0s6b1",
+        "Xname": "x1000c0s6b1n1",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.808858 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001028"
+          ],
+          "NID": 1028,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s7b0n0": {
+        "Parent": "x1000c0s7b0",
+        "Xname": "x1000c0s7b0n0",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.830676 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001029"
+          ],
+          "NID": 1029,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s7b0n1": {
+        "Parent": "x1000c0s7b0",
+        "Xname": "x1000c0s7b0n1",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.85105 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001030"
+          ],
+          "NID": 1030,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s7b1n0": {
+        "Parent": "x1000c0s7b1",
+        "Xname": "x1000c0s7b1n0",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.871531 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001031"
+          ],
+          "NID": 1031,
+          "Role": "Compute"
+        }
+      },
+      "x1000c0s7b1n1": {
+        "Parent": "x1000c0s7b1",
+        "Xname": "x1000c0s7b1n1",
+        "Type": "comptype_node",
+        "Class": "Mountain",
+        "TypeString": "Node",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.892176 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid001032"
+          ],
+          "NID": 1032,
+          "Role": "Compute"
+        }
+      },
+      "x1000c1": {
+        "Parent": "x1000",
+        "Children": [
+          "x1000c1b0"
+        ],
+        "Xname": "x1000c1",
+        "Type": "comptype_chassis",
+        "Class": "Mountain",
+        "TypeString": "Chassis",
+        "LastUpdated": 1686924409,
+        "LastUpdatedTime": "2023-06-16 14:06:49.988073 +0000 +0000"
+      },
+      "x1000c1b0": {
+        "Parent": "x1000c1",
+        "Xname": "x1000c1b0",
+        "Type": "comptype_chassis_bmc",
+        "Class": "Mountain",
+        "TypeString": "ChassisBMC",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.00655 +0000 +0000"
+      },
+      "x1000c2": {
+        "Parent": "x1000",
+        "Children": [
+          "x1000c2b0"
+        ],
+        "Xname": "x1000c2",
+        "Type": "comptype_chassis",
+        "Class": "Mountain",
+        "TypeString": "Chassis",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.026098 +0000 +0000"
+      },
+      "x1000c2b0": {
+        "Parent": "x1000c2",
+        "Xname": "x1000c2b0",
+        "Type": "comptype_chassis_bmc",
+        "Class": "Mountain",
+        "TypeString": "ChassisBMC",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.048826 +0000 +0000"
+      },
+      "x1000c3": {
+        "Parent": "x1000",
+        "Children": [
+          "x1000c3b0"
+        ],
+        "Xname": "x1000c3",
+        "Type": "comptype_chassis",
+        "Class": "Mountain",
+        "TypeString": "Chassis",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.067986 +0000 +0000"
+      },
+      "x1000c3b0": {
+        "Parent": "x1000c3",
+        "Xname": "x1000c3b0",
+        "Type": "comptype_chassis_bmc",
+        "Class": "Mountain",
+        "TypeString": "ChassisBMC",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.086311 +0000 +0000"
+      },
+      "x1000c4": {
+        "Parent": "x1000",
+        "Children": [
+          "x1000c4b0"
+        ],
+        "Xname": "x1000c4",
+        "Type": "comptype_chassis",
+        "Class": "Mountain",
+        "TypeString": "Chassis",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.105503 +0000 +0000"
+      },
+      "x1000c4b0": {
+        "Parent": "x1000c4",
+        "Xname": "x1000c4b0",
+        "Type": "comptype_chassis_bmc",
+        "Class": "Mountain",
+        "TypeString": "ChassisBMC",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.1286 +0000 +0000"
+      },
+      "x1000c5": {
+        "Parent": "x1000",
+        "Children": [
+          "x1000c5b0"
+        ],
+        "Xname": "x1000c5",
+        "Type": "comptype_chassis",
+        "Class": "Mountain",
+        "TypeString": "Chassis",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.148872 +0000 +0000"
+      },
+      "x1000c5b0": {
+        "Parent": "x1000c5",
+        "Xname": "x1000c5b0",
+        "Type": "comptype_chassis_bmc",
+        "Class": "Mountain",
+        "TypeString": "ChassisBMC",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.168003 +0000 +0000"
+      },
+      "x1000c6": {
+        "Parent": "x1000",
+        "Children": [
+          "x1000c6b0"
+        ],
+        "Xname": "x1000c6",
+        "Type": "comptype_chassis",
+        "Class": "Mountain",
+        "TypeString": "Chassis",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.186778 +0000 +0000"
+      },
+      "x1000c6b0": {
+        "Parent": "x1000c6",
+        "Xname": "x1000c6b0",
+        "Type": "comptype_chassis_bmc",
+        "Class": "Mountain",
+        "TypeString": "ChassisBMC",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.206803 +0000 +0000"
+      },
+      "x1000c7": {
+        "Parent": "x1000",
+        "Children": [
+          "x1000c7b0"
+        ],
+        "Xname": "x1000c7",
+        "Type": "comptype_chassis",
+        "Class": "Mountain",
+        "TypeString": "Chassis",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.224706 +0000 +0000"
+      },
+      "x1000c7b0": {
+        "Parent": "x1000c7",
+        "Xname": "x1000c7b0",
+        "Type": "comptype_chassis_bmc",
+        "Class": "Mountain",
+        "TypeString": "ChassisBMC",
+        "LastUpdated": 1686924410,
+        "LastUpdatedTime": "2023-06-16 14:06:50.244816 +0000 +0000"
+      },
+      "x3000": {
+        "Parent": "s0",
+        "Xname": "x3000",
+        "Type": "comptype_cabinet",
+        "Class": "River",
+        "TypeString": "Cabinet",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "Networks": {
+            "cn": {
+              "HMN": {
+                "CIDR": "10.107.0.0/22",
+                "Gateway": "10.107.0.1",
+                "VLan": 1513
+              },
+              "NMN": {
+                "CIDR": "10.106.0.0/22",
+                "Gateway": "10.106.0.1",
+                "VLan": 1770
+              }
+            },
+            "ncn": {
+              "HMN": {
+                "CIDR": "10.107.0.0/22",
+                "Gateway": "10.107.0.1",
+                "VLan": 1513
+              },
+              "NMN": {
+                "CIDR": "10.106.0.0/22",
+                "Gateway": "10.106.0.1",
+                "VLan": 1770
+              }
+            }
+          }
+        }
+      },
+      "x3000c0h61s1": {
+        "Parent": "x3000c0h61",
+        "Xname": "x3000c0h61s1",
+        "Type": "comptype_hl_switch",
+        "Class": "River",
+        "TypeString": "MgmtHLSwitch",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "sw-spine-001"
+          ],
+          "Brand": "Aruba",
+          "IP4addr": "10.254.0.2"
+        }
+      },
+      "x3000c0h62s1": {
+        "Parent": "x3000c0h62",
+        "Xname": "x3000c0h62s1",
+        "Type": "comptype_hl_switch",
+        "Class": "River",
+        "TypeString": "MgmtHLSwitch",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "sw-spine-002"
+          ],
+          "Brand": "Aruba",
+          "IP4addr": "10.254.0.3"
+        }
+      },
+      "x3000c0s15b0n0": {
+        "Parent": "x3000c0s15b0",
+        "Xname": "x3000c0s15b0n0",
+        "Type": "comptype_node",
+        "Class": "River",
+        "TypeString": "Node",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "ncn-w001"
+          ],
+          "NID": 100004,
+          "Role": "Management",
+          "SubRole": "Worker"
+        }
+      },
+      "x3000c0s16b0n0": {
+        "Parent": "x3000c0s16b0",
+        "Xname": "x3000c0s16b0n0",
+        "Type": "comptype_node",
+        "Class": "River",
+        "TypeString": "Node",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "ncn-w002"
+          ],
+          "NID": 100005,
+          "Role": "Management",
+          "SubRole": "Worker"
+        }
+      },
+      "x3000c0s17b0n0": {
+        "Parent": "x3000c0s17b0",
+        "Xname": "x3000c0s17b0n0",
+        "Type": "comptype_node",
+        "Class": "River",
+        "TypeString": "Node",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "ncn-w003"
+          ],
+          "NID": 100006,
+          "Role": "Management",
+          "SubRole": "Worker"
+        }
+      },
+      "x3000c0s1b0n0": {
+        "Parent": "x3000c0s1b0",
+        "Xname": "x3000c0s1b0n0",
+        "Type": "comptype_node",
+        "Class": "River",
+        "TypeString": "Node",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "ncn-m001"
+          ],
+          "NID": 100007,
+          "Role": "Management",
+          "SubRole": "Master"
+        }
+      },
+      "x3000c0s29b0n0": {
+        "Parent": "x3000c0s29b0",
+        "Xname": "x3000c0s29b0n0",
+        "Type": "comptype_node",
+        "Class": "River",
+        "TypeString": "Node",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "ncn-s001"
+          ],
+          "NID": 100001,
+          "Role": "Management",
+          "SubRole": "Storage"
+        }
+      },
+      "x3000c0s2b0n0": {
+        "Parent": "x3000c0s2b0",
+        "Xname": "x3000c0s2b0n0",
+        "Type": "comptype_node",
+        "Class": "River",
+        "TypeString": "Node",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "ncn-m002"
+          ],
+          "NID": 100008,
+          "Role": "Management",
+          "SubRole": "Master"
+        }
+      },
+      "x3000c0s30b0n0": {
+        "Parent": "x3000c0s30b0",
+        "Xname": "x3000c0s30b0n0",
+        "Type": "comptype_node",
+        "Class": "River",
+        "TypeString": "Node",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "ncn-s002"
+          ],
+          "NID": 100002,
+          "Role": "Management",
+          "SubRole": "Storage"
+        }
+      },
+      "x3000c0s31b0n0": {
+        "Parent": "x3000c0s31b0",
+        "Xname": "x3000c0s31b0n0",
+        "Type": "comptype_node",
+        "Class": "River",
+        "TypeString": "Node",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "ncn-s003"
+          ],
+          "NID": 100003,
+          "Role": "Management",
+          "SubRole": "Storage"
+        }
+      },
+      "x3000c0s3b0n0": {
+        "Parent": "x3000c0s3b0",
+        "Xname": "x3000c0s3b0n0",
+        "Type": "comptype_node",
+        "Class": "River",
+        "TypeString": "Node",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "ncn-m003"
+          ],
+          "NID": 100009,
+          "Role": "Management",
+          "SubRole": "Master"
+        }
+      },
+      "x3000c0s43b0n0": {
+        "Parent": "x3000c0s43b0",
+        "Xname": "x3000c0s43b0n0",
+        "Type": "comptype_node",
+        "Class": "River",
+        "TypeString": "Node",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "uan01"
+          ],
+          "Role": "Application",
+          "SubRole": "UAN"
+        }
+      },
+      "x3000c0s51b0n0": {
+        "Parent": "x3000c0s51b0",
+        "Xname": "x3000c0s51b0n0",
+        "Type": "comptype_node",
+        "Class": "River",
+        "TypeString": "Node",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "nid000001"
+          ],
+          "NID": 1,
+          "Role": "Compute"
+        }
+      },
+      "x3000c0w60": {
+        "Parent": "x3000c0",
+        "Children": [
+          "x3000c0w60j1",
+          "x3000c0w60j10",
+          "x3000c0w60j11",
+          "x3000c0w60j2",
+          "x3000c0w60j3",
+          "x3000c0w60j4",
+          "x3000c0w60j5",
+          "x3000c0w60j6",
+          "x3000c0w60j7",
+          "x3000c0w60j8",
+          "x3000c0w60j9"
+        ],
+        "Xname": "x3000c0w60",
+        "Type": "comptype_mgmt_switch",
+        "Class": "River",
+        "TypeString": "MgmtSwitch",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "sw-leaf-bmc-001"
+          ],
+          "Brand": "Aruba",
+          "IP4addr": "10.254.0.4",
+          "SNMPAuthPassword": "vault://hms-creds/x3000c0w60",
+          "SNMPAuthProtocol": "MD5",
+          "SNMPPrivPassword": "vault://hms-creds/x3000c0w60",
+          "SNMPPrivProtocol": "DES",
+          "SNMPUsername": "testuser"
+        }
+      },
+      "x3000c0w60j1": {
+        "Parent": "x3000c0w60",
+        "Xname": "x3000c0w60j1",
+        "Type": "comptype_mgmt_switch_connector",
+        "Class": "River",
+        "TypeString": "MgmtSwitchConnector",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "NodeNics": [
+            "x3000c0s43b0"
+          ],
+          "VendorName": "1/1/1"
+        }
+      },
+      "x3000c0w60j10": {
+        "Parent": "x3000c0w60",
+        "Xname": "x3000c0w60j10",
+        "Type": "comptype_mgmt_switch_connector",
+        "Class": "River",
+        "TypeString": "MgmtSwitchConnector",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "NodeNics": [
+            "x3000c0s2b0"
+          ],
+          "VendorName": "1/1/10"
+        }
+      },
+      "x3000c0w60j11": {
+        "Parent": "x3000c0w60",
+        "Xname": "x3000c0w60j11",
+        "Type": "comptype_mgmt_switch_connector",
+        "Class": "River",
+        "TypeString": "MgmtSwitchConnector",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "NodeNics": [
+            "x3000c0s3b0"
+          ],
+          "VendorName": "1/1/11"
+        }
+      },
+      "x3000c0w60j2": {
+        "Parent": "x3000c0w60",
+        "Xname": "x3000c0w60j2",
+        "Type": "comptype_mgmt_switch_connector",
+        "Class": "River",
+        "TypeString": "MgmtSwitchConnector",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "NodeNics": [
+            "x3000c0s51b0"
+          ],
+          "VendorName": "1/1/2"
+        }
+      },
+      "x3000c0w60j3": {
+        "Parent": "x3000c0w60",
+        "Xname": "x3000c0w60j3",
+        "Type": "comptype_mgmt_switch_connector",
+        "Class": "River",
+        "TypeString": "MgmtSwitchConnector",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "NodeNics": [
+            "x3000c0s29b0"
+          ],
+          "VendorName": "1/1/3"
+        }
+      },
+      "x3000c0w60j4": {
+        "Parent": "x3000c0w60",
+        "Xname": "x3000c0w60j4",
+        "Type": "comptype_mgmt_switch_connector",
+        "Class": "River",
+        "TypeString": "MgmtSwitchConnector",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "NodeNics": [
+            "x3000c0s30b0"
+          ],
+          "VendorName": "1/1/4"
+        }
+      },
+      "x3000c0w60j5": {
+        "Parent": "x3000c0w60",
+        "Xname": "x3000c0w60j5",
+        "Type": "comptype_mgmt_switch_connector",
+        "Class": "River",
+        "TypeString": "MgmtSwitchConnector",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "NodeNics": [
+            "x3000c0s31b0"
+          ],
+          "VendorName": "1/1/5"
+        }
+      },
+      "x3000c0w60j6": {
+        "Parent": "x3000c0w60",
+        "Xname": "x3000c0w60j6",
+        "Type": "comptype_mgmt_switch_connector",
+        "Class": "River",
+        "TypeString": "MgmtSwitchConnector",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "NodeNics": [
+            "x3000c0s15b0"
+          ],
+          "VendorName": "1/1/6"
+        }
+      },
+      "x3000c0w60j7": {
+        "Parent": "x3000c0w60",
+        "Xname": "x3000c0w60j7",
+        "Type": "comptype_mgmt_switch_connector",
+        "Class": "River",
+        "TypeString": "MgmtSwitchConnector",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "NodeNics": [
+            "x3000c0s16b0"
+          ],
+          "VendorName": "1/1/7"
+        }
+      },
+      "x3000c0w60j8": {
+        "Parent": "x3000c0w60",
+        "Xname": "x3000c0w60j8",
+        "Type": "comptype_mgmt_switch_connector",
+        "Class": "River",
+        "TypeString": "MgmtSwitchConnector",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "NodeNics": [
+            "x3000c0s17b0"
+          ],
+          "VendorName": "1/1/8"
+        }
+      },
+      "x3000c0w60j9": {
+        "Parent": "x3000c0w60",
+        "Xname": "x3000c0w60j9",
+        "Type": "comptype_mgmt_switch_connector",
+        "Class": "River",
+        "TypeString": "MgmtSwitchConnector",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.28954 +0000 +0000",
+        "ExtraProperties": {
+          "NodeNics": [
+            "x3000c0s1b0"
+          ],
+          "VendorName": "1/1/9"
+        }
+      }
+    },
+    "Networks": {
+      "BICAN": {
+        "Name": "BICAN",
+        "FullName": "SystemDefaultRoute points the network name of the default route",
+        "IPRanges": [
+          "0.0.0.0/0"
+        ],
+        "Type": "ethernet",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.541573 +0000 +0000",
+        "ExtraProperties": {
+          "CIDR": "0.0.0.0/0",
+          "MTU": 9000,
+          "Subnets": [],
+          "SystemDefaultRoute": "CAN",
+          "VlanRange": [
+            0
+          ]
+        }
+      },
+      "CAN": {
+        "Name": "CAN",
+        "FullName": "Customer Access Network",
+        "IPRanges": [
+          "10.103.5.128/26"
+        ],
+        "Type": "ethernet",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.541573 +0000 +0000",
+        "ExtraProperties": {
+          "CIDR": "10.103.5.128/26",
+          "MTU": 9000,
+          "Subnets": [
+            {
+              "CIDR": "10.103.5.160/27",
+              "FullName": "CAN Dynamic MetalLB",
+              "Gateway": "10.103.5.161",
+              "MetalLBPoolName": "customer-access",
+              "Name": "can_metallb_address_pool",
+              "VlanID": 6
+            },
+            {
+              "CIDR": "10.103.5.128/26",
+              "DHCPEnd": "10.103.5.159",
+              "DHCPStart": "10.103.5.143",
+              "FullName": "CAN Bootstrap DHCP Subnet",
+              "Gateway": "10.103.5.129",
+              "IPReservations": [
+                {
+                  "IPAddress": "10.103.5.130",
+                  "Name": "can-switch-1"
+                },
+                {
+                  "IPAddress": "10.103.5.131",
+                  "Name": "can-switch-2"
+                },
+                {
+                  "Comment": "k8s-virtual-ip",
+                  "IPAddress": "10.103.5.132",
+                  "Name": "kubeapi-vip"
+                },
+                {
+                  "Aliases": [
+                    "ncn-s001-can",
+                    "time-can",
+                    "time-can.local"
+                  ],
+                  "Comment": "x3000c0s29b0n0",
+                  "IPAddress": "10.103.5.133",
+                  "Name": "ncn-s001"
+                },
+                {
+                  "Aliases": [
+                    "ncn-s002-can",
+                    "time-can",
+                    "time-can.local"
+                  ],
+                  "Comment": "x3000c0s30b0n0",
+                  "IPAddress": "10.103.5.134",
+                  "Name": "ncn-s002"
+                },
+                {
+                  "Aliases": [
+                    "ncn-s003-can",
+                    "time-can",
+                    "time-can.local"
+                  ],
+                  "Comment": "x3000c0s31b0n0",
+                  "IPAddress": "10.103.5.135",
+                  "Name": "ncn-s003"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w001-can",
+                    "time-can",
+                    "time-can.local"
+                  ],
+                  "Comment": "x3000c0s15b0n0",
+                  "IPAddress": "10.103.5.136",
+                  "Name": "ncn-w001"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w002-can",
+                    "time-can",
+                    "time-can.local"
+                  ],
+                  "Comment": "x3000c0s16b0n0",
+                  "IPAddress": "10.103.5.137",
+                  "Name": "ncn-w002"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w003-can",
+                    "time-can",
+                    "time-can.local"
+                  ],
+                  "Comment": "x3000c0s17b0n0",
+                  "IPAddress": "10.103.5.138",
+                  "Name": "ncn-w003"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m001-can",
+                    "time-can",
+                    "time-can.local"
+                  ],
+                  "Comment": "x3000c0s1b0n0",
+                  "IPAddress": "10.103.5.139",
+                  "Name": "ncn-m001"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m002-can",
+                    "time-can",
+                    "time-can.local"
+                  ],
+                  "Comment": "x3000c0s2b0n0",
+                  "IPAddress": "10.103.5.140",
+                  "Name": "ncn-m002"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m003-can",
+                    "time-can",
+                    "time-can.local"
+                  ],
+                  "Comment": "x3000c0s3b0n0",
+                  "IPAddress": "10.103.5.141",
+                  "Name": "ncn-m003"
+                },
+                {
+                  "Comment": "x3000c0s43b0n0",
+                  "IPAddress": "10.103.5.142",
+                  "Name": "uan01"
+                }
+              ],
+              "Name": "bootstrap_dhcp",
+              "VlanID": 6
+            }
+          ],
+          "VlanRange": [
+            6
+          ]
+        }
+      },
+      "CMN": {
+        "Name": "CMN",
+        "FullName": "Customer Management Network",
+        "IPRanges": [
+          "10.103.5.0/25"
+        ],
+        "Type": "ethernet",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.541573 +0000 +0000",
+        "ExtraProperties": {
+          "CIDR": "10.103.5.0/25",
+          "MTU": 9000,
+          "MyASN": 65532,
+          "PeerASN": 65533,
+          "Subnets": [
+            {
+              "CIDR": "10.103.5.60/30",
+              "FullName": "CMN Static Pool MetalLB",
+              "Gateway": "10.103.5.61",
+              "IPReservations": [
+                {
+                  "Comment": "site to system lookups",
+                  "IPAddress": "10.103.5.61",
+                  "Name": "external-dns"
+                }
+              ],
+              "MetalLBPoolName": "customer-management-static",
+              "Name": "cmn_metallb_static_pool",
+              "VlanID": 7
+            },
+            {
+              "CIDR": "10.103.5.64/26",
+              "FullName": "CMN Dynamic MetalLB",
+              "Gateway": "10.103.5.65",
+              "MetalLBPoolName": "customer-management",
+              "Name": "cmn_metallb_address_pool",
+              "VlanID": 7
+            },
+            {
+              "CIDR": "10.103.5.0/25",
+              "FullName": "CMN Management Network Infrastructure",
+              "Gateway": "10.103.5.1",
+              "IPReservations": [
+                {
+                  "Comment": "x3000c0h61s1",
+                  "IPAddress": "10.103.5.2",
+                  "Name": "sw-spine-001"
+                },
+                {
+                  "Comment": "x3000c0h62s1",
+                  "IPAddress": "10.103.5.3",
+                  "Name": "sw-spine-002"
+                },
+                {
+                  "Comment": "x3000c0w60",
+                  "IPAddress": "10.103.5.4",
+                  "Name": "sw-leaf-bmc-001"
+                }
+              ],
+              "Name": "network_hardware",
+              "VlanID": 7
+            },
+            {
+              "CIDR": "10.103.5.16/25",
+              "DHCPEnd": "10.103.5.59",
+              "DHCPStart": "10.103.5.28",
+              "FullName": "CMN Bootstrap DHCP Subnet",
+              "Gateway": "10.103.5.1",
+              "IPReservations": [
+                {
+                  "Comment": "k8s-virtual-ip",
+                  "IPAddress": "10.103.5.18",
+                  "Name": "kubeapi-vip"
+                },
+                {
+                  "Aliases": [
+                    "ncn-s001-cmn",
+                    "time-cmn",
+                    "time-cmn.local"
+                  ],
+                  "Comment": "x3000c0s29b0n0",
+                  "IPAddress": "10.103.5.19",
+                  "Name": "ncn-s001"
+                },
+                {
+                  "Aliases": [
+                    "ncn-s002-cmn",
+                    "time-cmn",
+                    "time-cmn.local"
+                  ],
+                  "Comment": "x3000c0s30b0n0",
+                  "IPAddress": "10.103.5.20",
+                  "Name": "ncn-s002"
+                },
+                {
+                  "Aliases": [
+                    "ncn-s003-cmn",
+                    "time-cmn",
+                    "time-cmn.local"
+                  ],
+                  "Comment": "x3000c0s31b0n0",
+                  "IPAddress": "10.103.5.21",
+                  "Name": "ncn-s003"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w001-cmn",
+                    "time-cmn",
+                    "time-cmn.local"
+                  ],
+                  "Comment": "x3000c0s15b0n0",
+                  "IPAddress": "10.103.5.22",
+                  "Name": "ncn-w001"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w002-cmn",
+                    "time-cmn",
+                    "time-cmn.local"
+                  ],
+                  "Comment": "x3000c0s16b0n0",
+                  "IPAddress": "10.103.5.23",
+                  "Name": "ncn-w002"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w003-cmn",
+                    "time-cmn",
+                    "time-cmn.local"
+                  ],
+                  "Comment": "x3000c0s17b0n0",
+                  "IPAddress": "10.103.5.24",
+                  "Name": "ncn-w003"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m001-cmn",
+                    "time-cmn",
+                    "time-cmn.local"
+                  ],
+                  "Comment": "x3000c0s1b0n0",
+                  "IPAddress": "10.103.5.25",
+                  "Name": "ncn-m001"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m002-cmn",
+                    "time-cmn",
+                    "time-cmn.local"
+                  ],
+                  "Comment": "x3000c0s2b0n0",
+                  "IPAddress": "10.103.5.26",
+                  "Name": "ncn-m002"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m003-cmn",
+                    "time-cmn",
+                    "time-cmn.local"
+                  ],
+                  "Comment": "x3000c0s3b0n0",
+                  "IPAddress": "10.103.5.27",
+                  "Name": "ncn-m003"
+                }
+              ],
+              "Name": "bootstrap_dhcp",
+              "VlanID": 7
+            }
+          ],
+          "VlanRange": [
+            7
+          ]
+        }
+      },
+      "HMN": {
+        "Name": "HMN",
+        "FullName": "Hardware Management Network",
+        "IPRanges": [
+          "10.254.0.0/17"
+        ],
+        "Type": "ethernet",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.541573 +0000 +0000",
+        "ExtraProperties": {
+          "CIDR": "10.254.0.0/17",
+          "MTU": 9000,
+          "Subnets": [
+            {
+              "CIDR": "10.254.0.0/17",
+              "FullName": "HMN Management Network Infrastructure",
+              "Gateway": "10.254.0.1",
+              "IPReservations": [
+                {
+                  "Comment": "x3000c0h61s1",
+                  "IPAddress": "10.254.0.2",
+                  "Name": "sw-spine-001"
+                },
+                {
+                  "Comment": "x3000c0h62s1",
+                  "IPAddress": "10.254.0.3",
+                  "Name": "sw-spine-002"
+                },
+                {
+                  "Comment": "x3000c0w60",
+                  "IPAddress": "10.254.0.4",
+                  "Name": "sw-leaf-bmc-001"
+                }
+              ],
+              "Name": "network_hardware",
+              "VlanID": 4
+            },
+            {
+              "CIDR": "10.254.1.0/17",
+              "DHCPEnd": "10.254.1.221",
+              "DHCPStart": "10.254.1.21",
+              "FullName": "HMN Bootstrap DHCP Subnet",
+              "Gateway": "10.254.0.1",
+              "IPReservations": [
+                {
+                  "Comment": "k8s-virtual-ip",
+                  "IPAddress": "10.254.1.2",
+                  "Name": "kubeapi-vip"
+                },
+                {
+                  "Aliases": [
+                    "ncn-s001-mgmt"
+                  ],
+                  "Comment": "x3000c0s29b0",
+                  "IPAddress": "10.254.1.3",
+                  "Name": "x3000c0s29b0"
+                },
+                {
+                  "Aliases": [
+                    "ncn-s001-hmn",
+                    "time-hmn",
+                    "time-hmn.local",
+                    "rgw-vip.hmn"
+                  ],
+                  "Comment": "x3000c0s29b0n0",
+                  "IPAddress": "10.254.1.4",
+                  "Name": "ncn-s001"
+                },
+                {
+                  "Aliases": [
+                    "ncn-s002-mgmt"
+                  ],
+                  "Comment": "x3000c0s30b0",
+                  "IPAddress": "10.254.1.5",
+                  "Name": "x3000c0s30b0"
+                },
+                {
+                  "Aliases": [
+                    "ncn-s002-hmn",
+                    "time-hmn",
+                    "time-hmn.local",
+                    "rgw-vip.hmn"
+                  ],
+                  "Comment": "x3000c0s30b0n0",
+                  "IPAddress": "10.254.1.6",
+                  "Name": "ncn-s002"
+                },
+                {
+                  "Aliases": [
+                    "ncn-s003-mgmt"
+                  ],
+                  "Comment": "x3000c0s31b0",
+                  "IPAddress": "10.254.1.7",
+                  "Name": "x3000c0s31b0"
+                },
+                {
+                  "Aliases": [
+                    "ncn-s003-hmn",
+                    "time-hmn",
+                    "time-hmn.local",
+                    "rgw-vip.hmn"
+                  ],
+                  "Comment": "x3000c0s31b0n0",
+                  "IPAddress": "10.254.1.8",
+                  "Name": "ncn-s003"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w001-mgmt"
+                  ],
+                  "Comment": "x3000c0s15b0",
+                  "IPAddress": "10.254.1.9",
+                  "Name": "x3000c0s15b0"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w001-hmn",
+                    "time-hmn",
+                    "time-hmn.local"
+                  ],
+                  "Comment": "x3000c0s15b0n0",
+                  "IPAddress": "10.254.1.10",
+                  "Name": "ncn-w001"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w002-mgmt"
+                  ],
+                  "Comment": "x3000c0s16b0",
+                  "IPAddress": "10.254.1.11",
+                  "Name": "x3000c0s16b0"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w002-hmn",
+                    "time-hmn",
+                    "time-hmn.local"
+                  ],
+                  "Comment": "x3000c0s16b0n0",
+                  "IPAddress": "10.254.1.12",
+                  "Name": "ncn-w002"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w003-mgmt"
+                  ],
+                  "Comment": "x3000c0s17b0",
+                  "IPAddress": "10.254.1.13",
+                  "Name": "x3000c0s17b0"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w003-hmn",
+                    "time-hmn",
+                    "time-hmn.local"
+                  ],
+                  "Comment": "x3000c0s17b0n0",
+                  "IPAddress": "10.254.1.14",
+                  "Name": "ncn-w003"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m001-mgmt"
+                  ],
+                  "Comment": "x3000c0s1b0",
+                  "IPAddress": "10.254.1.15",
+                  "Name": "x3000c0s1b0"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m001-hmn",
+                    "time-hmn",
+                    "time-hmn.local"
+                  ],
+                  "Comment": "x3000c0s1b0n0",
+                  "IPAddress": "10.254.1.16",
+                  "Name": "ncn-m001"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m002-mgmt"
+                  ],
+                  "Comment": "x3000c0s2b0",
+                  "IPAddress": "10.254.1.17",
+                  "Name": "x3000c0s2b0"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m002-hmn",
+                    "time-hmn",
+                    "time-hmn.local"
+                  ],
+                  "Comment": "x3000c0s2b0n0",
+                  "IPAddress": "10.254.1.18",
+                  "Name": "ncn-m002"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m003-mgmt"
+                  ],
+                  "Comment": "x3000c0s3b0",
+                  "IPAddress": "10.254.1.19",
+                  "Name": "x3000c0s3b0"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m003-hmn",
+                    "time-hmn",
+                    "time-hmn.local"
+                  ],
+                  "Comment": "x3000c0s3b0n0",
+                  "IPAddress": "10.254.1.20",
+                  "Name": "ncn-m003"
+                }
+              ],
+              "Name": "bootstrap_dhcp",
+              "VlanID": 4
+            }
+          ],
+          "VlanRange": [
+            4
+          ]
+        }
+      },
+      "HMNLB": {
+        "Name": "HMNLB",
+        "FullName": "Hardware Management Network LoadBalancers",
+        "IPRanges": [
+          "10.94.100.0/24"
+        ],
+        "Type": "ethernet",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.541573 +0000 +0000",
+        "ExtraProperties": {
+          "CIDR": "10.94.100.0/24",
+          "MTU": 9000,
+          "Subnets": [
+            {
+              "CIDR": "10.94.100.0/24",
+              "FullName": "HMN MetalLB",
+              "Gateway": "10.94.100.1",
+              "IPReservations": [
+                {
+                  "IPAddress": "10.94.100.71",
+                  "Name": "istio-ingressgateway"
+                },
+                {
+                  "Aliases": [
+                    "rsyslog-agg-service"
+                  ],
+                  "Comment": "rsyslog-agg-service",
+                  "IPAddress": "10.94.100.72",
+                  "Name": "rsyslog-aggregator"
+                },
+                {
+                  "Aliases": [
+                    "tftp-service"
+                  ],
+                  "Comment": "tftp-service",
+                  "IPAddress": "10.94.100.60",
+                  "Name": "cray-tftp"
+                },
+                {
+                  "Aliases": [
+                    "unbound"
+                  ],
+                  "Comment": "unbound",
+                  "IPAddress": "10.94.100.225",
+                  "Name": "unbound"
+                },
+                {
+                  "Aliases": [
+                    "docker_registry_service"
+                  ],
+                  "Comment": "docker_registry_service",
+                  "IPAddress": "10.94.100.73",
+                  "Name": "docker-registry"
+                }
+              ],
+              "MetalLBPoolName": "hardware-management",
+              "Name": "hmn_metallb_address_pool",
+              "VlanID": 4
+            }
+          ],
+          "VlanRange": null
+        }
+      },
+      "HMN_MTN": {
+        "Name": "HMN_MTN",
+        "FullName": "Mountain Compute Hardware Management Network",
+        "IPRanges": [
+          "10.104.0.0/17"
+        ],
+        "Type": "ethernet",
+        "LastUpdated": 1686885971,
+        "LastUpdatedTime": "2023-06-16 03:26:11.054111 +0000 +0000",
+        "ExtraProperties": {
+          "CIDR": "10.104.0.0/17",
+          "MTU": 9000,
+          "Subnets": [
+            {
+              "CIDR": "10.104.0.0/22",
+              "DHCPEnd": "10.104.3.254",
+              "DHCPStart": "10.104.0.10",
+              "FullName": "",
+              "Gateway": "10.104.0.1",
+              "Name": "cabinet_1000",
+              "VlanID": 3000
+            }
+          ],
+          "VlanRange": [
+            4094,
+            0
+          ]
+        }
+      },
+      "HMN_RVR": {
+        "Name": "HMN_RVR",
+        "FullName": "River Compute Hardware Management Network",
+        "IPRanges": [
+          "10.107.0.0/17"
+        ],
+        "Type": "ethernet",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.541573 +0000 +0000",
+        "ExtraProperties": {
+          "CIDR": "10.107.0.0/17",
+          "MTU": 9000,
+          "Subnets": [
+            {
+              "CIDR": "10.107.0.0/22",
+              "DHCPEnd": "10.107.3.254",
+              "DHCPStart": "10.107.0.10",
+              "FullName": "",
+              "Gateway": "10.107.0.1",
+              "Name": "cabinet_3000",
+              "VlanID": 1513
+            }
+          ],
+          "VlanRange": [
+            1513,
+            1513
+          ]
+        }
+      },
+      "HSN": {
+        "Name": "HSN",
+        "FullName": "High Speed Network",
+        "IPRanges": [
+          "10.253.0.0/16"
+        ],
+        "Type": "slingshot10",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.541573 +0000 +0000",
+        "ExtraProperties": {
+          "CIDR": "10.253.0.0/16",
+          "MTU": 9000,
+          "Subnets": [
+            {
+              "CIDR": "10.253.0.0/16",
+              "FullName": "HSN Base Subnet",
+              "Gateway": "10.253.0.1",
+              "Name": "hsn_base_subnet",
+              "VlanID": 613
+            }
+          ],
+          "VlanRange": [
+            613,
+            868
+          ]
+        }
+      },
+      "MTL": {
+        "Name": "MTL",
+        "FullName": "Provisioning Network (untagged)",
+        "IPRanges": [
+          "10.1.1.0/16"
+        ],
+        "Type": "ethernet",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.541573 +0000 +0000",
+        "ExtraProperties": {
+          "CIDR": "10.1.1.0/16",
+          "Comment": "This network is only valid for the NCNs",
+          "MTU": 9000,
+          "Subnets": [
+            {
+              "CIDR": "10.1.0.0/16",
+              "FullName": "MTL Management Network Infrastructure",
+              "Gateway": "10.1.0.1",
+              "IPReservations": [
+                {
+                  "Comment": "x3000c0h61s1",
+                  "IPAddress": "10.1.0.2",
+                  "Name": "sw-spine-001"
+                },
+                {
+                  "Comment": "x3000c0h62s1",
+                  "IPAddress": "10.1.0.3",
+                  "Name": "sw-spine-002"
+                },
+                {
+                  "Comment": "x3000c0w60",
+                  "IPAddress": "10.1.0.4",
+                  "Name": "sw-leaf-bmc-001"
+                }
+              ],
+              "Name": "network_hardware",
+              "VlanID": 0
+            },
+            {
+              "CIDR": "10.1.1.0/16",
+              "DHCPEnd": "10.1.1.211",
+              "DHCPStart": "10.1.1.11",
+              "FullName": "MTL Bootstrap DHCP Subnet",
+              "Gateway": "10.1.0.1",
+              "IPReservations": [
+                {
+                  "Aliases": [
+                    "ncn-s001-mtl",
+                    "time-mtl",
+                    "time-mtl.local"
+                  ],
+                  "Comment": "x3000c0s29b0n0",
+                  "IPAddress": "10.1.1.2",
+                  "Name": "ncn-s001"
+                },
+                {
+                  "Aliases": [
+                    "ncn-s002-mtl",
+                    "time-mtl",
+                    "time-mtl.local"
+                  ],
+                  "Comment": "x3000c0s30b0n0",
+                  "IPAddress": "10.1.1.3",
+                  "Name": "ncn-s002"
+                },
+                {
+                  "Aliases": [
+                    "ncn-s003-mtl",
+                    "time-mtl",
+                    "time-mtl.local"
+                  ],
+                  "Comment": "x3000c0s31b0n0",
+                  "IPAddress": "10.1.1.4",
+                  "Name": "ncn-s003"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w001-mtl",
+                    "time-mtl",
+                    "time-mtl.local"
+                  ],
+                  "Comment": "x3000c0s15b0n0",
+                  "IPAddress": "10.1.1.5",
+                  "Name": "ncn-w001"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w002-mtl",
+                    "time-mtl",
+                    "time-mtl.local"
+                  ],
+                  "Comment": "x3000c0s16b0n0",
+                  "IPAddress": "10.1.1.6",
+                  "Name": "ncn-w002"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w003-mtl",
+                    "time-mtl",
+                    "time-mtl.local"
+                  ],
+                  "Comment": "x3000c0s17b0n0",
+                  "IPAddress": "10.1.1.7",
+                  "Name": "ncn-w003"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m001-mtl",
+                    "time-mtl",
+                    "time-mtl.local"
+                  ],
+                  "Comment": "x3000c0s1b0n0",
+                  "IPAddress": "10.1.1.8",
+                  "Name": "ncn-m001"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m002-mtl",
+                    "time-mtl",
+                    "time-mtl.local"
+                  ],
+                  "Comment": "x3000c0s2b0n0",
+                  "IPAddress": "10.1.1.9",
+                  "Name": "ncn-m002"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m003-mtl",
+                    "time-mtl",
+                    "time-mtl.local"
+                  ],
+                  "Comment": "x3000c0s3b0n0",
+                  "IPAddress": "10.1.1.10",
+                  "Name": "ncn-m003"
+                }
+              ],
+              "Name": "bootstrap_dhcp",
+              "VlanID": 0
+            }
+          ],
+          "VlanRange": [
+            0
+          ]
+        }
+      },
+      "NMN": {
+        "Name": "NMN",
+        "FullName": "Node Management Network",
+        "IPRanges": [
+          "10.252.0.0/17"
+        ],
+        "Type": "ethernet",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.541573 +0000 +0000",
+        "ExtraProperties": {
+          "CIDR": "10.252.0.0/17",
+          "MTU": 9000,
+          "MyASN": 65531,
+          "PeerASN": 65533,
+          "Subnets": [
+            {
+              "CIDR": "10.252.0.0/17",
+              "FullName": "NMN Management Network Infrastructure",
+              "Gateway": "10.252.0.1",
+              "IPReservations": [
+                {
+                  "Comment": "x3000c0h61s1",
+                  "IPAddress": "10.252.0.2",
+                  "Name": "sw-spine-001"
+                },
+                {
+                  "Comment": "x3000c0h62s1",
+                  "IPAddress": "10.252.0.3",
+                  "Name": "sw-spine-002"
+                },
+                {
+                  "Comment": "x3000c0w60",
+                  "IPAddress": "10.252.0.4",
+                  "Name": "sw-leaf-bmc-001"
+                }
+              ],
+              "Name": "network_hardware",
+              "VlanID": 2
+            },
+            {
+              "CIDR": "10.252.1.0/17",
+              "DHCPEnd": "10.252.1.213",
+              "DHCPStart": "10.252.1.13",
+              "FullName": "NMN Bootstrap DHCP Subnet",
+              "Gateway": "10.252.0.1",
+              "IPReservations": [
+                {
+                  "Aliases": [
+                    "kubeapi-vip.local"
+                  ],
+                  "Comment": "k8s-virtual-ip",
+                  "IPAddress": "10.252.1.2",
+                  "Name": "kubeapi-vip"
+                },
+                {
+                  "Aliases": [
+                    "rgw-vip.local"
+                  ],
+                  "Comment": "rgw-virtual-ip",
+                  "IPAddress": "10.252.1.3",
+                  "Name": "rgw-vip"
+                },
+                {
+                  "Aliases": [
+                    "ncn-s001-nmn",
+                    "time-nmn",
+                    "time-nmn.local",
+                    "x3000c0s29b0n0",
+                    "ncn-s001.local"
+                  ],
+                  "Comment": "x3000c0s29b0n0",
+                  "IPAddress": "10.252.1.4",
+                  "Name": "ncn-s001"
+                },
+                {
+                  "Aliases": [
+                    "ncn-s002-nmn",
+                    "time-nmn",
+                    "time-nmn.local",
+                    "x3000c0s30b0n0",
+                    "ncn-s002.local"
+                  ],
+                  "Comment": "x3000c0s30b0n0",
+                  "IPAddress": "10.252.1.5",
+                  "Name": "ncn-s002"
+                },
+                {
+                  "Aliases": [
+                    "ncn-s003-nmn",
+                    "time-nmn",
+                    "time-nmn.local",
+                    "x3000c0s31b0n0",
+                    "ncn-s003.local"
+                  ],
+                  "Comment": "x3000c0s31b0n0",
+                  "IPAddress": "10.252.1.6",
+                  "Name": "ncn-s003"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w001-nmn",
+                    "time-nmn",
+                    "time-nmn.local",
+                    "x3000c0s15b0n0",
+                    "ncn-w001.local"
+                  ],
+                  "Comment": "x3000c0s15b0n0",
+                  "IPAddress": "10.252.1.7",
+                  "Name": "ncn-w001"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w002-nmn",
+                    "time-nmn",
+                    "time-nmn.local",
+                    "x3000c0s16b0n0",
+                    "ncn-w002.local"
+                  ],
+                  "Comment": "x3000c0s16b0n0",
+                  "IPAddress": "10.252.1.8",
+                  "Name": "ncn-w002"
+                },
+                {
+                  "Aliases": [
+                    "ncn-w003-nmn",
+                    "time-nmn",
+                    "time-nmn.local",
+                    "x3000c0s17b0n0",
+                    "ncn-w003.local"
+                  ],
+                  "Comment": "x3000c0s17b0n0",
+                  "IPAddress": "10.252.1.9",
+                  "Name": "ncn-w003"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m001-nmn",
+                    "time-nmn",
+                    "time-nmn.local",
+                    "x3000c0s1b0n0",
+                    "ncn-m001.local"
+                  ],
+                  "Comment": "x3000c0s1b0n0",
+                  "IPAddress": "10.252.1.10",
+                  "Name": "ncn-m001"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m002-nmn",
+                    "time-nmn",
+                    "time-nmn.local",
+                    "x3000c0s2b0n0",
+                    "ncn-m002.local"
+                  ],
+                  "Comment": "x3000c0s2b0n0",
+                  "IPAddress": "10.252.1.11",
+                  "Name": "ncn-m002"
+                },
+                {
+                  "Aliases": [
+                    "ncn-m003-nmn",
+                    "time-nmn",
+                    "time-nmn.local",
+                    "x3000c0s3b0n0",
+                    "ncn-m003.local"
+                  ],
+                  "Comment": "x3000c0s3b0n0",
+                  "IPAddress": "10.252.1.12",
+                  "Name": "ncn-m003"
+                }
+              ],
+              "Name": "bootstrap_dhcp",
+              "VlanID": 2
+            },
+            {
+              "CIDR": "10.252.2.0/23",
+              "FullName": "NMN UAIs",
+              "Gateway": "10.252.0.1",
+              "IPReservations": [
+                {
+                  "Aliases": [
+                    "pbs-comm-service",
+                    "pbs-comm-service-nmn",
+                    "pbs_comm_service.local"
+                  ],
+                  "Comment": "pbs-comm-service,pbs-comm-service-nmn",
+                  "IPAddress": "10.252.2.2",
+                  "Name": "pbs_comm_service"
+                },
+                {
+                  "Aliases": [
+                    "pbs-service",
+                    "pbs-service-nmn",
+                    "pbs_service.local"
+                  ],
+                  "Comment": "pbs-service,pbs-service-nmn",
+                  "IPAddress": "10.252.2.3",
+                  "Name": "pbs_service"
+                },
+                {
+                  "Aliases": [
+                    "slurmctld-service",
+                    "slurmctld-service-nmn",
+                    "slurmctld_service.local"
+                  ],
+                  "Comment": "slurmctld-service,slurmctld-service-nmn",
+                  "IPAddress": "10.252.2.4",
+                  "Name": "slurmctld_service"
+                },
+                {
+                  "Aliases": [
+                    "slurmdbd-service",
+                    "slurmdbd-service-nmn",
+                    "slurmdbd_service.local"
+                  ],
+                  "Comment": "slurmdbd-service,slurmdbd-service-nmn",
+                  "IPAddress": "10.252.2.5",
+                  "Name": "slurmdbd_service"
+                },
+                {
+                  "Aliases": [
+                    "uai-nmn-blackhole",
+                    "uai_nmn_blackhole.local"
+                  ],
+                  "Comment": "uai-nmn-blackhole",
+                  "IPAddress": "10.252.2.6",
+                  "Name": "uai_nmn_blackhole"
+                }
+              ],
+              "Name": "uai_macvlan",
+              "ReservationEnd": "10.252.3.254",
+              "ReservationStart": "10.252.2.10",
+              "VlanID": 2
+            }
+          ],
+          "VlanRange": [
+            2
+          ]
+        }
+      },
+      "NMNLB": {
+        "Name": "NMNLB",
+        "FullName": "Node Management Network LoadBalancers",
+        "IPRanges": [
+          "10.92.100.0/24"
+        ],
+        "Type": "ethernet",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.541573 +0000 +0000",
+        "ExtraProperties": {
+          "CIDR": "10.92.100.0/24",
+          "MTU": 9000,
+          "Subnets": [
+            {
+              "CIDR": "10.92.100.0/24",
+              "FullName": "NMN MetalLB",
+              "Gateway": "10.92.100.1",
+              "IPReservations": [
+                {
+                  "Aliases": [
+                    "unbound"
+                  ],
+                  "Comment": "unbound",
+                  "IPAddress": "10.92.100.225",
+                  "Name": "unbound"
+                },
+                {
+                  "Aliases": [
+                    "docker_registry_service"
+                  ],
+                  "Comment": "docker_registry_service",
+                  "IPAddress": "10.92.100.73",
+                  "Name": "docker-registry"
+                },
+                {
+                  "Aliases": [
+                    "api-gw-service",
+                    "api-gw-service-nmn.local",
+                    "packages",
+                    "registry",
+                    "spire.local",
+                    "api_gw_service",
+                    "registry.local",
+                    "packages",
+                    "packages.local",
+                    "spire"
+                  ],
+                  "Comment": "api-gw-service,api-gw-service-nmn.local,packages,registry,spire.local,api_gw_service,registry.local,packages,packages.local,spire",
+                  "IPAddress": "10.92.100.71",
+                  "Name": "istio-ingressgateway"
+                },
+                {
+                  "Aliases": [
+                    "api-gw-service.local"
+                  ],
+                  "Comment": "api-gw-service.local",
+                  "IPAddress": "10.92.100.81",
+                  "Name": "istio-ingressgateway-local"
+                },
+                {
+                  "Aliases": [
+                    "rsyslog-agg-service"
+                  ],
+                  "Comment": "rsyslog-agg-service",
+                  "IPAddress": "10.92.100.72",
+                  "Name": "rsyslog-aggregator"
+                },
+                {
+                  "Aliases": [
+                    "tftp-service"
+                  ],
+                  "Comment": "tftp-service",
+                  "IPAddress": "10.92.100.60",
+                  "Name": "cray-tftp"
+                }
+              ],
+              "MetalLBPoolName": "node-management",
+              "Name": "nmn_metallb_address_pool",
+              "VlanID": 2
+            }
+          ],
+          "VlanRange": null
+        }
+      },
+      "NMN_MTN": {
+        "Name": "NMN_MTN",
+        "FullName": "Mountain Compute Node Management Network",
+        "IPRanges": [
+          "10.100.0.0/17"
+        ],
+        "Type": "ethernet",
+        "LastUpdated": 1686885977,
+        "LastUpdatedTime": "2023-06-16 03:26:17.008229 +0000 +0000",
+        "ExtraProperties": {
+          "CIDR": "10.100.0.0/17",
+          "MTU": 9000,
+          "Subnets": [
+            {
+              "CIDR": "10.100.0.0/22",
+              "DHCPEnd": "10.100.3.254",
+              "DHCPStart": "10.100.0.10",
+              "FullName": "",
+              "Gateway": "10.100.0.1",
+              "Name": "cabinet_1000",
+              "VlanID": 2000
+            }
+          ],
+          "VlanRange": [
+            4094,
+            0
+          ]
+        }
+      },
+      "NMN_RVR": {
+        "Name": "NMN_RVR",
+        "FullName": "River Compute Node Management Network",
+        "IPRanges": [
+          "10.106.0.0/17"
+        ],
+        "Type": "ethernet",
+        "LastUpdated": 1686885929,
+        "LastUpdatedTime": "2023-06-16 03:25:29.541573 +0000 +0000",
+        "ExtraProperties": {
+          "CIDR": "10.106.0.0/17",
+          "MTU": 9000,
+          "Subnets": [
+            {
+              "CIDR": "10.106.0.0/22",
+              "DHCPEnd": "10.106.3.254",
+              "DHCPStart": "10.106.0.10",
+              "FullName": "",
+              "Gateway": "10.106.0.1",
+              "Name": "cabinet_3000",
+              "VlanID": 1770
+            }
+          ],
+          "VlanRange": [
+            1770,
+            1770
+          ]
+        }
+      }
+    }
+  }


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- warns of schema mistmatch when importing during a session


# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Shows a warning when the schema version defined in the cani datastore does not match that of a piece of hardware being imported (I arbitrarily changed the cani schema version for this test)

```
go run main.go alpha session import                                                                                                                                                                                                                                                               11:24
11:24AM INF Session is STOPPED
11:24AM INF Committing changes to session
2023/07/05 11:24:57 [DEBUG] GET https://localhost:8443/apis/sls/v1/dumpstate
2023/07/05 11:24:57 [DEBUG] GET https://localhost:8443/apis/smd/hsm/v2/State/Components
2023/07/05 11:24:57 [DEBUG] GET https://localhost:8443/apis/smd/hsm/v2/Inventory/Hardware
11:24AM INF Cabinet x1000 (System:0->Cabinet:1000) exists in datastore with ID (fa7be1c0-7bbc-4578-9d1b-41ad7d5e2f0b)
11:24AM WRN Schema mismatch: expected v1beta1 but found v1alpha1 for SLS Cabinet x1000 (fa7be1c0-7bbc-4578-9d1b-41ad7d5e2f0b)
11:24AM WRN Schema mismatch: expected v1beta1 but found v1alpha1 for SLS Chassis x1000c4 (ef3c9029-d1e5-4c61-bffa-e4fceb828d39)
11:24AM WRN Schema mismatch: expected v1beta1 but found v1alpha1 for SLS Chassis x1000c7 (f46129d1-9183-471f-83fe-0c83de2f5d52)
11:24AM WRN Schema mismatch: expected v1beta1 but found v1alpha1 for SLS Chassis x1000c0 (a05b25dc-a009-40b3-a4f8-6bf3cd10c791)
11:24AM WRN Schema mismatch: expected v1beta1 but found v1alpha1 for SLS Chassis x1000c3 (8a924ebf-c80d-496f-9e8e-9c78a9dd511c)
11:24AM WRN Schema mismatch: expected v1beta1 but found v1alpha1 for SLS Chassis x1000c1 (6a8df08a-dd7e-469b-aa17-565832eb6df5)
11:24AM WRN Schema mismatch: expected v1beta1 but found v1alpha1 for SLS Chassis x1000c5 (4d649928-ed87-4e71-b3f2-2b4ddb9c9925)
11:24AM WRN Schema mismatch: expected v1beta1 but found v1alpha1 for SLS Chassis x1000c6 (b0fd9f78-b230-4ea5-ba3a-0b4931dd2c5d)
11:24AM WRN Schema mismatch: expected v1beta1 but found v1alpha1 for SLS Chassis x1000c2 (78de259d-4568-4cc3-b7cb-b213230e7bcd)
11:24AM WRN Schema mismatch: expected v1beta1 but found v1alpha1 for SLS ChassisManagementModule x1000c5b0 (ae579a09-54f9-4ab6-8ede-27eec5bc1e22)
11:24AM WRN Schema mismatch: expected v1beta1 but found v1alpha1 for SLS ChassisManagementModule x1000c0b0 (3d046e65-e52d-4f55-9d1c-3e2989832642)
11:24AM WRN Schema mismatch: expected v1beta1 but found v1alpha1 for SLS ChassisManagementModule x1000c3b0 (aa66b115-79bd-4e3a-a23e-594cd26a3e9b)
11:24AM WRN Schema mismatch: expected v1beta1 but found v1alpha1 for SLS ChassisManagementModule x1000c4b0 (000a7859-1b47-4e84-baf9-e8356080a624)
11:24AM WRN Schema mismatch: expected v1beta1 but found v1alpha1 for SLS ChassisManagementModule x1000c1b0 (d4fd028a-726c-4a7e-8461-e32c5c4a2bfd)
11:24AM WRN Schema mismatch: expected v1beta1 but found v1alpha1 for SLS ChassisManagementModule x1000c2b0 (ca585c0e-071a-4e1a-9f88-ca2160110ccc)
11:24AM WRN Schema mismatch: expected v1beta1 but found v1alpha1 for SLS ChassisManagementModule x1000c7b0 (5daa66ac-c30a-4210-ac37-782185267ac8)
11:24AM WRN Schema mismatch: expected v1beta1 but found v1alpha1 for SLS ChassisManagementModule x1000c6b0 (5264812d-b06e-46e7-afff-1f290945ceee)
```