### PR TITLE
setup and use simulator for integration tests with shellspec and tavern

### DIFF
--- a/.github/workflows/shellspec.yml
+++ b/.github/workflows/shellspec.yml
@@ -21,7 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-name: shell (unit tests)
+name: shellspec (unit and integration tests)
 on:
   push:
   workflow_dispatch:
@@ -29,33 +29,62 @@ jobs:
   shellspec:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest] # no macos for now; docker install takes too long and causes issues but steps in the flow remain if situation improves
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: cachix/install-nix-action@v18
+      - name: checkout hms-simulation-environment
+        uses: actions/checkout@v3
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
-      - if: ${{ matrix.os == 'ubuntu-latest' }}
-        name: Run shellspec
-        run: |
-          nix-shell -p shellspec --run 'make test'
+          path: hms-simulation-environment
+          repository: Cray-HPE/hms-simulation-environment
+          ref: v1
+          fetch-depth: 0
+        
+      - name: checkout shellspec
+        uses: actions/checkout@v3
+        with:
+          path: shellspec
+          repository: shellspec/shellspec
+          fetch-depth: 0
+        
+      - name: set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+        
+      - name: install python dependencies
+        run: pip3 install -r requirements.txt
 
       - if: ${{ matrix.os == 'macos-latest' }}
-        name: Install shellspec (macOS)
+        name: install docker for macos
         run: |
-          brew tap shellspec/shellspec
-          # brew update
-          brew install shellspec ksh93 bash
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask docker
+          sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
+          open -a /Applications/Docker.app --args --unattended --accept-license
+          echo "waiting for Docker to start...this can take a while on github runners"
+          while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do sleep 1; done
 
-      - if: ${{ matrix.os == 'macos-latest' }}
-        name: Run shellspec
+      - name: login to algol60 container registry
+        uses: docker/login-action@v2
+        with:
+          registry: artifactory.algol60.net
+          username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+
+      - name: standup simulation environment
+        id: setup-simulation-environment
+        continue-on-error: false
+        shell: bash
         run: |
+          spec/setup_simulator.sh ./hms-simulation-environment ../testdata/fixtures/sls/no_hardware.json
+
+      - name: Run shellspec
+        shell: bash
+        run: |
+          ln -s "$PWD"/shellspec/shellspec /usr/local/bin/
           make test
+

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ go.work
 .shellspec-local
 .shellspec-quick.log
 bin/
+!spec/support/bin
 report/
 coverage/
 

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ clean:
 	  bin \
 	  $(BUILD_DIR)
 
-spec:
+shellspec:
 	go run cmd/shellspec/main.go
 
 validate-hardware-type-schemas:
@@ -143,8 +143,13 @@ unittest: bin
 	     github.com/Cray-HPE/cani/internal/provider/csm/validate \
 	     github.com/Cray-HPE/cani/internal/provider/csm/validate/common
 
-test: bin validate-hardware-type-schemas unittest
-	shellspec --format tap --no-warning-as-failure
+spec: bin
+	shellspec --format tap --no-warning-as-failure spec/*_spec.sh
+
+integrate: bin
+	./spec/cani_integrate.sh
+
+test: bin validate-hardware-type-schemas unittest spec integrate
 
 tools:
 	go install golang.org/x/lint/golint@latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mkdocs==1.4.3
 mkdocs-awesome-pages-plugin==2.9.1
 mkdocs-material==9.1.15
 mkdocs-material-extensions==1.1.1
+tavern==2.2.0

--- a/spec/cani_integrate.sh
+++ b/spec/cani_integrate.sh
@@ -1,6 +1,8 @@
+#!/usr/bin/env sh
+#
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -19,59 +21,29 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-Name: %(echo $NAME)
-License: MIT License
-BuildArch: %(echo $ARCH)
-Summary: cani
-Version: %(echo ${VERSION})
-Release: 1
-Source: %{name}-%{version}.tar.bz2
-Vendor: Hewlett Packard Enterprise
-Provides: cani
+#
+set -e
+set -u
 
-%ifarch %ix86
-    %global GOARCH 386
-%endif
-%ifarch aarch64
-    %global GOARCH arm64
-%endif
-%ifarch x86_64
-    %global GOARCH amd64
-%endif
+# SIM_REPO="${1:-../hms-simulation-environment}"
+# SLS_DUMP="${2:-../hms-simulation-environment/configs/sls/no_hardware.json}"
 
-%description
-Installs the cani binary.
-
-%prep
-%setup -q
-
-%build
-CGO_ENABLED=0
-GOOS=linux
-GOARCH="%{GOARCH}"
-GO111MODULE=on
-export CGO_ENABLED GOOS GOARCH GO111MODULE
-
-go version
-
-make bin
-
-%install
-CGO_ENABLED=0
-GOOS=linux
-GOARCH="%{GOARCH}"
-GO111MODULE=on
-export CGO_ENABLED GOOS GOARCH GO111MODULE
-
-mkdir -pv ${RPM_BUILD_ROOT}/usr/bin/
-cp -pv bin/cani ${RPM_BUILD_ROOT}/usr/bin/cani
-
-%clean
-
-%files
-%doc README.md
-%license LICENSE
-%defattr(755,root,root)
-/usr/bin/cani
-
-%changelog
+# run a cani workflow, then inspect the CSM services 
+for test in ./spec/integration/*
+do
+  if ! [ -d "${test}" ]; then
+    # get the filename and extension
+    filename=$(basename -- "$test")
+    # extension="${filename##*.}"
+    filename="${filename%.*}"
+    # run shellspec to emulate human interation
+    if [ "${DEBUG:-false}" = "true" ]; then
+      shellspec "${test}" -f tap --no-banner -x
+    else 
+      shellspec "${test}" -f tap --no-banner
+    fi
+    # strip the _spec.sh extension and replace it with .yml (an assertion file with the same name as the shellspec test)
+    # run the tavern test to validate cani changed or didn't change the correct things within CSM services
+    tavern-ci ./spec/integration/tavern/test_"${filename%_spec}".tavern.yml
+  fi 
+done

--- a/spec/integration/session_start_import_1_spec.sh
+++ b/spec/integration/session_start_import_1_spec.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env sh
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+Describe 'INTEGRATION:'
+
+It 'start a session'
+  BeforeCall use_inactive_session
+  BeforeCall use_valid_datastore_system_only # deploy a valid datastore
+  BeforeCall "load_sls.sh testdata/fixtures/sls/valid_hardware_networks.json" # simulator is running, load a specific SLS config
+  When call bin/cani alpha session --config canitest.yml start csm -S
+  The status should equal 0
+  The line 1 of stderr should include 'Using simulation mode'
+  # The line 2 of stderr should include 'canidb.json does not exist, creating default datastore'
+  # The line 3 of stderr should include 'Session is now ACTIVE with provider csm and datastore canidb.json'
+  # The line 4 of stderr should include 'Validated external inventory provider'
+End
+
+It 'import from SLS'
+  When call bin/cani alpha session --config canitest.yml import
+  The status should equal 0
+  The line 1 of stderr should include 'Session is STOPPED'
+  The line 2 of stderr should include 'Committing changes to session'
+  The line 3 of stderr should include 'GET https://localhost:8443/apis/sls/v1/dumpstate'
+  The line 4 of stderr should include 'GET https://localhost:8443/apis/smd/hsm/v2/State/Components'
+  The line 5 of stderr should include 'GET https://localhost:8443/apis/smd/hsm/v2/Inventory/Hardware'
+  The line 6 of stderr should include 'Cabinet x9000 does not exist in datastore at System:0->Cabinet:9000'
+  The line 7 of stderr should include 'Cabinet x9000 device type slug is hpe-ex2000'
+End
+
+It 'commit and reconcile'
+  When call bin/cani alpha session --config canitest.yml stop --commit
+  The status should equal 0
+  The line 1 of stderr should include 'Session is STOPPED'
+  The line 2 of stderr should include 'Committing changes to session'
+  The line 1 of stdout should include 'Summary:'
+  The line 2 of stdout should include '--------'
+  The line 3 of stdout should include 'ID  TYPE  STATUS'
+  The line 5 of stdout should include '0 new hardware item(s) are in the inventory'
+End
+
+End

--- a/spec/integration/tavern/test_session_start_import_1.tavern.yml
+++ b/spec/integration/tavern/test_session_start_import_1.tavern.yml
@@ -1,0 +1,385 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+---
+
+test_name: get the dumpstate
+
+stages:
+  - name: ensure 200 response from the dumpstate and it has Hardware and Networks keys
+    request:
+      url: https://localhost:8443/apis/sls/v1/dumpstate
+      method: GET
+      verify: false
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern.helpers:validate_pykwalify
+        extra_kwargs:
+          schema:
+            type: map
+            required: True
+            mapping:
+              Hardware:
+                mapping:
+                  regex;(^[xsd].+$):
+                    type: map
+                    required: True
+                    mapping:
+                      Parent:
+                        type: str
+                        required: True
+                        pattern: "^[xsd].+"
+                      Children:
+                        type: seq
+                        required: False
+                        matching: all
+                        sequence:
+                          - type: str
+                            pattern: "^[xsd].+"
+                      Xname:
+                        type: str
+                        required: True
+                        pattern: "^[xsd].+"
+                      Type:
+                        type: str
+                        required: True
+                        pattern: "^comptype_.+"
+                      Class:
+                        type: str
+                        required: True
+                        enum:
+                          - "River"
+                          - "Hill"
+                          - "Mountain"
+                      TypeString:
+                        type: str
+                        required: True
+                        #TODO: MgmtHLSwitch not found in this pattern from SLS documentation
+                        #pattern: "^CDU$|^CabinetCDU$|^Cabinet$|^CabinetBMC$|^CabinetPDUController$|^CabinetPDU$|^CabinetPDUNic$|^CabinetPDUOutlet$|^Chassis$|^ChassisBMC$|^CMMRectifier$|^CMMFpga$|^CEC$|^ComputeModule$|^RouterModule$|^NodeBMC$|^NodeBMCNic$|^NodeEnclosure$|^NodePowerConnector$|^Node$|^Processor$|^NodeNIC$|^NodeHsnNIC$|^Memory$|^NodeAccel$|^NodeFpga$|^HSNAsic$|^RouterFpga$|^RouterTORFpga$|^RouterBMC$|^RouterBMCNic$|^HSNBoard$|^HSNLink$|^HSNConnector$|^HSNConnectorPort$|^MgmtSwitch$|^MgmtSwitchConnector$|^SMSBox$|^System$"
+                        pattern: "^CDU$|^CDUMgmtSwitch$|^CabinetCDU$|^Cabinet$|^CabinetBMC$|^CabinetPDUController$|^CabinetPDU$|^CabinetPDUNic$|^CabinetPDUOutlet$|^Chassis$|^ChassisBMC$|^CMMRectifier$|^CMMFpga$|^CEC$|^ComputeModule$|^RouterModule$|^NodeBMC$|^NodeBMCNic$|^NodeEnclosure$|^NodePowerConnector$|^Node$|^Processor$|^NodeNIC$|^NodeHsnNIC$|^Memory$|^NodeAccel$|^NodeFpga$|^HSNAsic$|^RouterFpga$|^RouterTORFpga$|^RouterBMC$|^RouterBMCNic$|^HSNBoard$|^HSNLink$|^HSNConnector$|^HSNConnectorPort$|^MgmtHLSwitch$|^MgmtSwitch$|^MgmtSwitchConnector$|^SMSBox$|^System$"
+                      LastUpdated:
+                        type: int
+                        required: True
+                      LastUpdatedTime:
+                        type: str
+                        required: True
+                        pattern: "[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}} [0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}.[0-9]+ \\+[0-9]{{4}} \\+[0-9]{{4}}|[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}} [0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}.[0-9]+ \\+[0-9]{{4}} UTC"
+                      ExtraProperties:
+                        type: map
+                        required: False
+                        allowempty: True
+                        mapping:
+                          Aliases:
+                            type: seq
+                            required: False
+                            matching: all
+                            sequence:
+                              - type: str
+                          Brand:
+                            type: str
+                            required: False
+                          IP4addr:
+                            type: str
+                            required: False
+                          Networks:
+                            type: map
+                            required: False
+                            allowempty: True
+                            mapping:
+                              cn:
+                                type: map
+                                required: False
+                                allowempty: True
+                                mapping:
+                                  HMN:
+                                    type: map
+                                    required: False
+                                    mapping:
+                                      CIDR:
+                                        type: str
+                                        required: True
+                                      Gateway:
+                                        type: str
+                                        required: True
+                                      VLan:
+                                        type: int
+                                        required: True
+                          NID:
+                            type: int
+                            required: False
+                          NodeNics:
+                            type: seq
+                            required: False
+                            matching: all
+                            sequence:
+                              - type: str
+                                pattern: "^[xs].+"
+                          Password:
+                            type: str
+                            required: False
+                          Role:
+                            type: str
+                            required: False
+                          SNMPAuthPassword:
+                            type: str
+                            required: False
+                          SNMPAuthProtocol:
+                            type: str
+                            required: False
+                          SNMPPrivPassword:
+                            type: str
+                            required: False
+                          SNMPPrivProtocol:
+                            type: str
+                            required: False
+                          SNMPUsername:
+                            type: str
+                            required: False
+                          SubRole:
+                            type: str
+                            required: False
+                          Username:
+                            type: str
+                            required: False
+                          VendorName:
+                            type: str
+                            required: False
+              Networks:
+                mapping:
+                  regex;(^.+$):
+                    type: map
+                    required: True
+                    mapping:
+                      Name:
+                        type: str
+                      FullName:
+                        type: str
+                      IPRanges:
+                        type: seq
+                        matching: all
+                        sequence:
+                          - type: str
+                            pattern: "[0-9]+.[0-9]+.[0-9]+.[0-9]+/[0-9]+"
+                      Type:
+                        type: str
+                      LastUpdated:
+                        type: int
+                      LastUpdatedTime:
+                        type: str
+                        required: True
+                        pattern: "[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}} [0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}.[0-9]+ \\+[0-9]{{4}} \\+[0-9]{{4}}|[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}} [0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}.[0-9]+ \\+[0-9]{{4}} UTC"
+                      ExtraProperties:
+                        type: map
+                        required: False
+                        allowempty: True
+                        mapping:
+                          CIDR:
+                            type: str
+                            required: False
+                            pattern: "[0-9]+.[0-9]+.[0-9]+.[0-9]+/[0-9]+"
+                          MTU:
+                            type: int
+                            required: False
+                          MyASN:
+                            type: int
+                            required: False
+                          PeerASN:
+                            type: int
+                            required: False
+                          Subnets:
+                            type: seq
+                            required: False
+                            matching: all
+                            sequence:
+                              - type: map
+                                allowempty: True
+                                mapping:
+                                  CIDR:
+                                    type: str
+                                    required: False
+                                    pattern: "[0-9]+.[0-9]+.[0-9]+.[0-9]+/[0-9]+"
+                                  DHCPEnd:
+                                    type: str
+                                    required: False
+                                    pattern: "[0-9]+.[0-9]+.[0-9]+.[0-9]+"
+                                  DHCPStart:
+                                    type: str
+                                    required: False
+                                    pattern: "[0-9]+.[0-9]+.[0-9]+.[0-9]+"
+                                  FullName:
+                                    type: str
+                                    required: False
+                                  Gateway:
+                                    type: str
+                                    required: False
+                                    pattern: "[0-9]+.[0-9]+.[0-9]+.[0-9]+"
+                                  IPReservations:
+                                    type: seq
+                                    required: False
+                                    matching: all
+                                    sequence:
+                                      - type: map
+                                        mapping:
+                                          Aliases:
+                                            type: seq
+                                            matching: all
+                                            sequence:
+                                              - type: str
+                                          Comment:
+                                            type: str
+                                          IPAddress:
+                                            type: str
+                                            pattern: "[0-9]+.[0-9]+.[0-9]+.[0-9]+"
+                                          Name:
+                                            type: str
+                                  MetalLBPoolName:
+                                    type: str
+                                    required: False
+                                  Name:
+                                    type: str
+                                    required: False
+                                  ReservationEnd:
+                                    type: str
+                                    required: False
+                                  ReservationStart:
+                                    type: str
+                                    required: False
+                                  VlanID:
+                                    type: int
+                                    required: False
+                          SystemDefaultRoute:
+                            type: str
+                            required: False
+                          VlanRange:
+                            type: seq
+                            required: False
+                            matching: all
+                            sequence:
+                              - type: int
+
+---
+test_name: ensure hardware exists and has cani metadata
+
+stages: 
+  - name: ensure x9000 exists and has cani metadata
+    request:
+      url: https://localhost:8443/apis/sls/v1/hardware/x9000
+      method: GET
+      verify: false
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern.helpers:validate_pykwalify
+        extra_kwargs:
+          schema:
+            type: map
+            required: True
+            mapping:
+              Parent:
+                type: str
+                required: True
+                pattern: "^s0$"
+              Children:
+                type: seq
+                required: False
+                matching: all
+                sequence:
+                  - type: str
+                    pattern: "^[xs].+"
+              Xname:
+                type: str
+                required: True
+                pattern: "^x9000$"
+              Type:
+                type: str
+                required: True
+                pattern: "^comptype_cabinet$"
+              Class:
+                type: str
+                required: True
+                pattern: "^Hill$"
+              TypeString:
+                type: str
+                required: True
+                pattern: "^Cabinet$"
+              LastUpdated:
+                type: int
+                required: True
+              LastUpdatedTime:
+                type: str
+                required: True
+                pattern: "^[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}} [0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}.[0-9]+ \\+[0-9]{{4}} \\+[0-9]{{4}}|[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}} [0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}.[0-9]+ \\+[0-9]{{4}} UTC$"
+              ExtraProperties:
+                type: map
+                required: False
+                allowempty: True
+                mapping:
+                  '@cani.id':
+                    type: str
+                    required: True
+                    # pattern: "^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$"
+                  '@cani.lastModified':
+                    type: str
+                    required: True
+                    # pattern: "^[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}} [0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}.[0-9]+ \\+[0-9]{{4}} \\+[0-9]{{4}}|[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}} [0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}.[0-9]+ \\+[0-9]{{4}} UTC$"
+                  '@cani.slsSchemaVersion':
+                    type: str
+                    required: True
+                    pattern: "^v1alpha1$"
+                  Aliases:
+                    type: seq
+                    required: False
+                    matching: all
+                    sequence:
+                      - type: str
+                  Brand:
+                    type: str
+                    required: False
+                  IP4addr:
+                    type: str
+                    required: False
+                  Networks:
+                    type: map
+                    required: False
+                    allowempty: True
+                    mapping:
+                      cn:
+                        type: map
+                        required: False
+                        allowempty: True
+                        mapping:
+                          HMN:
+                            type: map
+                            required: False
+                            mapping:
+                              CIDR:
+                                type: str
+                                required: True
+                              Gateway:
+                                type: str
+                                required: True
+                              VLan:
+                                type: int
+                                required: True

--- a/spec/setup_simulator.sh
+++ b/spec/setup_simulator.sh
@@ -1,6 +1,8 @@
+#!/usr/bin/env bash
+#
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -19,59 +21,18 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-Name: %(echo $NAME)
-License: MIT License
-BuildArch: %(echo $ARCH)
-Summary: cani
-Version: %(echo ${VERSION})
-Release: 1
-Source: %{name}-%{version}.tar.bz2
-Vendor: Hewlett Packard Enterprise
-Provides: cani
+#
+set -e
+set -u
+set -o pipefail
 
-%ifarch %ix86
-    %global GOARCH 386
-%endif
-%ifarch aarch64
-    %global GOARCH arm64
-%endif
-%ifarch x86_64
-    %global GOARCH amd64
-%endif
+SIM_REPO="${1:-../hms-simulation-environment}"
+SLS_DUMP="${2:-../hms-simulation-environment/configs/sls/no_hardware.json}"
 
-%description
-Installs the cani binary.
-
-%prep
-%setup -q
-
-%build
-CGO_ENABLED=0
-GOOS=linux
-GOARCH="%{GOARCH}"
-GO111MODULE=on
-export CGO_ENABLED GOOS GOARCH GO111MODULE
-
-go version
-
-make bin
-
-%install
-CGO_ENABLED=0
-GOOS=linux
-GOARCH="%{GOARCH}"
-GO111MODULE=on
-export CGO_ENABLED GOOS GOARCH GO111MODULE
-
-mkdir -pv ${RPM_BUILD_ROOT}/usr/bin/
-cp -pv bin/cani ${RPM_BUILD_ROOT}/usr/bin/cani
-
-%clean
-
-%files
-%doc README.md
-%license LICENSE
-%defattr(755,root,root)
-/usr/bin/cani
-
-%changelog
+# start the simulator with the specified SLS config
+pushd "${SIM_REPO}" || exit 1
+  ./setup_venv.sh
+  #shellcheck disable=SC1091
+  . ./venv/bin/activate
+  ./run.py "${SLS_DUMP}"
+popd || exit 1

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -1,3 +1,4 @@
+#
 # MIT License
 #
 # (C) Copyright 2023 Hewlett Packard Enterprise Development LP
@@ -19,7 +20,7 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-
+#
 # shellcheck shell=sh
 
 # Defining variables and functions here will affect all specfiles.
@@ -51,13 +52,13 @@ spec_helper_configure() {
   # compare value to file content
   fixture(){
     #shellcheck disable=SC2317
-    test "${fixture:?}" == "$( cat "$FIXTURES/$1" )"
+    [ "${fixture:?}" = "$( cat "$FIXTURES/$1" )" ]
   }
 
   #shellcheck disable=SC2317
   remove_config(){ rm -f canitest.yml; }
   #shellcheck disable=SC2317
-  remove_datastore() { rm -f canitestdb.json; }
+  remove_datastore() { rm -f canitestdb.json;rm -f canidb.json; }
   #shellcheck disable=SC2317
   remove_log() { rm -f canitestdb.log; }
 
@@ -122,6 +123,7 @@ spec_helper_configure() {
     #shellcheck disable=SC2317
     cp "$FIXTURES"/cani/configs/canitestdb_valid_ex4000_only.json canitestdb.json 
   } 
+
 }
 
 # Custom matcher used to find a string inside of a text containing ANSI escape codes.

--- a/testdata/fixtures/sls/EX2000_River.json
+++ b/testdata/fixtures/sls/EX2000_River.json
@@ -1,0 +1,1573 @@
+{
+    "Hardware": {
+        "d0w1": {
+            "Parent": "d0",
+            "Xname": "d0w1",
+            "Type": "comptype_cdu_mgmt_switch",
+            "Class": "Mountain",
+            "TypeString": "CDUMgmtSwitch",
+            "ExtraProperties": {
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-cdu-001"
+                ]
+            }
+        },
+        "d0w2": {
+            "Parent": "d0",
+            "Xname": "d0w2",
+            "Type": "comptype_cdu_mgmt_switch",
+            "Class": "Mountain",
+            "TypeString": "CDUMgmtSwitch",
+            "ExtraProperties": {
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-cdu-002"
+                ]
+            }
+        },
+        "x3000": {
+            "Parent": "s0",
+            "Xname": "x3000",
+            "Type": "comptype_cabinet",
+            "Class": "River",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    },
+                    "ncn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    }
+                }
+            }
+        },
+        "x3000c0h33s1": {
+            "Parent": "x3000c0h33",
+            "Xname": "x3000c0h33s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.4",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-001"
+                ]
+            }
+        },
+        "x3000c0h34s1": {
+            "Parent": "x3000c0h34",
+            "Xname": "x3000c0h34s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.5",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-002"
+                ]
+            }
+        },
+        "x3000c0h35s1": {
+            "Parent": "x3000c0h35",
+            "Xname": "x3000c0h35s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.6",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-003"
+                ]
+            }
+        },
+        "x3000c0h36s1": {
+            "Parent": "x3000c0h36",
+            "Xname": "x3000c0h36s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.7",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-004"
+                ]
+            }
+        },
+        "x3000c0h37s1": {
+            "Parent": "x3000c0h37",
+            "Xname": "x3000c0h37s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.2",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-001"
+                ]
+            }
+        },
+        "x3000c0h38s1": {
+            "Parent": "x3000c0h38",
+            "Xname": "x3000c0h38s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.3",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-002"
+                ]
+            }
+        },
+        "x3000c0r39b0": {
+            "Parent": "x3000c0r39",
+            "Xname": "x3000c0r39b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x3000c0r39b0",
+                "Password": "vault://hms-creds/x3000c0r39b0"
+            }
+        },
+        "x3000c0r40b0": {
+            "Parent": "x3000c0r40",
+            "Xname": "x3000c0r40b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x3000c0r40b0",
+                "Password": "vault://hms-creds/x3000c0r40b0"
+            }
+        },
+        "x3000c0s10b0n0": {
+            "Parent": "x3000c0s10b0",
+            "Xname": "x3000c0s10b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100001,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s003"
+                ]
+            }
+        },
+        "x3000c0s15b0n0": {
+            "Parent": "x3000c0s15b0",
+            "Xname": "x3000c0s15b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan01"
+                ]
+            }
+        },
+        "x3000c0s16b0n0": {
+            "Parent": "x3000c0s16b0",
+            "Xname": "x3000c0s16b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan02"
+                ]
+            }
+        },
+        "x3000c0s1b0n0": {
+            "Parent": "x3000c0s1b0",
+            "Xname": "x3000c0s1b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100010,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m001"
+                ]
+            }
+        },
+        "x3000c0s24b0n0": {
+            "Parent": "x3000c0s24b0",
+            "Xname": "x3000c0s24b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "@rie.mockup": "XL675d_A40",
+                "NID": 1,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid000001"
+                ]
+            }
+        },
+        "x3000c0s2b0n0": {
+            "Parent": "x3000c0s2b0",
+            "Xname": "x3000c0s2b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100009,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m002"
+                ]
+            }
+        },
+        "x3000c0s3b0n0": {
+            "Parent": "x3000c0s3b0",
+            "Xname": "x3000c0s3b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100008,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m003"
+                ]
+            }
+        },
+        "x3000c0s4b0n0": {
+            "Parent": "x3000c0s4b0",
+            "Xname": "x3000c0s4b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100007,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w001"
+                ]
+            }
+        },
+        "x3000c0s5b0n0": {
+            "Parent": "x3000c0s5b0",
+            "Xname": "x3000c0s5b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100006,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w002"
+                ]
+            }
+        },
+        "x3000c0s6b0n0": {
+            "Parent": "x3000c0s6b0",
+            "Xname": "x3000c0s6b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100005,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w003"
+                ]
+            }
+        },
+        "x3000c0s7b0n0": {
+            "Parent": "x3000c0s7b0",
+            "Xname": "x3000c0s7b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100004,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w004"
+                ]
+            }
+        },
+        "x3000c0s8b0n0": {
+            "Parent": "x3000c0s8b0",
+            "Xname": "x3000c0s8b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100003,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s001"
+                ]
+            }
+        },
+        "x3000c0s9b0n0": {
+            "Parent": "x3000c0s9b0",
+            "Xname": "x3000c0s9b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100002,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s002"
+                ]
+            }
+        },
+        "x3000c0w31": {
+            "Parent": "x3000c0",
+            "Xname": "x3000c0w31",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.8",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-001"
+                ]
+            }
+        },
+        "x3000c0w31j29": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j29",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s24b0"
+                ],
+                "VendorName": "1/1/29"
+            }
+        },
+        "x3000c0w31j34": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j34",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s2b0"
+                ],
+                "VendorName": "1/1/34"
+            }
+        },
+        "x3000c0w31j35": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j35",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s4b0"
+                ],
+                "VendorName": "1/1/35"
+            }
+        },
+        "x3000c0w31j36": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s5b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x3000c0w31j37": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s6b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x3000c0w31j38": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s8b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x3000c0w31j39": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j39",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s9b0"
+                ],
+                "VendorName": "1/1/39"
+            }
+        },
+        "x3000c0w31j40": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j40",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s15b0"
+                ],
+                "VendorName": "1/1/40"
+            }
+        },
+        "x3000c0w31j41": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j41",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s16b0"
+                ],
+                "VendorName": "1/1/41"
+            }
+        },
+        "x3000c0w31j47": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0r39b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x3000c0w31j48": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000m0"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x3000c0w32": {
+            "Parent": "x3000c0",
+            "Xname": "x3000c0w32",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.9",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x3000c0w32",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x3000c0w32",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-002"
+                ]
+            }
+        },
+        "x3000c0w32j36": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s3b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x3000c0w32j37": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s7b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x3000c0w32j38": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s10b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x3000c0w32j47": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0r40b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x3000c0w32j48": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000m1"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x3000m0": {
+            "Parent": "x3000",
+            "Xname": "x3000m0",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        },
+        "x3000m1": {
+            "Parent": "x3000",
+            "Xname": "x3000m1",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        },
+        "x9000": {
+            "Parent": "s0",
+            "Xname": "x9000",
+            "Type": "comptype_cabinet",
+            "Class": "Hill",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Model": "EX2000",
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.104.0.0/22",
+                            "Gateway": "10.104.0.1",
+                            "VLan": 3002
+                        },
+                        "NMN": {
+                            "CIDR": "10.100.0.0/22",
+                            "Gateway": "10.100.0.1",
+                            "VLan": 2002
+                        }
+                    }
+                }
+            }
+        },
+        "x9000c1": {
+            "Parent": "x9000",
+            "Xname": "x9000c1",
+            "Type": "comptype_chassis",
+            "Class": "Hill",
+            "TypeString": "Chassis"
+        },
+        "x9000c1b0": {
+            "Parent": "x9000c1",
+            "Xname": "x9000c1b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Hill",
+            "TypeString": "ChassisBMC"
+        },
+        "x9000c1s0b0n0": {
+            "Parent": "x9000c1s0b0",
+            "Xname": "x9000c1s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1000,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001000"
+                ]
+            }
+        },
+        "x9000c1s0b0n1": {
+            "Parent": "x9000c1s0b0",
+            "Xname": "x9000c1s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1001,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001001"
+                ]
+            }
+        },
+        "x9000c1s0b1n0": {
+            "Parent": "x9000c1s0b1",
+            "Xname": "x9000c1s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1002,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001002"
+                ]
+            }
+        },
+        "x9000c1s0b1n1": {
+            "Parent": "x9000c1s0b1",
+            "Xname": "x9000c1s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1003,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001003"
+                ]
+            }
+        },
+        "x9000c1s1b0n0": {
+            "Parent": "x9000c1s1b0",
+            "Xname": "x9000c1s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1004,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001004"
+                ]
+            }
+        },
+        "x9000c1s1b0n1": {
+            "Parent": "x9000c1s1b0",
+            "Xname": "x9000c1s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1005,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001005"
+                ]
+            }
+        },
+        "x9000c1s1b1n0": {
+            "Parent": "x9000c1s1b1",
+            "Xname": "x9000c1s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1006,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001006"
+                ]
+            }
+        },
+        "x9000c1s1b1n1": {
+            "Parent": "x9000c1s1b1",
+            "Xname": "x9000c1s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1007,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001007"
+                ]
+            }
+        },
+        "x9000c1s2b0n0": {
+            "Parent": "x9000c1s2b0",
+            "Xname": "x9000c1s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1008,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001008"
+                ]
+            }
+        },
+        "x9000c1s2b0n1": {
+            "Parent": "x9000c1s2b0",
+            "Xname": "x9000c1s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1009,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001009"
+                ]
+            }
+        },
+        "x9000c1s2b1n0": {
+            "Parent": "x9000c1s2b1",
+            "Xname": "x9000c1s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1010,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001010"
+                ]
+            }
+        },
+        "x9000c1s2b1n1": {
+            "Parent": "x9000c1s2b1",
+            "Xname": "x9000c1s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1011,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001011"
+                ]
+            }
+        },
+        "x9000c1s3b0n0": {
+            "Parent": "x9000c1s3b0",
+            "Xname": "x9000c1s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1012,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001012"
+                ]
+            }
+        },
+        "x9000c1s3b0n1": {
+            "Parent": "x9000c1s3b0",
+            "Xname": "x9000c1s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1013,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001013"
+                ]
+            }
+        },
+        "x9000c1s3b1n0": {
+            "Parent": "x9000c1s3b1",
+            "Xname": "x9000c1s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1014,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001014"
+                ]
+            }
+        },
+        "x9000c1s3b1n1": {
+            "Parent": "x9000c1s3b1",
+            "Xname": "x9000c1s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1015,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001015"
+                ]
+            }
+        },
+        "x9000c1s4b0n0": {
+            "Parent": "x9000c1s4b0",
+            "Xname": "x9000c1s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1016,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001016"
+                ]
+            }
+        },
+        "x9000c1s4b0n1": {
+            "Parent": "x9000c1s4b0",
+            "Xname": "x9000c1s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1017,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001017"
+                ]
+            }
+        },
+        "x9000c1s4b1n0": {
+            "Parent": "x9000c1s4b1",
+            "Xname": "x9000c1s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1018,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001018"
+                ]
+            }
+        },
+        "x9000c1s4b1n1": {
+            "Parent": "x9000c1s4b1",
+            "Xname": "x9000c1s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1019,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001019"
+                ]
+            }
+        },
+        "x9000c1s5b0n0": {
+            "Parent": "x9000c1s5b0",
+            "Xname": "x9000c1s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1020,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001020"
+                ]
+            }
+        },
+        "x9000c1s5b0n1": {
+            "Parent": "x9000c1s5b0",
+            "Xname": "x9000c1s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1021,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001021"
+                ]
+            }
+        },
+        "x9000c1s5b1n0": {
+            "Parent": "x9000c1s5b1",
+            "Xname": "x9000c1s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1022,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001022"
+                ]
+            }
+        },
+        "x9000c1s5b1n1": {
+            "Parent": "x9000c1s5b1",
+            "Xname": "x9000c1s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1023,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001023"
+                ]
+            }
+        },
+        "x9000c1s6b0n0": {
+            "Parent": "x9000c1s6b0",
+            "Xname": "x9000c1s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1024,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001024"
+                ]
+            }
+        },
+        "x9000c1s6b0n1": {
+            "Parent": "x9000c1s6b0",
+            "Xname": "x9000c1s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1025,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001025"
+                ]
+            }
+        },
+        "x9000c1s6b1n0": {
+            "Parent": "x9000c1s6b1",
+            "Xname": "x9000c1s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1026,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001026"
+                ]
+            }
+        },
+        "x9000c1s6b1n1": {
+            "Parent": "x9000c1s6b1",
+            "Xname": "x9000c1s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1027,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001027"
+                ]
+            }
+        },
+        "x9000c1s7b0n0": {
+            "Parent": "x9000c1s7b0",
+            "Xname": "x9000c1s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1028,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001028"
+                ]
+            }
+        },
+        "x9000c1s7b0n1": {
+            "Parent": "x9000c1s7b0",
+            "Xname": "x9000c1s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1029,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001029"
+                ]
+            }
+        },
+        "x9000c1s7b1n0": {
+            "Parent": "x9000c1s7b1",
+            "Xname": "x9000c1s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1030,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001030"
+                ]
+            }
+        },
+        "x9000c1s7b1n1": {
+            "Parent": "x9000c1s7b1",
+            "Xname": "x9000c1s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1031,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001031"
+                ]
+            }
+        },
+        "x9000c3": {
+            "Parent": "x9000",
+            "Xname": "x9000c3",
+            "Type": "comptype_chassis",
+            "Class": "Hill",
+            "TypeString": "Chassis"
+        },
+        "x9000c3b0": {
+            "Parent": "x9000c3",
+            "Xname": "x9000c3b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Hill",
+            "TypeString": "ChassisBMC"
+        },
+        "x9000c3s0b0n0": {
+            "Parent": "x9000c3s0b0",
+            "Xname": "x9000c3s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1032,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001032"
+                ]
+            }
+        },
+        "x9000c3s0b0n1": {
+            "Parent": "x9000c3s0b0",
+            "Xname": "x9000c3s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1033,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001033"
+                ]
+            }
+        },
+        "x9000c3s0b1n0": {
+            "Parent": "x9000c3s0b1",
+            "Xname": "x9000c3s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1034,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001034"
+                ]
+            }
+        },
+        "x9000c3s0b1n1": {
+            "Parent": "x9000c3s0b1",
+            "Xname": "x9000c3s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1035,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001035"
+                ]
+            }
+        },
+        "x9000c3s1b0n0": {
+            "Parent": "x9000c3s1b0",
+            "Xname": "x9000c3s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1036,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001036"
+                ]
+            }
+        },
+        "x9000c3s1b0n1": {
+            "Parent": "x9000c3s1b0",
+            "Xname": "x9000c3s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1037,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001037"
+                ]
+            }
+        },
+        "x9000c3s1b1n0": {
+            "Parent": "x9000c3s1b1",
+            "Xname": "x9000c3s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1038,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001038"
+                ]
+            }
+        },
+        "x9000c3s1b1n1": {
+            "Parent": "x9000c3s1b1",
+            "Xname": "x9000c3s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1039,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001039"
+                ]
+            }
+        },
+        "x9000c3s2b0n0": {
+            "Parent": "x9000c3s2b0",
+            "Xname": "x9000c3s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1040,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001040"
+                ]
+            }
+        },
+        "x9000c3s2b0n1": {
+            "Parent": "x9000c3s2b0",
+            "Xname": "x9000c3s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1041,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001041"
+                ]
+            }
+        },
+        "x9000c3s2b1n0": {
+            "Parent": "x9000c3s2b1",
+            "Xname": "x9000c3s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1042,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001042"
+                ]
+            }
+        },
+        "x9000c3s2b1n1": {
+            "Parent": "x9000c3s2b1",
+            "Xname": "x9000c3s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1043,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001043"
+                ]
+            }
+        },
+        "x9000c3s3b0n0": {
+            "Parent": "x9000c3s3b0",
+            "Xname": "x9000c3s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1044,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001044"
+                ]
+            }
+        },
+        "x9000c3s3b0n1": {
+            "Parent": "x9000c3s3b0",
+            "Xname": "x9000c3s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1045,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001045"
+                ]
+            }
+        },
+        "x9000c3s3b1n0": {
+            "Parent": "x9000c3s3b1",
+            "Xname": "x9000c3s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1046,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001046"
+                ]
+            }
+        },
+        "x9000c3s3b1n1": {
+            "Parent": "x9000c3s3b1",
+            "Xname": "x9000c3s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1047,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001047"
+                ]
+            }
+        },
+        "x9000c3s4b0n0": {
+            "Parent": "x9000c3s4b0",
+            "Xname": "x9000c3s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1048,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001048"
+                ]
+            }
+        },
+        "x9000c3s4b0n1": {
+            "Parent": "x9000c3s4b0",
+            "Xname": "x9000c3s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1049,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001049"
+                ]
+            }
+        },
+        "x9000c3s4b1n0": {
+            "Parent": "x9000c3s4b1",
+            "Xname": "x9000c3s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1050,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001050"
+                ]
+            }
+        },
+        "x9000c3s4b1n1": {
+            "Parent": "x9000c3s4b1",
+            "Xname": "x9000c3s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1051,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001051"
+                ]
+            }
+        },
+        "x9000c3s5b0n0": {
+            "Parent": "x9000c3s5b0",
+            "Xname": "x9000c3s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1052,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001052"
+                ]
+            }
+        },
+        "x9000c3s5b0n1": {
+            "Parent": "x9000c3s5b0",
+            "Xname": "x9000c3s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1053,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001053"
+                ]
+            }
+        },
+        "x9000c3s5b1n0": {
+            "Parent": "x9000c3s5b1",
+            "Xname": "x9000c3s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1054,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001054"
+                ]
+            }
+        },
+        "x9000c3s5b1n1": {
+            "Parent": "x9000c3s5b1",
+            "Xname": "x9000c3s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1055,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001055"
+                ]
+            }
+        },
+        "x9000c3s6b0n0": {
+            "Parent": "x9000c3s6b0",
+            "Xname": "x9000c3s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1056,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001056"
+                ]
+            }
+        },
+        "x9000c3s6b0n1": {
+            "Parent": "x9000c3s6b0",
+            "Xname": "x9000c3s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1057,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001057"
+                ]
+            }
+        },
+        "x9000c3s6b1n0": {
+            "Parent": "x9000c3s6b1",
+            "Xname": "x9000c3s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1058,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001058"
+                ]
+            }
+        },
+        "x9000c3s6b1n1": {
+            "Parent": "x9000c3s6b1",
+            "Xname": "x9000c3s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1059,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001059"
+                ]
+            }
+        },
+        "x9000c3s7b0n0": {
+            "Parent": "x9000c3s7b0",
+            "Xname": "x9000c3s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1060,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001060"
+                ]
+            }
+        },
+        "x9000c3s7b0n1": {
+            "Parent": "x9000c3s7b0",
+            "Xname": "x9000c3s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1061,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001061"
+                ]
+            }
+        },
+        "x9000c3s7b1n0": {
+            "Parent": "x9000c3s7b1",
+            "Xname": "x9000c3s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1062,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001062"
+                ]
+            }
+        },
+        "x9000c3s7b1n1": {
+            "Parent": "x9000c3s7b1",
+            "Xname": "x9000c3s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1063,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001063"
+                ]
+            }
+        }
+    },
+    "Networks": {}
+}

--- a/testdata/fixtures/sls/EX2500_Mixed_Cabinet.json
+++ b/testdata/fixtures/sls/EX2500_Mixed_Cabinet.json
@@ -1,0 +1,1075 @@
+{
+    "Hardware": {
+        "d0w1": {
+            "Parent": "d0",
+            "Xname": "d0w1",
+            "Type": "comptype_cdu_mgmt_switch",
+            "Class": "Mountain",
+            "TypeString": "CDUMgmtSwitch",
+            "ExtraProperties": {
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-cdu-001"
+                ]
+            }
+        },
+        "d0w2": {
+            "Parent": "d0",
+            "Xname": "d0w2",
+            "Type": "comptype_cdu_mgmt_switch",
+            "Class": "Mountain",
+            "TypeString": "CDUMgmtSwitch",
+            "ExtraProperties": {
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-cdu-002"
+                ]
+            }
+        },
+        "x8000": {
+            "Parent": "s0",
+            "Xname": "x8000",
+            "Type": "comptype_cabinet",
+            "Class": "Hill",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Model": "EX2500",
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.104.0.0/22",
+                            "Gateway": "10.104.0.1",
+                            "VLan": 3003
+                        },
+                        "NMN": {
+                            "CIDR": "10.100.0.0/22",
+                            "Gateway": "10.100.0.1",
+                            "VLan": 2003
+                        }
+                    }
+                }
+            }
+        },
+        "x8000c0": {
+            "Parent": "x8000",
+            "Xname": "x8000c0",
+            "Type": "comptype_chassis",
+            "Class": "Hill",
+            "TypeString": "Chassis"
+        },
+        "x8000c0b0": {
+            "Parent": "x8000c0",
+            "Xname": "x8000c0b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Hill",
+            "TypeString": "ChassisBMC"
+        },
+        "x8000c0s0b0n0": {
+            "Parent": "x8000c0s0b0",
+            "Xname": "x8000c0s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1000,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001000"
+                ]
+            }
+        },
+        "x8000c0s0b0n1": {
+            "Parent": "x8000c0s0b0",
+            "Xname": "x8000c0s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1001,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001001"
+                ]
+            }
+        },
+        "x8000c0s0b1n0": {
+            "Parent": "x8000c0s0b1",
+            "Xname": "x8000c0s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1002,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001002"
+                ]
+            }
+        },
+        "x8000c0s0b1n1": {
+            "Parent": "x8000c0s0b1",
+            "Xname": "x8000c0s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1003,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001003"
+                ]
+            }
+        },
+        "x8000c0s1b0n0": {
+            "Parent": "x8000c0s1b0",
+            "Xname": "x8000c0s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1004,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001004"
+                ]
+            }
+        },
+        "x8000c0s1b0n1": {
+            "Parent": "x8000c0s1b0",
+            "Xname": "x8000c0s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1005,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001005"
+                ]
+            }
+        },
+        "x8000c0s1b1n0": {
+            "Parent": "x8000c0s1b1",
+            "Xname": "x8000c0s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1006,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001006"
+                ]
+            }
+        },
+        "x8000c0s1b1n1": {
+            "Parent": "x8000c0s1b1",
+            "Xname": "x8000c0s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1007,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001007"
+                ]
+            }
+        },
+        "x8000c0s2b0n0": {
+            "Parent": "x8000c0s2b0",
+            "Xname": "x8000c0s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1008,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001008"
+                ]
+            }
+        },
+        "x8000c0s2b0n1": {
+            "Parent": "x8000c0s2b0",
+            "Xname": "x8000c0s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1009,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001009"
+                ]
+            }
+        },
+        "x8000c0s2b1n0": {
+            "Parent": "x8000c0s2b1",
+            "Xname": "x8000c0s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1010,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001010"
+                ]
+            }
+        },
+        "x8000c0s2b1n1": {
+            "Parent": "x8000c0s2b1",
+            "Xname": "x8000c0s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1011,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001011"
+                ]
+            }
+        },
+        "x8000c0s3b0n0": {
+            "Parent": "x8000c0s3b0",
+            "Xname": "x8000c0s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1012,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001012"
+                ]
+            }
+        },
+        "x8000c0s3b0n1": {
+            "Parent": "x8000c0s3b0",
+            "Xname": "x8000c0s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1013,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001013"
+                ]
+            }
+        },
+        "x8000c0s3b1n0": {
+            "Parent": "x8000c0s3b1",
+            "Xname": "x8000c0s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1014,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001014"
+                ]
+            }
+        },
+        "x8000c0s3b1n1": {
+            "Parent": "x8000c0s3b1",
+            "Xname": "x8000c0s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1015,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001015"
+                ]
+            }
+        },
+        "x8000c0s4b0n0": {
+            "Parent": "x8000c0s4b0",
+            "Xname": "x8000c0s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1016,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001016"
+                ]
+            }
+        },
+        "x8000c0s4b0n1": {
+            "Parent": "x8000c0s4b0",
+            "Xname": "x8000c0s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1017,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001017"
+                ]
+            }
+        },
+        "x8000c0s4b1n0": {
+            "Parent": "x8000c0s4b1",
+            "Xname": "x8000c0s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1018,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001018"
+                ]
+            }
+        },
+        "x8000c0s4b1n1": {
+            "Parent": "x8000c0s4b1",
+            "Xname": "x8000c0s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1019,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001019"
+                ]
+            }
+        },
+        "x8000c0s5b0n0": {
+            "Parent": "x8000c0s5b0",
+            "Xname": "x8000c0s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1020,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001020"
+                ]
+            }
+        },
+        "x8000c0s5b0n1": {
+            "Parent": "x8000c0s5b0",
+            "Xname": "x8000c0s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1021,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001021"
+                ]
+            }
+        },
+        "x8000c0s5b1n0": {
+            "Parent": "x8000c0s5b1",
+            "Xname": "x8000c0s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1022,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001022"
+                ]
+            }
+        },
+        "x8000c0s5b1n1": {
+            "Parent": "x8000c0s5b1",
+            "Xname": "x8000c0s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1023,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001023"
+                ]
+            }
+        },
+        "x8000c0s6b0n0": {
+            "Parent": "x8000c0s6b0",
+            "Xname": "x8000c0s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1024,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001024"
+                ]
+            }
+        },
+        "x8000c0s6b0n1": {
+            "Parent": "x8000c0s6b0",
+            "Xname": "x8000c0s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1025,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001025"
+                ]
+            }
+        },
+        "x8000c0s6b1n0": {
+            "Parent": "x8000c0s6b1",
+            "Xname": "x8000c0s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1026,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001026"
+                ]
+            }
+        },
+        "x8000c0s6b1n1": {
+            "Parent": "x8000c0s6b1",
+            "Xname": "x8000c0s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1027,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001027"
+                ]
+            }
+        },
+        "x8000c0s7b0n0": {
+            "Parent": "x8000c0s7b0",
+            "Xname": "x8000c0s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1028,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001028"
+                ]
+            }
+        },
+        "x8000c0s7b0n1": {
+            "Parent": "x8000c0s7b0",
+            "Xname": "x8000c0s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1029,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001029"
+                ]
+            }
+        },
+        "x8000c0s7b1n0": {
+            "Parent": "x8000c0s7b1",
+            "Xname": "x8000c0s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1030,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001030"
+                ]
+            }
+        },
+        "x8000c0s7b1n1": {
+            "Parent": "x8000c0s7b1",
+            "Xname": "x8000c0s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1031,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001031"
+                ]
+            }
+        },
+        "x8000c4h33s1": {
+            "Parent": "x8000c4h33",
+            "Xname": "x8000c4h33s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.4",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-001"
+                ]
+            }
+        },
+        "x8000c4h34s1": {
+            "Parent": "x8000c4h34",
+            "Xname": "x8000c4h34s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.5",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-002"
+                ]
+            }
+        },
+        "x8000c4h35s1": {
+            "Parent": "x8000c4h35",
+            "Xname": "x8000c4h35s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.6",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-003"
+                ]
+            }
+        },
+        "x8000c4h36s1": {
+            "Parent": "x8000c4h36",
+            "Xname": "x8000c4h36s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.7",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-004"
+                ]
+            }
+        },
+        "x8000c4h37s1": {
+            "Parent": "x8000c4h37",
+            "Xname": "x8000c4h37s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.2",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-001"
+                ]
+            }
+        },
+        "x8000c4h38s1": {
+            "Parent": "x8000c4h38",
+            "Xname": "x8000c4h38s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.3",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-002"
+                ]
+            }
+        },
+        "x8000c4r39b0": {
+            "Parent": "x8000c4r39",
+            "Xname": "x8000c4r39b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x8000c4r39b0",
+                "Password": "vault://hms-creds/x8000c4r39b0"
+            }
+        },
+        "x8000c4r40b0": {
+            "Parent": "x8000c4r40",
+            "Xname": "x8000c4r40b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x8000c4r40b0",
+                "Password": "vault://hms-creds/x8000c4r40b0"
+            }
+        },
+        "x8000c4s10b0n0": {
+            "Parent": "x8000c4s10b0",
+            "Xname": "x8000c4s10b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100001,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s003"
+                ]
+            }
+        },
+        "x8000c4s15b0n0": {
+            "Parent": "x8000c4s15b0",
+            "Xname": "x8000c4s15b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan01"
+                ]
+            }
+        },
+        "x8000c4s16b0n0": {
+            "Parent": "x8000c4s16b0",
+            "Xname": "x8000c4s16b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan02"
+                ]
+            }
+        },
+        "x8000c4s1b0n0": {
+            "Parent": "x8000c4s1b0",
+            "Xname": "x8000c4s1b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100010,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m001"
+                ]
+            }
+        },
+        "x8000c4s24b1n0": {
+            "Parent": "x8000c4s24b1",
+            "Xname": "x8000c4s24b1n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid000001"
+                ]
+            }
+        },
+        "x8000c4s2b0n0": {
+            "Parent": "x8000c4s2b0",
+            "Xname": "x8000c4s2b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100009,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m002"
+                ]
+            }
+        },
+        "x8000c4s3b0n0": {
+            "Parent": "x8000c4s3b0",
+            "Xname": "x8000c4s3b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100008,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m003"
+                ]
+            }
+        },
+        "x8000c4s4b0n0": {
+            "Parent": "x8000c4s4b0",
+            "Xname": "x8000c4s4b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100007,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w001"
+                ]
+            }
+        },
+        "x8000c4s5b0n0": {
+            "Parent": "x8000c4s5b0",
+            "Xname": "x8000c4s5b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100006,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w002"
+                ]
+            }
+        },
+        "x8000c4s6b0n0": {
+            "Parent": "x8000c4s6b0",
+            "Xname": "x8000c4s6b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100005,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w003"
+                ]
+            }
+        },
+        "x8000c4s7b0n0": {
+            "Parent": "x8000c4s7b0",
+            "Xname": "x8000c4s7b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100004,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w004"
+                ]
+            }
+        },
+        "x8000c4s8b0n0": {
+            "Parent": "x8000c4s8b0",
+            "Xname": "x8000c4s8b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100003,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s001"
+                ]
+            }
+        },
+        "x8000c4s9b0n0": {
+            "Parent": "x8000c4s9b0",
+            "Xname": "x8000c4s9b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100002,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s002"
+                ]
+            }
+        },
+        "x8000c4w31": {
+            "Parent": "x8000c4",
+            "Xname": "x8000c4w31",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.8",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x8000c4w31",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x8000c4w31",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-001"
+                ]
+            }
+        },
+        "x8000c4w31j29": {
+            "Parent": "x8000c4w31",
+            "Xname": "x8000c4w31j29",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x8000c4s24b1"
+                ],
+                "VendorName": "1/1/29"
+            }
+        },
+        "x8000c4w31j34": {
+            "Parent": "x8000c4w31",
+            "Xname": "x8000c4w31j34",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x8000c4s2b0"
+                ],
+                "VendorName": "1/1/34"
+            }
+        },
+        "x8000c4w31j35": {
+            "Parent": "x8000c4w31",
+            "Xname": "x8000c4w31j35",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x8000c4s4b0"
+                ],
+                "VendorName": "1/1/35"
+            }
+        },
+        "x8000c4w31j36": {
+            "Parent": "x8000c4w31",
+            "Xname": "x8000c4w31j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x8000c4s5b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x8000c4w31j37": {
+            "Parent": "x8000c4w31",
+            "Xname": "x8000c4w31j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x8000c4s6b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x8000c4w31j38": {
+            "Parent": "x8000c4w31",
+            "Xname": "x8000c4w31j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x8000c4s8b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x8000c4w31j39": {
+            "Parent": "x8000c4w31",
+            "Xname": "x8000c4w31j39",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x8000c4s9b0"
+                ],
+                "VendorName": "1/1/39"
+            }
+        },
+        "x8000c4w31j40": {
+            "Parent": "x8000c4w31",
+            "Xname": "x8000c4w31j40",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x8000c4s15b0"
+                ],
+                "VendorName": "1/1/40"
+            }
+        },
+        "x8000c4w31j41": {
+            "Parent": "x8000c4w31",
+            "Xname": "x8000c4w31j41",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x8000c4s16b0"
+                ],
+                "VendorName": "1/1/41"
+            }
+        },
+        "x8000c4w31j47": {
+            "Parent": "x8000c4w31",
+            "Xname": "x8000c4w31j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x8000c4r39b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x8000c4w31j48": {
+            "Parent": "x8000c4w31",
+            "Xname": "x8000c4w31j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x8000m0"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x8000c4w32": {
+            "Parent": "x8000c4",
+            "Xname": "x8000c4w32",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.9",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x8000c4w32",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x8000c4w32",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-002"
+                ]
+            }
+        },
+        "x8000c4w32j36": {
+            "Parent": "x8000c4w32",
+            "Xname": "x8000c4w32j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x8000c4s3b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x8000c4w32j37": {
+            "Parent": "x8000c4w32",
+            "Xname": "x8000c4w32j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x8000c4s7b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x8000c4w32j38": {
+            "Parent": "x8000c4w32",
+            "Xname": "x8000c4w32j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x8000c4s10b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x8000c4w32j47": {
+            "Parent": "x8000c4w32",
+            "Xname": "x8000c4w32j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x8000c4r40b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x8000c4w32j48": {
+            "Parent": "x8000c4w32",
+            "Xname": "x8000c4w32j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x8000m1"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x8000m0": {
+            "Parent": "x8000",
+            "Xname": "x8000m0",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        },
+        "x8000m1": {
+            "Parent": "x8000",
+            "Xname": "x8000m1",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        }
+    },
+    "Networks": {}
+}

--- a/testdata/fixtures/sls/EX2500_River.json
+++ b/testdata/fixtures/sls/EX2500_River.json
@@ -1,0 +1,3469 @@
+{
+    "Hardware": {
+        "d0w1": {
+            "Parent": "d0",
+            "Xname": "d0w1",
+            "Type": "comptype_cdu_mgmt_switch",
+            "Class": "Mountain",
+            "TypeString": "CDUMgmtSwitch",
+            "ExtraProperties": {
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-cdu-001"
+                ]
+            }
+        },
+        "d0w2": {
+            "Parent": "d0",
+            "Xname": "d0w2",
+            "Type": "comptype_cdu_mgmt_switch",
+            "Class": "Mountain",
+            "TypeString": "CDUMgmtSwitch",
+            "ExtraProperties": {
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-cdu-002"
+                ]
+            }
+        },
+        "x3000": {
+            "Parent": "s0",
+            "Xname": "x3000",
+            "Type": "comptype_cabinet",
+            "Class": "River",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    },
+                    "ncn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    }
+                }
+            }
+        },
+        "x3000c0h33s1": {
+            "Parent": "x3000c0h33",
+            "Xname": "x3000c0h33s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.4",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-001"
+                ]
+            }
+        },
+        "x3000c0h34s1": {
+            "Parent": "x3000c0h34",
+            "Xname": "x3000c0h34s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.5",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-002"
+                ]
+            }
+        },
+        "x3000c0h35s1": {
+            "Parent": "x3000c0h35",
+            "Xname": "x3000c0h35s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.6",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-003"
+                ]
+            }
+        },
+        "x3000c0h36s1": {
+            "Parent": "x3000c0h36",
+            "Xname": "x3000c0h36s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.7",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-004"
+                ]
+            }
+        },
+        "x3000c0h37s1": {
+            "Parent": "x3000c0h37",
+            "Xname": "x3000c0h37s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.2",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-001"
+                ]
+            }
+        },
+        "x3000c0h38s1": {
+            "Parent": "x3000c0h38",
+            "Xname": "x3000c0h38s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.3",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-002"
+                ]
+            }
+        },
+        "x3000c0r39b0": {
+            "Parent": "x3000c0r39",
+            "Xname": "x3000c0r39b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x3000c0r39b0",
+                "Password": "vault://hms-creds/x3000c0r39b0"
+            }
+        },
+        "x3000c0r40b0": {
+            "Parent": "x3000c0r40",
+            "Xname": "x3000c0r40b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x3000c0r40b0",
+                "Password": "vault://hms-creds/x3000c0r40b0"
+            }
+        },
+        "x3000c0s10b0n0": {
+            "Parent": "x3000c0s10b0",
+            "Xname": "x3000c0s10b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100001,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s003"
+                ]
+            }
+        },
+        "x3000c0s15b0n0": {
+            "Parent": "x3000c0s15b0",
+            "Xname": "x3000c0s15b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan01"
+                ]
+            }
+        },
+        "x3000c0s16b0n0": {
+            "Parent": "x3000c0s16b0",
+            "Xname": "x3000c0s16b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan02"
+                ]
+            }
+        },
+        "x3000c0s1b0n0": {
+            "Parent": "x3000c0s1b0",
+            "Xname": "x3000c0s1b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100010,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m001"
+                ]
+            }
+        },
+        "x3000c0s24b0n0": {
+            "Parent": "x3000c0s24b0",
+            "Xname": "x3000c0s24b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "@rie.mockup": "XL675d_A40",
+                "NID": 1,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid000001"
+                ]
+            }
+        },
+        "x3000c0s2b0n0": {
+            "Parent": "x3000c0s2b0",
+            "Xname": "x3000c0s2b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100009,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m002"
+                ]
+            }
+        },
+        "x3000c0s3b0n0": {
+            "Parent": "x3000c0s3b0",
+            "Xname": "x3000c0s3b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100008,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m003"
+                ]
+            }
+        },
+        "x3000c0s4b0n0": {
+            "Parent": "x3000c0s4b0",
+            "Xname": "x3000c0s4b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100007,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w001"
+                ]
+            }
+        },
+        "x3000c0s5b0n0": {
+            "Parent": "x3000c0s5b0",
+            "Xname": "x3000c0s5b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100006,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w002"
+                ]
+            }
+        },
+        "x3000c0s6b0n0": {
+            "Parent": "x3000c0s6b0",
+            "Xname": "x3000c0s6b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100005,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w003"
+                ]
+            }
+        },
+        "x3000c0s7b0n0": {
+            "Parent": "x3000c0s7b0",
+            "Xname": "x3000c0s7b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100004,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w004"
+                ]
+            }
+        },
+        "x3000c0s8b0n0": {
+            "Parent": "x3000c0s8b0",
+            "Xname": "x3000c0s8b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100003,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s001"
+                ]
+            }
+        },
+        "x3000c0s9b0n0": {
+            "Parent": "x3000c0s9b0",
+            "Xname": "x3000c0s9b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100002,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s002"
+                ]
+            }
+        },
+        "x3000c0w31": {
+            "Parent": "x3000c0",
+            "Xname": "x3000c0w31",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.8",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-001"
+                ]
+            }
+        },
+        "x3000c0w31j29": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j29",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s24b0"
+                ],
+                "VendorName": "1/1/29"
+            }
+        },
+        "x3000c0w31j34": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j34",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s2b0"
+                ],
+                "VendorName": "1/1/34"
+            }
+        },
+        "x3000c0w31j35": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j35",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s4b0"
+                ],
+                "VendorName": "1/1/35"
+            }
+        },
+        "x3000c0w31j36": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s5b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x3000c0w31j37": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s6b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x3000c0w31j38": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s8b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x3000c0w31j39": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j39",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s9b0"
+                ],
+                "VendorName": "1/1/39"
+            }
+        },
+        "x3000c0w31j40": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j40",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s15b0"
+                ],
+                "VendorName": "1/1/40"
+            }
+        },
+        "x3000c0w31j41": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j41",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s16b0"
+                ],
+                "VendorName": "1/1/41"
+            }
+        },
+        "x3000c0w31j47": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0r39b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x3000c0w31j48": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000m0"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x3000c0w32": {
+            "Parent": "x3000c0",
+            "Xname": "x3000c0w32",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.9",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x3000c0w32",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x3000c0w32",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-002"
+                ]
+            }
+        },
+        "x3000c0w32j36": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s3b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x3000c0w32j37": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s7b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x3000c0w32j38": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s10b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x3000c0w32j47": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0r40b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x3000c0w32j48": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000m1"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x3000m0": {
+            "Parent": "x3000",
+            "Xname": "x3000m0",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        },
+        "x3000m1": {
+            "Parent": "x3000",
+            "Xname": "x3000m1",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        },
+        "x8001": {
+            "Parent": "s0",
+            "Xname": "x8001",
+            "Type": "comptype_cabinet",
+            "Class": "Hill",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Model": "EX2500",
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.104.0.0/22",
+                            "Gateway": "10.104.0.1",
+                            "VLan": 3004
+                        },
+                        "NMN": {
+                            "CIDR": "10.100.0.0/22",
+                            "Gateway": "10.100.0.1",
+                            "VLan": 2004
+                        }
+                    }
+                }
+            }
+        },
+        "x8001c0": {
+            "Parent": "x8001",
+            "Xname": "x8001c0",
+            "Type": "comptype_chassis",
+            "Class": "Hill",
+            "TypeString": "Chassis"
+        },
+        "x8001c0b0": {
+            "Parent": "x8001c0",
+            "Xname": "x8001c0b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Hill",
+            "TypeString": "ChassisBMC"
+        },
+        "x8001c0s0b0n0": {
+            "Parent": "x8001c0s0b0",
+            "Xname": "x8001c0s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1000,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001000"
+                ]
+            }
+        },
+        "x8001c0s0b0n1": {
+            "Parent": "x8001c0s0b0",
+            "Xname": "x8001c0s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1001,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001001"
+                ]
+            }
+        },
+        "x8001c0s0b1n0": {
+            "Parent": "x8001c0s0b1",
+            "Xname": "x8001c0s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1002,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001002"
+                ]
+            }
+        },
+        "x8001c0s0b1n1": {
+            "Parent": "x8001c0s0b1",
+            "Xname": "x8001c0s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1003,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001003"
+                ]
+            }
+        },
+        "x8001c0s1b0n0": {
+            "Parent": "x8001c0s1b0",
+            "Xname": "x8001c0s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1004,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001004"
+                ]
+            }
+        },
+        "x8001c0s1b0n1": {
+            "Parent": "x8001c0s1b0",
+            "Xname": "x8001c0s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1005,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001005"
+                ]
+            }
+        },
+        "x8001c0s1b1n0": {
+            "Parent": "x8001c0s1b1",
+            "Xname": "x8001c0s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1006,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001006"
+                ]
+            }
+        },
+        "x8001c0s1b1n1": {
+            "Parent": "x8001c0s1b1",
+            "Xname": "x8001c0s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1007,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001007"
+                ]
+            }
+        },
+        "x8001c0s2b0n0": {
+            "Parent": "x8001c0s2b0",
+            "Xname": "x8001c0s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1008,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001008"
+                ]
+            }
+        },
+        "x8001c0s2b0n1": {
+            "Parent": "x8001c0s2b0",
+            "Xname": "x8001c0s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1009,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001009"
+                ]
+            }
+        },
+        "x8001c0s2b1n0": {
+            "Parent": "x8001c0s2b1",
+            "Xname": "x8001c0s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1010,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001010"
+                ]
+            }
+        },
+        "x8001c0s2b1n1": {
+            "Parent": "x8001c0s2b1",
+            "Xname": "x8001c0s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1011,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001011"
+                ]
+            }
+        },
+        "x8001c0s3b0n0": {
+            "Parent": "x8001c0s3b0",
+            "Xname": "x8001c0s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1012,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001012"
+                ]
+            }
+        },
+        "x8001c0s3b0n1": {
+            "Parent": "x8001c0s3b0",
+            "Xname": "x8001c0s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1013,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001013"
+                ]
+            }
+        },
+        "x8001c0s3b1n0": {
+            "Parent": "x8001c0s3b1",
+            "Xname": "x8001c0s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1014,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001014"
+                ]
+            }
+        },
+        "x8001c0s3b1n1": {
+            "Parent": "x8001c0s3b1",
+            "Xname": "x8001c0s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1015,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001015"
+                ]
+            }
+        },
+        "x8001c0s4b0n0": {
+            "Parent": "x8001c0s4b0",
+            "Xname": "x8001c0s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1016,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001016"
+                ]
+            }
+        },
+        "x8001c0s4b0n1": {
+            "Parent": "x8001c0s4b0",
+            "Xname": "x8001c0s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1017,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001017"
+                ]
+            }
+        },
+        "x8001c0s4b1n0": {
+            "Parent": "x8001c0s4b1",
+            "Xname": "x8001c0s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1018,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001018"
+                ]
+            }
+        },
+        "x8001c0s4b1n1": {
+            "Parent": "x8001c0s4b1",
+            "Xname": "x8001c0s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1019,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001019"
+                ]
+            }
+        },
+        "x8001c0s5b0n0": {
+            "Parent": "x8001c0s5b0",
+            "Xname": "x8001c0s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1020,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001020"
+                ]
+            }
+        },
+        "x8001c0s5b0n1": {
+            "Parent": "x8001c0s5b0",
+            "Xname": "x8001c0s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1021,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001021"
+                ]
+            }
+        },
+        "x8001c0s5b1n0": {
+            "Parent": "x8001c0s5b1",
+            "Xname": "x8001c0s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1022,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001022"
+                ]
+            }
+        },
+        "x8001c0s5b1n1": {
+            "Parent": "x8001c0s5b1",
+            "Xname": "x8001c0s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1023,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001023"
+                ]
+            }
+        },
+        "x8001c0s6b0n0": {
+            "Parent": "x8001c0s6b0",
+            "Xname": "x8001c0s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1024,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001024"
+                ]
+            }
+        },
+        "x8001c0s6b0n1": {
+            "Parent": "x8001c0s6b0",
+            "Xname": "x8001c0s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1025,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001025"
+                ]
+            }
+        },
+        "x8001c0s6b1n0": {
+            "Parent": "x8001c0s6b1",
+            "Xname": "x8001c0s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1026,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001026"
+                ]
+            }
+        },
+        "x8001c0s6b1n1": {
+            "Parent": "x8001c0s6b1",
+            "Xname": "x8001c0s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1027,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001027"
+                ]
+            }
+        },
+        "x8001c0s7b0n0": {
+            "Parent": "x8001c0s7b0",
+            "Xname": "x8001c0s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1028,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001028"
+                ]
+            }
+        },
+        "x8001c0s7b0n1": {
+            "Parent": "x8001c0s7b0",
+            "Xname": "x8001c0s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1029,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001029"
+                ]
+            }
+        },
+        "x8001c0s7b1n0": {
+            "Parent": "x8001c0s7b1",
+            "Xname": "x8001c0s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1030,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001030"
+                ]
+            }
+        },
+        "x8001c0s7b1n1": {
+            "Parent": "x8001c0s7b1",
+            "Xname": "x8001c0s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1031,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001031"
+                ]
+            }
+        },
+        "x8002": {
+            "Parent": "s0",
+            "Xname": "x8002",
+            "Type": "comptype_cabinet",
+            "Class": "Hill",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Model": "EX2500",
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.104.4.0/22",
+                            "Gateway": "10.104.4.1",
+                            "VLan": 3005
+                        },
+                        "NMN": {
+                            "CIDR": "10.100.4.0/22",
+                            "Gateway": "10.100.4.1",
+                            "VLan": 2005
+                        }
+                    }
+                }
+            }
+        },
+        "x8002c0": {
+            "Parent": "x8002",
+            "Xname": "x8002c0",
+            "Type": "comptype_chassis",
+            "Class": "Hill",
+            "TypeString": "Chassis"
+        },
+        "x8002c0b0": {
+            "Parent": "x8002c0",
+            "Xname": "x8002c0b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Hill",
+            "TypeString": "ChassisBMC"
+        },
+        "x8002c0s0b0n0": {
+            "Parent": "x8002c0s0b0",
+            "Xname": "x8002c0s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1032,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001032"
+                ]
+            }
+        },
+        "x8002c0s0b0n1": {
+            "Parent": "x8002c0s0b0",
+            "Xname": "x8002c0s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1033,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001033"
+                ]
+            }
+        },
+        "x8002c0s0b1n0": {
+            "Parent": "x8002c0s0b1",
+            "Xname": "x8002c0s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1034,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001034"
+                ]
+            }
+        },
+        "x8002c0s0b1n1": {
+            "Parent": "x8002c0s0b1",
+            "Xname": "x8002c0s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1035,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001035"
+                ]
+            }
+        },
+        "x8002c0s1b0n0": {
+            "Parent": "x8002c0s1b0",
+            "Xname": "x8002c0s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1036,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001036"
+                ]
+            }
+        },
+        "x8002c0s1b0n1": {
+            "Parent": "x8002c0s1b0",
+            "Xname": "x8002c0s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1037,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001037"
+                ]
+            }
+        },
+        "x8002c0s1b1n0": {
+            "Parent": "x8002c0s1b1",
+            "Xname": "x8002c0s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1038,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001038"
+                ]
+            }
+        },
+        "x8002c0s1b1n1": {
+            "Parent": "x8002c0s1b1",
+            "Xname": "x8002c0s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1039,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001039"
+                ]
+            }
+        },
+        "x8002c0s2b0n0": {
+            "Parent": "x8002c0s2b0",
+            "Xname": "x8002c0s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1040,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001040"
+                ]
+            }
+        },
+        "x8002c0s2b0n1": {
+            "Parent": "x8002c0s2b0",
+            "Xname": "x8002c0s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1041,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001041"
+                ]
+            }
+        },
+        "x8002c0s2b1n0": {
+            "Parent": "x8002c0s2b1",
+            "Xname": "x8002c0s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1042,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001042"
+                ]
+            }
+        },
+        "x8002c0s2b1n1": {
+            "Parent": "x8002c0s2b1",
+            "Xname": "x8002c0s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1043,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001043"
+                ]
+            }
+        },
+        "x8002c0s3b0n0": {
+            "Parent": "x8002c0s3b0",
+            "Xname": "x8002c0s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1044,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001044"
+                ]
+            }
+        },
+        "x8002c0s3b0n1": {
+            "Parent": "x8002c0s3b0",
+            "Xname": "x8002c0s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1045,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001045"
+                ]
+            }
+        },
+        "x8002c0s3b1n0": {
+            "Parent": "x8002c0s3b1",
+            "Xname": "x8002c0s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1046,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001046"
+                ]
+            }
+        },
+        "x8002c0s3b1n1": {
+            "Parent": "x8002c0s3b1",
+            "Xname": "x8002c0s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1047,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001047"
+                ]
+            }
+        },
+        "x8002c0s4b0n0": {
+            "Parent": "x8002c0s4b0",
+            "Xname": "x8002c0s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1048,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001048"
+                ]
+            }
+        },
+        "x8002c0s4b0n1": {
+            "Parent": "x8002c0s4b0",
+            "Xname": "x8002c0s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1049,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001049"
+                ]
+            }
+        },
+        "x8002c0s4b1n0": {
+            "Parent": "x8002c0s4b1",
+            "Xname": "x8002c0s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1050,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001050"
+                ]
+            }
+        },
+        "x8002c0s4b1n1": {
+            "Parent": "x8002c0s4b1",
+            "Xname": "x8002c0s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1051,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001051"
+                ]
+            }
+        },
+        "x8002c0s5b0n0": {
+            "Parent": "x8002c0s5b0",
+            "Xname": "x8002c0s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1052,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001052"
+                ]
+            }
+        },
+        "x8002c0s5b0n1": {
+            "Parent": "x8002c0s5b0",
+            "Xname": "x8002c0s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1053,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001053"
+                ]
+            }
+        },
+        "x8002c0s5b1n0": {
+            "Parent": "x8002c0s5b1",
+            "Xname": "x8002c0s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1054,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001054"
+                ]
+            }
+        },
+        "x8002c0s5b1n1": {
+            "Parent": "x8002c0s5b1",
+            "Xname": "x8002c0s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1055,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001055"
+                ]
+            }
+        },
+        "x8002c0s6b0n0": {
+            "Parent": "x8002c0s6b0",
+            "Xname": "x8002c0s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1056,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001056"
+                ]
+            }
+        },
+        "x8002c0s6b0n1": {
+            "Parent": "x8002c0s6b0",
+            "Xname": "x8002c0s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1057,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001057"
+                ]
+            }
+        },
+        "x8002c0s6b1n0": {
+            "Parent": "x8002c0s6b1",
+            "Xname": "x8002c0s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1058,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001058"
+                ]
+            }
+        },
+        "x8002c0s6b1n1": {
+            "Parent": "x8002c0s6b1",
+            "Xname": "x8002c0s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1059,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001059"
+                ]
+            }
+        },
+        "x8002c0s7b0n0": {
+            "Parent": "x8002c0s7b0",
+            "Xname": "x8002c0s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1060,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001060"
+                ]
+            }
+        },
+        "x8002c0s7b0n1": {
+            "Parent": "x8002c0s7b0",
+            "Xname": "x8002c0s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1061,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001061"
+                ]
+            }
+        },
+        "x8002c0s7b1n0": {
+            "Parent": "x8002c0s7b1",
+            "Xname": "x8002c0s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1062,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001062"
+                ]
+            }
+        },
+        "x8002c0s7b1n1": {
+            "Parent": "x8002c0s7b1",
+            "Xname": "x8002c0s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1063,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001063"
+                ]
+            }
+        },
+        "x8002c1": {
+            "Parent": "x8002",
+            "Xname": "x8002c1",
+            "Type": "comptype_chassis",
+            "Class": "Hill",
+            "TypeString": "Chassis"
+        },
+        "x8002c1b0": {
+            "Parent": "x8002c1",
+            "Xname": "x8002c1b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Hill",
+            "TypeString": "ChassisBMC"
+        },
+        "x8002c1s0b0n0": {
+            "Parent": "x8002c1s0b0",
+            "Xname": "x8002c1s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1064,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001064"
+                ]
+            }
+        },
+        "x8002c1s0b0n1": {
+            "Parent": "x8002c1s0b0",
+            "Xname": "x8002c1s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1065,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001065"
+                ]
+            }
+        },
+        "x8002c1s0b1n0": {
+            "Parent": "x8002c1s0b1",
+            "Xname": "x8002c1s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1066,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001066"
+                ]
+            }
+        },
+        "x8002c1s0b1n1": {
+            "Parent": "x8002c1s0b1",
+            "Xname": "x8002c1s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1067,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001067"
+                ]
+            }
+        },
+        "x8002c1s1b0n0": {
+            "Parent": "x8002c1s1b0",
+            "Xname": "x8002c1s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1068,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001068"
+                ]
+            }
+        },
+        "x8002c1s1b0n1": {
+            "Parent": "x8002c1s1b0",
+            "Xname": "x8002c1s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1069,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001069"
+                ]
+            }
+        },
+        "x8002c1s1b1n0": {
+            "Parent": "x8002c1s1b1",
+            "Xname": "x8002c1s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1070,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001070"
+                ]
+            }
+        },
+        "x8002c1s1b1n1": {
+            "Parent": "x8002c1s1b1",
+            "Xname": "x8002c1s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1071,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001071"
+                ]
+            }
+        },
+        "x8002c1s2b0n0": {
+            "Parent": "x8002c1s2b0",
+            "Xname": "x8002c1s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1072,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001072"
+                ]
+            }
+        },
+        "x8002c1s2b0n1": {
+            "Parent": "x8002c1s2b0",
+            "Xname": "x8002c1s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1073,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001073"
+                ]
+            }
+        },
+        "x8002c1s2b1n0": {
+            "Parent": "x8002c1s2b1",
+            "Xname": "x8002c1s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1074,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001074"
+                ]
+            }
+        },
+        "x8002c1s2b1n1": {
+            "Parent": "x8002c1s2b1",
+            "Xname": "x8002c1s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1075,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001075"
+                ]
+            }
+        },
+        "x8002c1s3b0n0": {
+            "Parent": "x8002c1s3b0",
+            "Xname": "x8002c1s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1076,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001076"
+                ]
+            }
+        },
+        "x8002c1s3b0n1": {
+            "Parent": "x8002c1s3b0",
+            "Xname": "x8002c1s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1077,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001077"
+                ]
+            }
+        },
+        "x8002c1s3b1n0": {
+            "Parent": "x8002c1s3b1",
+            "Xname": "x8002c1s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1078,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001078"
+                ]
+            }
+        },
+        "x8002c1s3b1n1": {
+            "Parent": "x8002c1s3b1",
+            "Xname": "x8002c1s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1079,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001079"
+                ]
+            }
+        },
+        "x8002c1s4b0n0": {
+            "Parent": "x8002c1s4b0",
+            "Xname": "x8002c1s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1080,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001080"
+                ]
+            }
+        },
+        "x8002c1s4b0n1": {
+            "Parent": "x8002c1s4b0",
+            "Xname": "x8002c1s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1081,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001081"
+                ]
+            }
+        },
+        "x8002c1s4b1n0": {
+            "Parent": "x8002c1s4b1",
+            "Xname": "x8002c1s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1082,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001082"
+                ]
+            }
+        },
+        "x8002c1s4b1n1": {
+            "Parent": "x8002c1s4b1",
+            "Xname": "x8002c1s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1083,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001083"
+                ]
+            }
+        },
+        "x8002c1s5b0n0": {
+            "Parent": "x8002c1s5b0",
+            "Xname": "x8002c1s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1084,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001084"
+                ]
+            }
+        },
+        "x8002c1s5b0n1": {
+            "Parent": "x8002c1s5b0",
+            "Xname": "x8002c1s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1085,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001085"
+                ]
+            }
+        },
+        "x8002c1s5b1n0": {
+            "Parent": "x8002c1s5b1",
+            "Xname": "x8002c1s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1086,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001086"
+                ]
+            }
+        },
+        "x8002c1s5b1n1": {
+            "Parent": "x8002c1s5b1",
+            "Xname": "x8002c1s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1087,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001087"
+                ]
+            }
+        },
+        "x8002c1s6b0n0": {
+            "Parent": "x8002c1s6b0",
+            "Xname": "x8002c1s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1088,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001088"
+                ]
+            }
+        },
+        "x8002c1s6b0n1": {
+            "Parent": "x8002c1s6b0",
+            "Xname": "x8002c1s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1089,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001089"
+                ]
+            }
+        },
+        "x8002c1s6b1n0": {
+            "Parent": "x8002c1s6b1",
+            "Xname": "x8002c1s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1090,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001090"
+                ]
+            }
+        },
+        "x8002c1s6b1n1": {
+            "Parent": "x8002c1s6b1",
+            "Xname": "x8002c1s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1091,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001091"
+                ]
+            }
+        },
+        "x8002c1s7b0n0": {
+            "Parent": "x8002c1s7b0",
+            "Xname": "x8002c1s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1092,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001092"
+                ]
+            }
+        },
+        "x8002c1s7b0n1": {
+            "Parent": "x8002c1s7b0",
+            "Xname": "x8002c1s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1093,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001093"
+                ]
+            }
+        },
+        "x8002c1s7b1n0": {
+            "Parent": "x8002c1s7b1",
+            "Xname": "x8002c1s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1094,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001094"
+                ]
+            }
+        },
+        "x8002c1s7b1n1": {
+            "Parent": "x8002c1s7b1",
+            "Xname": "x8002c1s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1095,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001095"
+                ]
+            }
+        },
+        "x8003": {
+            "Parent": "s0",
+            "Xname": "x8003",
+            "Type": "comptype_cabinet",
+            "Class": "Hill",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Model": "EX2500",
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.104.8.0/22",
+                            "Gateway": "10.104.8.1",
+                            "VLan": 3006
+                        },
+                        "NMN": {
+                            "CIDR": "10.100.8.0/22",
+                            "Gateway": "10.100.8.1",
+                            "VLan": 2006
+                        }
+                    }
+                }
+            }
+        },
+        "x8003c0": {
+            "Parent": "x8003",
+            "Xname": "x8003c0",
+            "Type": "comptype_chassis",
+            "Class": "Hill",
+            "TypeString": "Chassis"
+        },
+        "x8003c0b0": {
+            "Parent": "x8003c0",
+            "Xname": "x8003c0b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Hill",
+            "TypeString": "ChassisBMC"
+        },
+        "x8003c0s0b0n0": {
+            "Parent": "x8003c0s0b0",
+            "Xname": "x8003c0s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1096,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001096"
+                ]
+            }
+        },
+        "x8003c0s0b0n1": {
+            "Parent": "x8003c0s0b0",
+            "Xname": "x8003c0s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1097,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001097"
+                ]
+            }
+        },
+        "x8003c0s0b1n0": {
+            "Parent": "x8003c0s0b1",
+            "Xname": "x8003c0s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1098,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001098"
+                ]
+            }
+        },
+        "x8003c0s0b1n1": {
+            "Parent": "x8003c0s0b1",
+            "Xname": "x8003c0s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1099,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001099"
+                ]
+            }
+        },
+        "x8003c0s1b0n0": {
+            "Parent": "x8003c0s1b0",
+            "Xname": "x8003c0s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1100,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001100"
+                ]
+            }
+        },
+        "x8003c0s1b0n1": {
+            "Parent": "x8003c0s1b0",
+            "Xname": "x8003c0s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1101,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001101"
+                ]
+            }
+        },
+        "x8003c0s1b1n0": {
+            "Parent": "x8003c0s1b1",
+            "Xname": "x8003c0s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1102,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001102"
+                ]
+            }
+        },
+        "x8003c0s1b1n1": {
+            "Parent": "x8003c0s1b1",
+            "Xname": "x8003c0s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1103,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001103"
+                ]
+            }
+        },
+        "x8003c0s2b0n0": {
+            "Parent": "x8003c0s2b0",
+            "Xname": "x8003c0s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1104,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001104"
+                ]
+            }
+        },
+        "x8003c0s2b0n1": {
+            "Parent": "x8003c0s2b0",
+            "Xname": "x8003c0s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1105,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001105"
+                ]
+            }
+        },
+        "x8003c0s2b1n0": {
+            "Parent": "x8003c0s2b1",
+            "Xname": "x8003c0s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1106,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001106"
+                ]
+            }
+        },
+        "x8003c0s2b1n1": {
+            "Parent": "x8003c0s2b1",
+            "Xname": "x8003c0s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1107,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001107"
+                ]
+            }
+        },
+        "x8003c0s3b0n0": {
+            "Parent": "x8003c0s3b0",
+            "Xname": "x8003c0s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1108,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001108"
+                ]
+            }
+        },
+        "x8003c0s3b0n1": {
+            "Parent": "x8003c0s3b0",
+            "Xname": "x8003c0s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1109,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001109"
+                ]
+            }
+        },
+        "x8003c0s3b1n0": {
+            "Parent": "x8003c0s3b1",
+            "Xname": "x8003c0s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1110,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001110"
+                ]
+            }
+        },
+        "x8003c0s3b1n1": {
+            "Parent": "x8003c0s3b1",
+            "Xname": "x8003c0s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1111,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001111"
+                ]
+            }
+        },
+        "x8003c0s4b0n0": {
+            "Parent": "x8003c0s4b0",
+            "Xname": "x8003c0s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1112,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001112"
+                ]
+            }
+        },
+        "x8003c0s4b0n1": {
+            "Parent": "x8003c0s4b0",
+            "Xname": "x8003c0s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1113,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001113"
+                ]
+            }
+        },
+        "x8003c0s4b1n0": {
+            "Parent": "x8003c0s4b1",
+            "Xname": "x8003c0s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1114,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001114"
+                ]
+            }
+        },
+        "x8003c0s4b1n1": {
+            "Parent": "x8003c0s4b1",
+            "Xname": "x8003c0s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1115,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001115"
+                ]
+            }
+        },
+        "x8003c0s5b0n0": {
+            "Parent": "x8003c0s5b0",
+            "Xname": "x8003c0s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1116,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001116"
+                ]
+            }
+        },
+        "x8003c0s5b0n1": {
+            "Parent": "x8003c0s5b0",
+            "Xname": "x8003c0s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1117,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001117"
+                ]
+            }
+        },
+        "x8003c0s5b1n0": {
+            "Parent": "x8003c0s5b1",
+            "Xname": "x8003c0s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1118,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001118"
+                ]
+            }
+        },
+        "x8003c0s5b1n1": {
+            "Parent": "x8003c0s5b1",
+            "Xname": "x8003c0s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1119,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001119"
+                ]
+            }
+        },
+        "x8003c0s6b0n0": {
+            "Parent": "x8003c0s6b0",
+            "Xname": "x8003c0s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1120,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001120"
+                ]
+            }
+        },
+        "x8003c0s6b0n1": {
+            "Parent": "x8003c0s6b0",
+            "Xname": "x8003c0s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1121,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001121"
+                ]
+            }
+        },
+        "x8003c0s6b1n0": {
+            "Parent": "x8003c0s6b1",
+            "Xname": "x8003c0s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1122,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001122"
+                ]
+            }
+        },
+        "x8003c0s6b1n1": {
+            "Parent": "x8003c0s6b1",
+            "Xname": "x8003c0s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1123,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001123"
+                ]
+            }
+        },
+        "x8003c0s7b0n0": {
+            "Parent": "x8003c0s7b0",
+            "Xname": "x8003c0s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1124,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001124"
+                ]
+            }
+        },
+        "x8003c0s7b0n1": {
+            "Parent": "x8003c0s7b0",
+            "Xname": "x8003c0s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1125,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001125"
+                ]
+            }
+        },
+        "x8003c0s7b1n0": {
+            "Parent": "x8003c0s7b1",
+            "Xname": "x8003c0s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1126,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001126"
+                ]
+            }
+        },
+        "x8003c0s7b1n1": {
+            "Parent": "x8003c0s7b1",
+            "Xname": "x8003c0s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1127,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001127"
+                ]
+            }
+        },
+        "x8003c1": {
+            "Parent": "x8003",
+            "Xname": "x8003c1",
+            "Type": "comptype_chassis",
+            "Class": "Hill",
+            "TypeString": "Chassis"
+        },
+        "x8003c1b0": {
+            "Parent": "x8003c1",
+            "Xname": "x8003c1b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Hill",
+            "TypeString": "ChassisBMC"
+        },
+        "x8003c1s0b0n0": {
+            "Parent": "x8003c1s0b0",
+            "Xname": "x8003c1s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1128,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001128"
+                ]
+            }
+        },
+        "x8003c1s0b0n1": {
+            "Parent": "x8003c1s0b0",
+            "Xname": "x8003c1s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1129,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001129"
+                ]
+            }
+        },
+        "x8003c1s0b1n0": {
+            "Parent": "x8003c1s0b1",
+            "Xname": "x8003c1s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1130,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001130"
+                ]
+            }
+        },
+        "x8003c1s0b1n1": {
+            "Parent": "x8003c1s0b1",
+            "Xname": "x8003c1s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1131,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001131"
+                ]
+            }
+        },
+        "x8003c1s1b0n0": {
+            "Parent": "x8003c1s1b0",
+            "Xname": "x8003c1s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1132,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001132"
+                ]
+            }
+        },
+        "x8003c1s1b0n1": {
+            "Parent": "x8003c1s1b0",
+            "Xname": "x8003c1s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1133,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001133"
+                ]
+            }
+        },
+        "x8003c1s1b1n0": {
+            "Parent": "x8003c1s1b1",
+            "Xname": "x8003c1s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1134,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001134"
+                ]
+            }
+        },
+        "x8003c1s1b1n1": {
+            "Parent": "x8003c1s1b1",
+            "Xname": "x8003c1s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1135,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001135"
+                ]
+            }
+        },
+        "x8003c1s2b0n0": {
+            "Parent": "x8003c1s2b0",
+            "Xname": "x8003c1s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1136,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001136"
+                ]
+            }
+        },
+        "x8003c1s2b0n1": {
+            "Parent": "x8003c1s2b0",
+            "Xname": "x8003c1s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1137,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001137"
+                ]
+            }
+        },
+        "x8003c1s2b1n0": {
+            "Parent": "x8003c1s2b1",
+            "Xname": "x8003c1s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1138,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001138"
+                ]
+            }
+        },
+        "x8003c1s2b1n1": {
+            "Parent": "x8003c1s2b1",
+            "Xname": "x8003c1s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1139,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001139"
+                ]
+            }
+        },
+        "x8003c1s3b0n0": {
+            "Parent": "x8003c1s3b0",
+            "Xname": "x8003c1s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1140,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001140"
+                ]
+            }
+        },
+        "x8003c1s3b0n1": {
+            "Parent": "x8003c1s3b0",
+            "Xname": "x8003c1s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1141,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001141"
+                ]
+            }
+        },
+        "x8003c1s3b1n0": {
+            "Parent": "x8003c1s3b1",
+            "Xname": "x8003c1s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1142,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001142"
+                ]
+            }
+        },
+        "x8003c1s3b1n1": {
+            "Parent": "x8003c1s3b1",
+            "Xname": "x8003c1s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1143,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001143"
+                ]
+            }
+        },
+        "x8003c1s4b0n0": {
+            "Parent": "x8003c1s4b0",
+            "Xname": "x8003c1s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1144,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001144"
+                ]
+            }
+        },
+        "x8003c1s4b0n1": {
+            "Parent": "x8003c1s4b0",
+            "Xname": "x8003c1s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1145,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001145"
+                ]
+            }
+        },
+        "x8003c1s4b1n0": {
+            "Parent": "x8003c1s4b1",
+            "Xname": "x8003c1s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1146,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001146"
+                ]
+            }
+        },
+        "x8003c1s4b1n1": {
+            "Parent": "x8003c1s4b1",
+            "Xname": "x8003c1s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1147,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001147"
+                ]
+            }
+        },
+        "x8003c1s5b0n0": {
+            "Parent": "x8003c1s5b0",
+            "Xname": "x8003c1s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1148,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001148"
+                ]
+            }
+        },
+        "x8003c1s5b0n1": {
+            "Parent": "x8003c1s5b0",
+            "Xname": "x8003c1s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1149,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001149"
+                ]
+            }
+        },
+        "x8003c1s5b1n0": {
+            "Parent": "x8003c1s5b1",
+            "Xname": "x8003c1s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1150,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001150"
+                ]
+            }
+        },
+        "x8003c1s5b1n1": {
+            "Parent": "x8003c1s5b1",
+            "Xname": "x8003c1s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1151,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001151"
+                ]
+            }
+        },
+        "x8003c1s6b0n0": {
+            "Parent": "x8003c1s6b0",
+            "Xname": "x8003c1s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1152,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001152"
+                ]
+            }
+        },
+        "x8003c1s6b0n1": {
+            "Parent": "x8003c1s6b0",
+            "Xname": "x8003c1s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1153,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001153"
+                ]
+            }
+        },
+        "x8003c1s6b1n0": {
+            "Parent": "x8003c1s6b1",
+            "Xname": "x8003c1s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1154,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001154"
+                ]
+            }
+        },
+        "x8003c1s6b1n1": {
+            "Parent": "x8003c1s6b1",
+            "Xname": "x8003c1s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1155,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001155"
+                ]
+            }
+        },
+        "x8003c1s7b0n0": {
+            "Parent": "x8003c1s7b0",
+            "Xname": "x8003c1s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1156,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001156"
+                ]
+            }
+        },
+        "x8003c1s7b0n1": {
+            "Parent": "x8003c1s7b0",
+            "Xname": "x8003c1s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1157,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001157"
+                ]
+            }
+        },
+        "x8003c1s7b1n0": {
+            "Parent": "x8003c1s7b1",
+            "Xname": "x8003c1s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1158,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001158"
+                ]
+            }
+        },
+        "x8003c1s7b1n1": {
+            "Parent": "x8003c1s7b1",
+            "Xname": "x8003c1s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1159,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001159"
+                ]
+            }
+        },
+        "x8003c2": {
+            "Parent": "x8003",
+            "Xname": "x8003c2",
+            "Type": "comptype_chassis",
+            "Class": "Hill",
+            "TypeString": "Chassis"
+        },
+        "x8003c2b0": {
+            "Parent": "x8003c2",
+            "Xname": "x8003c2b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Hill",
+            "TypeString": "ChassisBMC"
+        },
+        "x8003c2s0b0n0": {
+            "Parent": "x8003c2s0b0",
+            "Xname": "x8003c2s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1160,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001160"
+                ]
+            }
+        },
+        "x8003c2s0b0n1": {
+            "Parent": "x8003c2s0b0",
+            "Xname": "x8003c2s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1161,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001161"
+                ]
+            }
+        },
+        "x8003c2s0b1n0": {
+            "Parent": "x8003c2s0b1",
+            "Xname": "x8003c2s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1162,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001162"
+                ]
+            }
+        },
+        "x8003c2s0b1n1": {
+            "Parent": "x8003c2s0b1",
+            "Xname": "x8003c2s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1163,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001163"
+                ]
+            }
+        },
+        "x8003c2s1b0n0": {
+            "Parent": "x8003c2s1b0",
+            "Xname": "x8003c2s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1164,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001164"
+                ]
+            }
+        },
+        "x8003c2s1b0n1": {
+            "Parent": "x8003c2s1b0",
+            "Xname": "x8003c2s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1165,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001165"
+                ]
+            }
+        },
+        "x8003c2s1b1n0": {
+            "Parent": "x8003c2s1b1",
+            "Xname": "x8003c2s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1166,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001166"
+                ]
+            }
+        },
+        "x8003c2s1b1n1": {
+            "Parent": "x8003c2s1b1",
+            "Xname": "x8003c2s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1167,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001167"
+                ]
+            }
+        },
+        "x8003c2s2b0n0": {
+            "Parent": "x8003c2s2b0",
+            "Xname": "x8003c2s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1168,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001168"
+                ]
+            }
+        },
+        "x8003c2s2b0n1": {
+            "Parent": "x8003c2s2b0",
+            "Xname": "x8003c2s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1169,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001169"
+                ]
+            }
+        },
+        "x8003c2s2b1n0": {
+            "Parent": "x8003c2s2b1",
+            "Xname": "x8003c2s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1170,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001170"
+                ]
+            }
+        },
+        "x8003c2s2b1n1": {
+            "Parent": "x8003c2s2b1",
+            "Xname": "x8003c2s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1171,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001171"
+                ]
+            }
+        },
+        "x8003c2s3b0n0": {
+            "Parent": "x8003c2s3b0",
+            "Xname": "x8003c2s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1172,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001172"
+                ]
+            }
+        },
+        "x8003c2s3b0n1": {
+            "Parent": "x8003c2s3b0",
+            "Xname": "x8003c2s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1173,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001173"
+                ]
+            }
+        },
+        "x8003c2s3b1n0": {
+            "Parent": "x8003c2s3b1",
+            "Xname": "x8003c2s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1174,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001174"
+                ]
+            }
+        },
+        "x8003c2s3b1n1": {
+            "Parent": "x8003c2s3b1",
+            "Xname": "x8003c2s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1175,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001175"
+                ]
+            }
+        },
+        "x8003c2s4b0n0": {
+            "Parent": "x8003c2s4b0",
+            "Xname": "x8003c2s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1176,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001176"
+                ]
+            }
+        },
+        "x8003c2s4b0n1": {
+            "Parent": "x8003c2s4b0",
+            "Xname": "x8003c2s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1177,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001177"
+                ]
+            }
+        },
+        "x8003c2s4b1n0": {
+            "Parent": "x8003c2s4b1",
+            "Xname": "x8003c2s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1178,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001178"
+                ]
+            }
+        },
+        "x8003c2s4b1n1": {
+            "Parent": "x8003c2s4b1",
+            "Xname": "x8003c2s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1179,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001179"
+                ]
+            }
+        },
+        "x8003c2s5b0n0": {
+            "Parent": "x8003c2s5b0",
+            "Xname": "x8003c2s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1180,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001180"
+                ]
+            }
+        },
+        "x8003c2s5b0n1": {
+            "Parent": "x8003c2s5b0",
+            "Xname": "x8003c2s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1181,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001181"
+                ]
+            }
+        },
+        "x8003c2s5b1n0": {
+            "Parent": "x8003c2s5b1",
+            "Xname": "x8003c2s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1182,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001182"
+                ]
+            }
+        },
+        "x8003c2s5b1n1": {
+            "Parent": "x8003c2s5b1",
+            "Xname": "x8003c2s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1183,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001183"
+                ]
+            }
+        },
+        "x8003c2s6b0n0": {
+            "Parent": "x8003c2s6b0",
+            "Xname": "x8003c2s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1184,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001184"
+                ]
+            }
+        },
+        "x8003c2s6b0n1": {
+            "Parent": "x8003c2s6b0",
+            "Xname": "x8003c2s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1185,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001185"
+                ]
+            }
+        },
+        "x8003c2s6b1n0": {
+            "Parent": "x8003c2s6b1",
+            "Xname": "x8003c2s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1186,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001186"
+                ]
+            }
+        },
+        "x8003c2s6b1n1": {
+            "Parent": "x8003c2s6b1",
+            "Xname": "x8003c2s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1187,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001187"
+                ]
+            }
+        },
+        "x8003c2s7b0n0": {
+            "Parent": "x8003c2s7b0",
+            "Xname": "x8003c2s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1188,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001188"
+                ]
+            }
+        },
+        "x8003c2s7b0n1": {
+            "Parent": "x8003c2s7b0",
+            "Xname": "x8003c2s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1189,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001189"
+                ]
+            }
+        },
+        "x8003c2s7b1n0": {
+            "Parent": "x8003c2s7b1",
+            "Xname": "x8003c2s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1190,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001190"
+                ]
+            }
+        },
+        "x8003c2s7b1n1": {
+            "Parent": "x8003c2s7b1",
+            "Xname": "x8003c2s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1191,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001191"
+                ]
+            }
+        }
+    },
+    "Networks": {}
+}

--- a/testdata/fixtures/sls/EX3000_River.json
+++ b/testdata/fixtures/sls/EX3000_River.json
@@ -1,0 +1,4345 @@
+{
+    "Hardware": {
+        "d0w1": {
+            "Parent": "d0",
+            "Xname": "d0w1",
+            "Type": "comptype_cdu_mgmt_switch",
+            "Class": "Mountain",
+            "TypeString": "CDUMgmtSwitch",
+            "ExtraProperties": {
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-cdu-001"
+                ]
+            }
+        },
+        "d0w2": {
+            "Parent": "d0",
+            "Xname": "d0w2",
+            "Type": "comptype_cdu_mgmt_switch",
+            "Class": "Mountain",
+            "TypeString": "CDUMgmtSwitch",
+            "ExtraProperties": {
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-cdu-002"
+                ]
+            }
+        },
+        "x1000": {
+            "Parent": "s0",
+            "Xname": "x1000",
+            "Type": "comptype_cabinet",
+            "Class": "Mountain",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Model": "EX3000",
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.104.0.0/22",
+                            "Gateway": "10.104.0.1",
+                            "VLan": 3000
+                        },
+                        "NMN": {
+                            "CIDR": "10.100.0.0/22",
+                            "Gateway": "10.100.0.1",
+                            "VLan": 2000
+                        }
+                    }
+                }
+            }
+        },
+        "x1000c0": {
+            "Parent": "x1000",
+            "Xname": "x1000c0",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c0b0": {
+            "Parent": "x1000c0",
+            "Xname": "x1000c0b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c0s0b0n0": {
+            "Parent": "x1000c0s0b0",
+            "Xname": "x1000c0s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1000,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001000"
+                ]
+            }
+        },
+        "x1000c0s0b0n1": {
+            "Parent": "x1000c0s0b0",
+            "Xname": "x1000c0s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1001,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001001"
+                ]
+            }
+        },
+        "x1000c0s0b1n0": {
+            "Parent": "x1000c0s0b1",
+            "Xname": "x1000c0s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1002,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001002"
+                ]
+            }
+        },
+        "x1000c0s0b1n1": {
+            "Parent": "x1000c0s0b1",
+            "Xname": "x1000c0s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1003,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001003"
+                ]
+            }
+        },
+        "x1000c0s1b0n0": {
+            "Parent": "x1000c0s1b0",
+            "Xname": "x1000c0s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1004,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001004"
+                ]
+            }
+        },
+        "x1000c0s1b0n1": {
+            "Parent": "x1000c0s1b0",
+            "Xname": "x1000c0s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1005,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001005"
+                ]
+            }
+        },
+        "x1000c0s1b1n0": {
+            "Parent": "x1000c0s1b1",
+            "Xname": "x1000c0s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1006,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001006"
+                ]
+            }
+        },
+        "x1000c0s1b1n1": {
+            "Parent": "x1000c0s1b1",
+            "Xname": "x1000c0s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1007,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001007"
+                ]
+            }
+        },
+        "x1000c0s2b0n0": {
+            "Parent": "x1000c0s2b0",
+            "Xname": "x1000c0s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1008,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001008"
+                ]
+            }
+        },
+        "x1000c0s2b0n1": {
+            "Parent": "x1000c0s2b0",
+            "Xname": "x1000c0s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1009,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001009"
+                ]
+            }
+        },
+        "x1000c0s2b1n0": {
+            "Parent": "x1000c0s2b1",
+            "Xname": "x1000c0s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1010,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001010"
+                ]
+            }
+        },
+        "x1000c0s2b1n1": {
+            "Parent": "x1000c0s2b1",
+            "Xname": "x1000c0s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1011,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001011"
+                ]
+            }
+        },
+        "x1000c0s3b0n0": {
+            "Parent": "x1000c0s3b0",
+            "Xname": "x1000c0s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1012,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001012"
+                ]
+            }
+        },
+        "x1000c0s3b0n1": {
+            "Parent": "x1000c0s3b0",
+            "Xname": "x1000c0s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1013,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001013"
+                ]
+            }
+        },
+        "x1000c0s3b1n0": {
+            "Parent": "x1000c0s3b1",
+            "Xname": "x1000c0s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1014,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001014"
+                ]
+            }
+        },
+        "x1000c0s3b1n1": {
+            "Parent": "x1000c0s3b1",
+            "Xname": "x1000c0s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1015,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001015"
+                ]
+            }
+        },
+        "x1000c0s4b0n0": {
+            "Parent": "x1000c0s4b0",
+            "Xname": "x1000c0s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1016,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001016"
+                ]
+            }
+        },
+        "x1000c0s4b0n1": {
+            "Parent": "x1000c0s4b0",
+            "Xname": "x1000c0s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1017,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001017"
+                ]
+            }
+        },
+        "x1000c0s4b1n0": {
+            "Parent": "x1000c0s4b1",
+            "Xname": "x1000c0s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1018,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001018"
+                ]
+            }
+        },
+        "x1000c0s4b1n1": {
+            "Parent": "x1000c0s4b1",
+            "Xname": "x1000c0s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1019,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001019"
+                ]
+            }
+        },
+        "x1000c0s5b0n0": {
+            "Parent": "x1000c0s5b0",
+            "Xname": "x1000c0s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1020,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001020"
+                ]
+            }
+        },
+        "x1000c0s5b0n1": {
+            "Parent": "x1000c0s5b0",
+            "Xname": "x1000c0s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1021,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001021"
+                ]
+            }
+        },
+        "x1000c0s5b1n0": {
+            "Parent": "x1000c0s5b1",
+            "Xname": "x1000c0s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1022,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001022"
+                ]
+            }
+        },
+        "x1000c0s5b1n1": {
+            "Parent": "x1000c0s5b1",
+            "Xname": "x1000c0s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1023,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001023"
+                ]
+            }
+        },
+        "x1000c0s6b0n0": {
+            "Parent": "x1000c0s6b0",
+            "Xname": "x1000c0s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1024,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001024"
+                ]
+            }
+        },
+        "x1000c0s6b0n1": {
+            "Parent": "x1000c0s6b0",
+            "Xname": "x1000c0s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1025,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001025"
+                ]
+            }
+        },
+        "x1000c0s6b1n0": {
+            "Parent": "x1000c0s6b1",
+            "Xname": "x1000c0s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1026,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001026"
+                ]
+            }
+        },
+        "x1000c0s6b1n1": {
+            "Parent": "x1000c0s6b1",
+            "Xname": "x1000c0s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1027,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001027"
+                ]
+            }
+        },
+        "x1000c0s7b0n0": {
+            "Parent": "x1000c0s7b0",
+            "Xname": "x1000c0s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1028,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001028"
+                ]
+            }
+        },
+        "x1000c0s7b0n1": {
+            "Parent": "x1000c0s7b0",
+            "Xname": "x1000c0s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1029,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001029"
+                ]
+            }
+        },
+        "x1000c0s7b1n0": {
+            "Parent": "x1000c0s7b1",
+            "Xname": "x1000c0s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1030,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001030"
+                ]
+            }
+        },
+        "x1000c0s7b1n1": {
+            "Parent": "x1000c0s7b1",
+            "Xname": "x1000c0s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1031,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001031"
+                ]
+            }
+        },
+        "x1000c1": {
+            "Parent": "x1000",
+            "Xname": "x1000c1",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c1b0": {
+            "Parent": "x1000c1",
+            "Xname": "x1000c1b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c1s0b0n0": {
+            "Parent": "x1000c1s0b0",
+            "Xname": "x1000c1s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1032,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001032"
+                ]
+            }
+        },
+        "x1000c1s0b0n1": {
+            "Parent": "x1000c1s0b0",
+            "Xname": "x1000c1s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1033,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001033"
+                ]
+            }
+        },
+        "x1000c1s0b1n0": {
+            "Parent": "x1000c1s0b1",
+            "Xname": "x1000c1s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1034,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001034"
+                ]
+            }
+        },
+        "x1000c1s0b1n1": {
+            "Parent": "x1000c1s0b1",
+            "Xname": "x1000c1s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1035,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001035"
+                ]
+            }
+        },
+        "x1000c1s1b0n0": {
+            "Parent": "x1000c1s1b0",
+            "Xname": "x1000c1s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1036,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001036"
+                ]
+            }
+        },
+        "x1000c1s1b0n1": {
+            "Parent": "x1000c1s1b0",
+            "Xname": "x1000c1s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1037,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001037"
+                ]
+            }
+        },
+        "x1000c1s1b1n0": {
+            "Parent": "x1000c1s1b1",
+            "Xname": "x1000c1s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1038,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001038"
+                ]
+            }
+        },
+        "x1000c1s1b1n1": {
+            "Parent": "x1000c1s1b1",
+            "Xname": "x1000c1s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1039,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001039"
+                ]
+            }
+        },
+        "x1000c1s2b0n0": {
+            "Parent": "x1000c1s2b0",
+            "Xname": "x1000c1s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1040,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001040"
+                ]
+            }
+        },
+        "x1000c1s2b0n1": {
+            "Parent": "x1000c1s2b0",
+            "Xname": "x1000c1s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1041,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001041"
+                ]
+            }
+        },
+        "x1000c1s2b1n0": {
+            "Parent": "x1000c1s2b1",
+            "Xname": "x1000c1s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1042,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001042"
+                ]
+            }
+        },
+        "x1000c1s2b1n1": {
+            "Parent": "x1000c1s2b1",
+            "Xname": "x1000c1s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1043,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001043"
+                ]
+            }
+        },
+        "x1000c1s3b0n0": {
+            "Parent": "x1000c1s3b0",
+            "Xname": "x1000c1s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1044,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001044"
+                ]
+            }
+        },
+        "x1000c1s3b0n1": {
+            "Parent": "x1000c1s3b0",
+            "Xname": "x1000c1s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1045,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001045"
+                ]
+            }
+        },
+        "x1000c1s3b1n0": {
+            "Parent": "x1000c1s3b1",
+            "Xname": "x1000c1s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1046,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001046"
+                ]
+            }
+        },
+        "x1000c1s3b1n1": {
+            "Parent": "x1000c1s3b1",
+            "Xname": "x1000c1s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1047,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001047"
+                ]
+            }
+        },
+        "x1000c1s4b0n0": {
+            "Parent": "x1000c1s4b0",
+            "Xname": "x1000c1s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1048,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001048"
+                ]
+            }
+        },
+        "x1000c1s4b0n1": {
+            "Parent": "x1000c1s4b0",
+            "Xname": "x1000c1s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1049,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001049"
+                ]
+            }
+        },
+        "x1000c1s4b1n0": {
+            "Parent": "x1000c1s4b1",
+            "Xname": "x1000c1s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1050,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001050"
+                ]
+            }
+        },
+        "x1000c1s4b1n1": {
+            "Parent": "x1000c1s4b1",
+            "Xname": "x1000c1s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1051,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001051"
+                ]
+            }
+        },
+        "x1000c1s5b0n0": {
+            "Parent": "x1000c1s5b0",
+            "Xname": "x1000c1s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1052,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001052"
+                ]
+            }
+        },
+        "x1000c1s5b0n1": {
+            "Parent": "x1000c1s5b0",
+            "Xname": "x1000c1s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1053,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001053"
+                ]
+            }
+        },
+        "x1000c1s5b1n0": {
+            "Parent": "x1000c1s5b1",
+            "Xname": "x1000c1s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1054,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001054"
+                ]
+            }
+        },
+        "x1000c1s5b1n1": {
+            "Parent": "x1000c1s5b1",
+            "Xname": "x1000c1s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1055,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001055"
+                ]
+            }
+        },
+        "x1000c1s6b0n0": {
+            "Parent": "x1000c1s6b0",
+            "Xname": "x1000c1s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1056,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001056"
+                ]
+            }
+        },
+        "x1000c1s6b0n1": {
+            "Parent": "x1000c1s6b0",
+            "Xname": "x1000c1s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1057,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001057"
+                ]
+            }
+        },
+        "x1000c1s6b1n0": {
+            "Parent": "x1000c1s6b1",
+            "Xname": "x1000c1s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1058,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001058"
+                ]
+            }
+        },
+        "x1000c1s6b1n1": {
+            "Parent": "x1000c1s6b1",
+            "Xname": "x1000c1s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1059,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001059"
+                ]
+            }
+        },
+        "x1000c1s7b0n0": {
+            "Parent": "x1000c1s7b0",
+            "Xname": "x1000c1s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1060,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001060"
+                ]
+            }
+        },
+        "x1000c1s7b0n1": {
+            "Parent": "x1000c1s7b0",
+            "Xname": "x1000c1s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1061,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001061"
+                ]
+            }
+        },
+        "x1000c1s7b1n0": {
+            "Parent": "x1000c1s7b1",
+            "Xname": "x1000c1s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1062,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001062"
+                ]
+            }
+        },
+        "x1000c1s7b1n1": {
+            "Parent": "x1000c1s7b1",
+            "Xname": "x1000c1s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1063,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001063"
+                ]
+            }
+        },
+        "x1000c2": {
+            "Parent": "x1000",
+            "Xname": "x1000c2",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c2b0": {
+            "Parent": "x1000c2",
+            "Xname": "x1000c2b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c2s0b0n0": {
+            "Parent": "x1000c2s0b0",
+            "Xname": "x1000c2s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1064,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001064"
+                ]
+            }
+        },
+        "x1000c2s0b0n1": {
+            "Parent": "x1000c2s0b0",
+            "Xname": "x1000c2s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1065,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001065"
+                ]
+            }
+        },
+        "x1000c2s0b1n0": {
+            "Parent": "x1000c2s0b1",
+            "Xname": "x1000c2s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1066,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001066"
+                ]
+            }
+        },
+        "x1000c2s0b1n1": {
+            "Parent": "x1000c2s0b1",
+            "Xname": "x1000c2s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1067,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001067"
+                ]
+            }
+        },
+        "x1000c2s1b0n0": {
+            "Parent": "x1000c2s1b0",
+            "Xname": "x1000c2s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1068,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001068"
+                ]
+            }
+        },
+        "x1000c2s1b0n1": {
+            "Parent": "x1000c2s1b0",
+            "Xname": "x1000c2s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1069,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001069"
+                ]
+            }
+        },
+        "x1000c2s1b1n0": {
+            "Parent": "x1000c2s1b1",
+            "Xname": "x1000c2s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1070,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001070"
+                ]
+            }
+        },
+        "x1000c2s1b1n1": {
+            "Parent": "x1000c2s1b1",
+            "Xname": "x1000c2s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1071,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001071"
+                ]
+            }
+        },
+        "x1000c2s2b0n0": {
+            "Parent": "x1000c2s2b0",
+            "Xname": "x1000c2s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1072,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001072"
+                ]
+            }
+        },
+        "x1000c2s2b0n1": {
+            "Parent": "x1000c2s2b0",
+            "Xname": "x1000c2s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1073,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001073"
+                ]
+            }
+        },
+        "x1000c2s2b1n0": {
+            "Parent": "x1000c2s2b1",
+            "Xname": "x1000c2s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1074,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001074"
+                ]
+            }
+        },
+        "x1000c2s2b1n1": {
+            "Parent": "x1000c2s2b1",
+            "Xname": "x1000c2s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1075,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001075"
+                ]
+            }
+        },
+        "x1000c2s3b0n0": {
+            "Parent": "x1000c2s3b0",
+            "Xname": "x1000c2s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1076,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001076"
+                ]
+            }
+        },
+        "x1000c2s3b0n1": {
+            "Parent": "x1000c2s3b0",
+            "Xname": "x1000c2s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1077,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001077"
+                ]
+            }
+        },
+        "x1000c2s3b1n0": {
+            "Parent": "x1000c2s3b1",
+            "Xname": "x1000c2s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1078,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001078"
+                ]
+            }
+        },
+        "x1000c2s3b1n1": {
+            "Parent": "x1000c2s3b1",
+            "Xname": "x1000c2s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1079,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001079"
+                ]
+            }
+        },
+        "x1000c2s4b0n0": {
+            "Parent": "x1000c2s4b0",
+            "Xname": "x1000c2s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1080,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001080"
+                ]
+            }
+        },
+        "x1000c2s4b0n1": {
+            "Parent": "x1000c2s4b0",
+            "Xname": "x1000c2s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1081,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001081"
+                ]
+            }
+        },
+        "x1000c2s4b1n0": {
+            "Parent": "x1000c2s4b1",
+            "Xname": "x1000c2s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1082,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001082"
+                ]
+            }
+        },
+        "x1000c2s4b1n1": {
+            "Parent": "x1000c2s4b1",
+            "Xname": "x1000c2s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1083,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001083"
+                ]
+            }
+        },
+        "x1000c2s5b0n0": {
+            "Parent": "x1000c2s5b0",
+            "Xname": "x1000c2s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1084,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001084"
+                ]
+            }
+        },
+        "x1000c2s5b0n1": {
+            "Parent": "x1000c2s5b0",
+            "Xname": "x1000c2s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1085,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001085"
+                ]
+            }
+        },
+        "x1000c2s5b1n0": {
+            "Parent": "x1000c2s5b1",
+            "Xname": "x1000c2s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1086,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001086"
+                ]
+            }
+        },
+        "x1000c2s5b1n1": {
+            "Parent": "x1000c2s5b1",
+            "Xname": "x1000c2s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1087,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001087"
+                ]
+            }
+        },
+        "x1000c2s6b0n0": {
+            "Parent": "x1000c2s6b0",
+            "Xname": "x1000c2s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1088,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001088"
+                ]
+            }
+        },
+        "x1000c2s6b0n1": {
+            "Parent": "x1000c2s6b0",
+            "Xname": "x1000c2s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1089,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001089"
+                ]
+            }
+        },
+        "x1000c2s6b1n0": {
+            "Parent": "x1000c2s6b1",
+            "Xname": "x1000c2s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1090,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001090"
+                ]
+            }
+        },
+        "x1000c2s6b1n1": {
+            "Parent": "x1000c2s6b1",
+            "Xname": "x1000c2s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1091,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001091"
+                ]
+            }
+        },
+        "x1000c2s7b0n0": {
+            "Parent": "x1000c2s7b0",
+            "Xname": "x1000c2s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1092,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001092"
+                ]
+            }
+        },
+        "x1000c2s7b0n1": {
+            "Parent": "x1000c2s7b0",
+            "Xname": "x1000c2s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1093,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001093"
+                ]
+            }
+        },
+        "x1000c2s7b1n0": {
+            "Parent": "x1000c2s7b1",
+            "Xname": "x1000c2s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1094,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001094"
+                ]
+            }
+        },
+        "x1000c2s7b1n1": {
+            "Parent": "x1000c2s7b1",
+            "Xname": "x1000c2s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1095,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001095"
+                ]
+            }
+        },
+        "x1000c3": {
+            "Parent": "x1000",
+            "Xname": "x1000c3",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c3b0": {
+            "Parent": "x1000c3",
+            "Xname": "x1000c3b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c3s0b0n0": {
+            "Parent": "x1000c3s0b0",
+            "Xname": "x1000c3s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1096,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001096"
+                ]
+            }
+        },
+        "x1000c3s0b0n1": {
+            "Parent": "x1000c3s0b0",
+            "Xname": "x1000c3s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1097,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001097"
+                ]
+            }
+        },
+        "x1000c3s0b1n0": {
+            "Parent": "x1000c3s0b1",
+            "Xname": "x1000c3s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1098,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001098"
+                ]
+            }
+        },
+        "x1000c3s0b1n1": {
+            "Parent": "x1000c3s0b1",
+            "Xname": "x1000c3s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1099,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001099"
+                ]
+            }
+        },
+        "x1000c3s1b0n0": {
+            "Parent": "x1000c3s1b0",
+            "Xname": "x1000c3s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1100,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001100"
+                ]
+            }
+        },
+        "x1000c3s1b0n1": {
+            "Parent": "x1000c3s1b0",
+            "Xname": "x1000c3s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1101,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001101"
+                ]
+            }
+        },
+        "x1000c3s1b1n0": {
+            "Parent": "x1000c3s1b1",
+            "Xname": "x1000c3s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1102,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001102"
+                ]
+            }
+        },
+        "x1000c3s1b1n1": {
+            "Parent": "x1000c3s1b1",
+            "Xname": "x1000c3s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1103,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001103"
+                ]
+            }
+        },
+        "x1000c3s2b0n0": {
+            "Parent": "x1000c3s2b0",
+            "Xname": "x1000c3s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1104,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001104"
+                ]
+            }
+        },
+        "x1000c3s2b0n1": {
+            "Parent": "x1000c3s2b0",
+            "Xname": "x1000c3s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1105,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001105"
+                ]
+            }
+        },
+        "x1000c3s2b1n0": {
+            "Parent": "x1000c3s2b1",
+            "Xname": "x1000c3s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1106,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001106"
+                ]
+            }
+        },
+        "x1000c3s2b1n1": {
+            "Parent": "x1000c3s2b1",
+            "Xname": "x1000c3s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1107,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001107"
+                ]
+            }
+        },
+        "x1000c3s3b0n0": {
+            "Parent": "x1000c3s3b0",
+            "Xname": "x1000c3s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1108,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001108"
+                ]
+            }
+        },
+        "x1000c3s3b0n1": {
+            "Parent": "x1000c3s3b0",
+            "Xname": "x1000c3s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1109,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001109"
+                ]
+            }
+        },
+        "x1000c3s3b1n0": {
+            "Parent": "x1000c3s3b1",
+            "Xname": "x1000c3s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1110,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001110"
+                ]
+            }
+        },
+        "x1000c3s3b1n1": {
+            "Parent": "x1000c3s3b1",
+            "Xname": "x1000c3s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1111,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001111"
+                ]
+            }
+        },
+        "x1000c3s4b0n0": {
+            "Parent": "x1000c3s4b0",
+            "Xname": "x1000c3s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1112,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001112"
+                ]
+            }
+        },
+        "x1000c3s4b0n1": {
+            "Parent": "x1000c3s4b0",
+            "Xname": "x1000c3s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1113,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001113"
+                ]
+            }
+        },
+        "x1000c3s4b1n0": {
+            "Parent": "x1000c3s4b1",
+            "Xname": "x1000c3s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1114,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001114"
+                ]
+            }
+        },
+        "x1000c3s4b1n1": {
+            "Parent": "x1000c3s4b1",
+            "Xname": "x1000c3s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1115,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001115"
+                ]
+            }
+        },
+        "x1000c3s5b0n0": {
+            "Parent": "x1000c3s5b0",
+            "Xname": "x1000c3s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1116,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001116"
+                ]
+            }
+        },
+        "x1000c3s5b0n1": {
+            "Parent": "x1000c3s5b0",
+            "Xname": "x1000c3s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1117,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001117"
+                ]
+            }
+        },
+        "x1000c3s5b1n0": {
+            "Parent": "x1000c3s5b1",
+            "Xname": "x1000c3s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1118,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001118"
+                ]
+            }
+        },
+        "x1000c3s5b1n1": {
+            "Parent": "x1000c3s5b1",
+            "Xname": "x1000c3s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1119,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001119"
+                ]
+            }
+        },
+        "x1000c3s6b0n0": {
+            "Parent": "x1000c3s6b0",
+            "Xname": "x1000c3s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1120,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001120"
+                ]
+            }
+        },
+        "x1000c3s6b0n1": {
+            "Parent": "x1000c3s6b0",
+            "Xname": "x1000c3s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1121,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001121"
+                ]
+            }
+        },
+        "x1000c3s6b1n0": {
+            "Parent": "x1000c3s6b1",
+            "Xname": "x1000c3s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1122,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001122"
+                ]
+            }
+        },
+        "x1000c3s6b1n1": {
+            "Parent": "x1000c3s6b1",
+            "Xname": "x1000c3s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1123,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001123"
+                ]
+            }
+        },
+        "x1000c3s7b0n0": {
+            "Parent": "x1000c3s7b0",
+            "Xname": "x1000c3s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1124,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001124"
+                ]
+            }
+        },
+        "x1000c3s7b0n1": {
+            "Parent": "x1000c3s7b0",
+            "Xname": "x1000c3s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1125,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001125"
+                ]
+            }
+        },
+        "x1000c3s7b1n0": {
+            "Parent": "x1000c3s7b1",
+            "Xname": "x1000c3s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1126,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001126"
+                ]
+            }
+        },
+        "x1000c3s7b1n1": {
+            "Parent": "x1000c3s7b1",
+            "Xname": "x1000c3s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1127,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001127"
+                ]
+            }
+        },
+        "x1000c4": {
+            "Parent": "x1000",
+            "Xname": "x1000c4",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c4b0": {
+            "Parent": "x1000c4",
+            "Xname": "x1000c4b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c4s0b0n0": {
+            "Parent": "x1000c4s0b0",
+            "Xname": "x1000c4s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1128,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001128"
+                ]
+            }
+        },
+        "x1000c4s0b0n1": {
+            "Parent": "x1000c4s0b0",
+            "Xname": "x1000c4s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1129,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001129"
+                ]
+            }
+        },
+        "x1000c4s0b1n0": {
+            "Parent": "x1000c4s0b1",
+            "Xname": "x1000c4s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1130,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001130"
+                ]
+            }
+        },
+        "x1000c4s0b1n1": {
+            "Parent": "x1000c4s0b1",
+            "Xname": "x1000c4s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1131,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001131"
+                ]
+            }
+        },
+        "x1000c4s1b0n0": {
+            "Parent": "x1000c4s1b0",
+            "Xname": "x1000c4s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1132,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001132"
+                ]
+            }
+        },
+        "x1000c4s1b0n1": {
+            "Parent": "x1000c4s1b0",
+            "Xname": "x1000c4s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1133,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001133"
+                ]
+            }
+        },
+        "x1000c4s1b1n0": {
+            "Parent": "x1000c4s1b1",
+            "Xname": "x1000c4s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1134,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001134"
+                ]
+            }
+        },
+        "x1000c4s1b1n1": {
+            "Parent": "x1000c4s1b1",
+            "Xname": "x1000c4s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1135,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001135"
+                ]
+            }
+        },
+        "x1000c4s2b0n0": {
+            "Parent": "x1000c4s2b0",
+            "Xname": "x1000c4s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1136,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001136"
+                ]
+            }
+        },
+        "x1000c4s2b0n1": {
+            "Parent": "x1000c4s2b0",
+            "Xname": "x1000c4s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1137,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001137"
+                ]
+            }
+        },
+        "x1000c4s2b1n0": {
+            "Parent": "x1000c4s2b1",
+            "Xname": "x1000c4s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1138,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001138"
+                ]
+            }
+        },
+        "x1000c4s2b1n1": {
+            "Parent": "x1000c4s2b1",
+            "Xname": "x1000c4s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1139,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001139"
+                ]
+            }
+        },
+        "x1000c4s3b0n0": {
+            "Parent": "x1000c4s3b0",
+            "Xname": "x1000c4s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1140,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001140"
+                ]
+            }
+        },
+        "x1000c4s3b0n1": {
+            "Parent": "x1000c4s3b0",
+            "Xname": "x1000c4s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1141,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001141"
+                ]
+            }
+        },
+        "x1000c4s3b1n0": {
+            "Parent": "x1000c4s3b1",
+            "Xname": "x1000c4s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1142,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001142"
+                ]
+            }
+        },
+        "x1000c4s3b1n1": {
+            "Parent": "x1000c4s3b1",
+            "Xname": "x1000c4s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1143,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001143"
+                ]
+            }
+        },
+        "x1000c4s4b0n0": {
+            "Parent": "x1000c4s4b0",
+            "Xname": "x1000c4s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1144,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001144"
+                ]
+            }
+        },
+        "x1000c4s4b0n1": {
+            "Parent": "x1000c4s4b0",
+            "Xname": "x1000c4s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1145,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001145"
+                ]
+            }
+        },
+        "x1000c4s4b1n0": {
+            "Parent": "x1000c4s4b1",
+            "Xname": "x1000c4s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1146,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001146"
+                ]
+            }
+        },
+        "x1000c4s4b1n1": {
+            "Parent": "x1000c4s4b1",
+            "Xname": "x1000c4s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1147,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001147"
+                ]
+            }
+        },
+        "x1000c4s5b0n0": {
+            "Parent": "x1000c4s5b0",
+            "Xname": "x1000c4s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1148,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001148"
+                ]
+            }
+        },
+        "x1000c4s5b0n1": {
+            "Parent": "x1000c4s5b0",
+            "Xname": "x1000c4s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1149,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001149"
+                ]
+            }
+        },
+        "x1000c4s5b1n0": {
+            "Parent": "x1000c4s5b1",
+            "Xname": "x1000c4s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1150,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001150"
+                ]
+            }
+        },
+        "x1000c4s5b1n1": {
+            "Parent": "x1000c4s5b1",
+            "Xname": "x1000c4s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1151,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001151"
+                ]
+            }
+        },
+        "x1000c4s6b0n0": {
+            "Parent": "x1000c4s6b0",
+            "Xname": "x1000c4s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1152,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001152"
+                ]
+            }
+        },
+        "x1000c4s6b0n1": {
+            "Parent": "x1000c4s6b0",
+            "Xname": "x1000c4s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1153,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001153"
+                ]
+            }
+        },
+        "x1000c4s6b1n0": {
+            "Parent": "x1000c4s6b1",
+            "Xname": "x1000c4s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1154,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001154"
+                ]
+            }
+        },
+        "x1000c4s6b1n1": {
+            "Parent": "x1000c4s6b1",
+            "Xname": "x1000c4s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1155,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001155"
+                ]
+            }
+        },
+        "x1000c4s7b0n0": {
+            "Parent": "x1000c4s7b0",
+            "Xname": "x1000c4s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1156,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001156"
+                ]
+            }
+        },
+        "x1000c4s7b0n1": {
+            "Parent": "x1000c4s7b0",
+            "Xname": "x1000c4s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1157,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001157"
+                ]
+            }
+        },
+        "x1000c4s7b1n0": {
+            "Parent": "x1000c4s7b1",
+            "Xname": "x1000c4s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1158,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001158"
+                ]
+            }
+        },
+        "x1000c4s7b1n1": {
+            "Parent": "x1000c4s7b1",
+            "Xname": "x1000c4s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1159,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001159"
+                ]
+            }
+        },
+        "x1000c5": {
+            "Parent": "x1000",
+            "Xname": "x1000c5",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c5b0": {
+            "Parent": "x1000c5",
+            "Xname": "x1000c5b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c5s0b0n0": {
+            "Parent": "x1000c5s0b0",
+            "Xname": "x1000c5s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1160,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001160"
+                ]
+            }
+        },
+        "x1000c5s0b0n1": {
+            "Parent": "x1000c5s0b0",
+            "Xname": "x1000c5s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1161,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001161"
+                ]
+            }
+        },
+        "x1000c5s0b1n0": {
+            "Parent": "x1000c5s0b1",
+            "Xname": "x1000c5s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1162,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001162"
+                ]
+            }
+        },
+        "x1000c5s0b1n1": {
+            "Parent": "x1000c5s0b1",
+            "Xname": "x1000c5s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1163,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001163"
+                ]
+            }
+        },
+        "x1000c5s1b0n0": {
+            "Parent": "x1000c5s1b0",
+            "Xname": "x1000c5s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1164,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001164"
+                ]
+            }
+        },
+        "x1000c5s1b0n1": {
+            "Parent": "x1000c5s1b0",
+            "Xname": "x1000c5s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1165,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001165"
+                ]
+            }
+        },
+        "x1000c5s1b1n0": {
+            "Parent": "x1000c5s1b1",
+            "Xname": "x1000c5s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1166,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001166"
+                ]
+            }
+        },
+        "x1000c5s1b1n1": {
+            "Parent": "x1000c5s1b1",
+            "Xname": "x1000c5s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1167,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001167"
+                ]
+            }
+        },
+        "x1000c5s2b0n0": {
+            "Parent": "x1000c5s2b0",
+            "Xname": "x1000c5s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1168,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001168"
+                ]
+            }
+        },
+        "x1000c5s2b0n1": {
+            "Parent": "x1000c5s2b0",
+            "Xname": "x1000c5s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1169,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001169"
+                ]
+            }
+        },
+        "x1000c5s2b1n0": {
+            "Parent": "x1000c5s2b1",
+            "Xname": "x1000c5s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1170,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001170"
+                ]
+            }
+        },
+        "x1000c5s2b1n1": {
+            "Parent": "x1000c5s2b1",
+            "Xname": "x1000c5s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1171,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001171"
+                ]
+            }
+        },
+        "x1000c5s3b0n0": {
+            "Parent": "x1000c5s3b0",
+            "Xname": "x1000c5s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1172,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001172"
+                ]
+            }
+        },
+        "x1000c5s3b0n1": {
+            "Parent": "x1000c5s3b0",
+            "Xname": "x1000c5s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1173,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001173"
+                ]
+            }
+        },
+        "x1000c5s3b1n0": {
+            "Parent": "x1000c5s3b1",
+            "Xname": "x1000c5s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1174,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001174"
+                ]
+            }
+        },
+        "x1000c5s3b1n1": {
+            "Parent": "x1000c5s3b1",
+            "Xname": "x1000c5s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1175,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001175"
+                ]
+            }
+        },
+        "x1000c5s4b0n0": {
+            "Parent": "x1000c5s4b0",
+            "Xname": "x1000c5s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1176,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001176"
+                ]
+            }
+        },
+        "x1000c5s4b0n1": {
+            "Parent": "x1000c5s4b0",
+            "Xname": "x1000c5s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1177,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001177"
+                ]
+            }
+        },
+        "x1000c5s4b1n0": {
+            "Parent": "x1000c5s4b1",
+            "Xname": "x1000c5s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1178,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001178"
+                ]
+            }
+        },
+        "x1000c5s4b1n1": {
+            "Parent": "x1000c5s4b1",
+            "Xname": "x1000c5s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1179,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001179"
+                ]
+            }
+        },
+        "x1000c5s5b0n0": {
+            "Parent": "x1000c5s5b0",
+            "Xname": "x1000c5s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1180,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001180"
+                ]
+            }
+        },
+        "x1000c5s5b0n1": {
+            "Parent": "x1000c5s5b0",
+            "Xname": "x1000c5s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1181,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001181"
+                ]
+            }
+        },
+        "x1000c5s5b1n0": {
+            "Parent": "x1000c5s5b1",
+            "Xname": "x1000c5s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1182,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001182"
+                ]
+            }
+        },
+        "x1000c5s5b1n1": {
+            "Parent": "x1000c5s5b1",
+            "Xname": "x1000c5s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1183,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001183"
+                ]
+            }
+        },
+        "x1000c5s6b0n0": {
+            "Parent": "x1000c5s6b0",
+            "Xname": "x1000c5s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1184,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001184"
+                ]
+            }
+        },
+        "x1000c5s6b0n1": {
+            "Parent": "x1000c5s6b0",
+            "Xname": "x1000c5s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1185,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001185"
+                ]
+            }
+        },
+        "x1000c5s6b1n0": {
+            "Parent": "x1000c5s6b1",
+            "Xname": "x1000c5s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1186,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001186"
+                ]
+            }
+        },
+        "x1000c5s6b1n1": {
+            "Parent": "x1000c5s6b1",
+            "Xname": "x1000c5s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1187,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001187"
+                ]
+            }
+        },
+        "x1000c5s7b0n0": {
+            "Parent": "x1000c5s7b0",
+            "Xname": "x1000c5s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1188,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001188"
+                ]
+            }
+        },
+        "x1000c5s7b0n1": {
+            "Parent": "x1000c5s7b0",
+            "Xname": "x1000c5s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1189,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001189"
+                ]
+            }
+        },
+        "x1000c5s7b1n0": {
+            "Parent": "x1000c5s7b1",
+            "Xname": "x1000c5s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1190,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001190"
+                ]
+            }
+        },
+        "x1000c5s7b1n1": {
+            "Parent": "x1000c5s7b1",
+            "Xname": "x1000c5s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1191,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001191"
+                ]
+            }
+        },
+        "x1000c6": {
+            "Parent": "x1000",
+            "Xname": "x1000c6",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c6b0": {
+            "Parent": "x1000c6",
+            "Xname": "x1000c6b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c6s0b0n0": {
+            "Parent": "x1000c6s0b0",
+            "Xname": "x1000c6s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1192,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001192"
+                ]
+            }
+        },
+        "x1000c6s0b0n1": {
+            "Parent": "x1000c6s0b0",
+            "Xname": "x1000c6s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1193,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001193"
+                ]
+            }
+        },
+        "x1000c6s0b1n0": {
+            "Parent": "x1000c6s0b1",
+            "Xname": "x1000c6s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1194,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001194"
+                ]
+            }
+        },
+        "x1000c6s0b1n1": {
+            "Parent": "x1000c6s0b1",
+            "Xname": "x1000c6s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1195,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001195"
+                ]
+            }
+        },
+        "x1000c6s1b0n0": {
+            "Parent": "x1000c6s1b0",
+            "Xname": "x1000c6s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1196,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001196"
+                ]
+            }
+        },
+        "x1000c6s1b0n1": {
+            "Parent": "x1000c6s1b0",
+            "Xname": "x1000c6s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1197,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001197"
+                ]
+            }
+        },
+        "x1000c6s1b1n0": {
+            "Parent": "x1000c6s1b1",
+            "Xname": "x1000c6s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1198,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001198"
+                ]
+            }
+        },
+        "x1000c6s1b1n1": {
+            "Parent": "x1000c6s1b1",
+            "Xname": "x1000c6s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1199,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001199"
+                ]
+            }
+        },
+        "x1000c6s2b0n0": {
+            "Parent": "x1000c6s2b0",
+            "Xname": "x1000c6s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1200,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001200"
+                ]
+            }
+        },
+        "x1000c6s2b0n1": {
+            "Parent": "x1000c6s2b0",
+            "Xname": "x1000c6s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1201,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001201"
+                ]
+            }
+        },
+        "x1000c6s2b1n0": {
+            "Parent": "x1000c6s2b1",
+            "Xname": "x1000c6s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1202,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001202"
+                ]
+            }
+        },
+        "x1000c6s2b1n1": {
+            "Parent": "x1000c6s2b1",
+            "Xname": "x1000c6s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1203,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001203"
+                ]
+            }
+        },
+        "x1000c6s3b0n0": {
+            "Parent": "x1000c6s3b0",
+            "Xname": "x1000c6s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1204,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001204"
+                ]
+            }
+        },
+        "x1000c6s3b0n1": {
+            "Parent": "x1000c6s3b0",
+            "Xname": "x1000c6s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1205,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001205"
+                ]
+            }
+        },
+        "x1000c6s3b1n0": {
+            "Parent": "x1000c6s3b1",
+            "Xname": "x1000c6s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1206,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001206"
+                ]
+            }
+        },
+        "x1000c6s3b1n1": {
+            "Parent": "x1000c6s3b1",
+            "Xname": "x1000c6s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1207,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001207"
+                ]
+            }
+        },
+        "x1000c6s4b0n0": {
+            "Parent": "x1000c6s4b0",
+            "Xname": "x1000c6s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1208,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001208"
+                ]
+            }
+        },
+        "x1000c6s4b0n1": {
+            "Parent": "x1000c6s4b0",
+            "Xname": "x1000c6s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1209,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001209"
+                ]
+            }
+        },
+        "x1000c6s4b1n0": {
+            "Parent": "x1000c6s4b1",
+            "Xname": "x1000c6s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1210,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001210"
+                ]
+            }
+        },
+        "x1000c6s4b1n1": {
+            "Parent": "x1000c6s4b1",
+            "Xname": "x1000c6s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1211,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001211"
+                ]
+            }
+        },
+        "x1000c6s5b0n0": {
+            "Parent": "x1000c6s5b0",
+            "Xname": "x1000c6s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1212,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001212"
+                ]
+            }
+        },
+        "x1000c6s5b0n1": {
+            "Parent": "x1000c6s5b0",
+            "Xname": "x1000c6s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1213,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001213"
+                ]
+            }
+        },
+        "x1000c6s5b1n0": {
+            "Parent": "x1000c6s5b1",
+            "Xname": "x1000c6s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1214,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001214"
+                ]
+            }
+        },
+        "x1000c6s5b1n1": {
+            "Parent": "x1000c6s5b1",
+            "Xname": "x1000c6s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1215,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001215"
+                ]
+            }
+        },
+        "x1000c6s6b0n0": {
+            "Parent": "x1000c6s6b0",
+            "Xname": "x1000c6s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1216,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001216"
+                ]
+            }
+        },
+        "x1000c6s6b0n1": {
+            "Parent": "x1000c6s6b0",
+            "Xname": "x1000c6s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1217,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001217"
+                ]
+            }
+        },
+        "x1000c6s6b1n0": {
+            "Parent": "x1000c6s6b1",
+            "Xname": "x1000c6s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1218,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001218"
+                ]
+            }
+        },
+        "x1000c6s6b1n1": {
+            "Parent": "x1000c6s6b1",
+            "Xname": "x1000c6s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1219,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001219"
+                ]
+            }
+        },
+        "x1000c6s7b0n0": {
+            "Parent": "x1000c6s7b0",
+            "Xname": "x1000c6s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1220,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001220"
+                ]
+            }
+        },
+        "x1000c6s7b0n1": {
+            "Parent": "x1000c6s7b0",
+            "Xname": "x1000c6s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1221,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001221"
+                ]
+            }
+        },
+        "x1000c6s7b1n0": {
+            "Parent": "x1000c6s7b1",
+            "Xname": "x1000c6s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1222,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001222"
+                ]
+            }
+        },
+        "x1000c6s7b1n1": {
+            "Parent": "x1000c6s7b1",
+            "Xname": "x1000c6s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1223,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001223"
+                ]
+            }
+        },
+        "x1000c7": {
+            "Parent": "x1000",
+            "Xname": "x1000c7",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c7b0": {
+            "Parent": "x1000c7",
+            "Xname": "x1000c7b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c7s0b0n0": {
+            "Parent": "x1000c7s0b0",
+            "Xname": "x1000c7s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1224,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001224"
+                ]
+            }
+        },
+        "x1000c7s0b0n1": {
+            "Parent": "x1000c7s0b0",
+            "Xname": "x1000c7s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1225,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001225"
+                ]
+            }
+        },
+        "x1000c7s0b1n0": {
+            "Parent": "x1000c7s0b1",
+            "Xname": "x1000c7s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1226,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001226"
+                ]
+            }
+        },
+        "x1000c7s0b1n1": {
+            "Parent": "x1000c7s0b1",
+            "Xname": "x1000c7s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1227,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001227"
+                ]
+            }
+        },
+        "x1000c7s1b0n0": {
+            "Parent": "x1000c7s1b0",
+            "Xname": "x1000c7s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1228,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001228"
+                ]
+            }
+        },
+        "x1000c7s1b0n1": {
+            "Parent": "x1000c7s1b0",
+            "Xname": "x1000c7s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1229,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001229"
+                ]
+            }
+        },
+        "x1000c7s1b1n0": {
+            "Parent": "x1000c7s1b1",
+            "Xname": "x1000c7s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1230,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001230"
+                ]
+            }
+        },
+        "x1000c7s1b1n1": {
+            "Parent": "x1000c7s1b1",
+            "Xname": "x1000c7s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1231,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001231"
+                ]
+            }
+        },
+        "x1000c7s2b0n0": {
+            "Parent": "x1000c7s2b0",
+            "Xname": "x1000c7s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1232,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001232"
+                ]
+            }
+        },
+        "x1000c7s2b0n1": {
+            "Parent": "x1000c7s2b0",
+            "Xname": "x1000c7s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1233,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001233"
+                ]
+            }
+        },
+        "x1000c7s2b1n0": {
+            "Parent": "x1000c7s2b1",
+            "Xname": "x1000c7s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1234,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001234"
+                ]
+            }
+        },
+        "x1000c7s2b1n1": {
+            "Parent": "x1000c7s2b1",
+            "Xname": "x1000c7s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1235,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001235"
+                ]
+            }
+        },
+        "x1000c7s3b0n0": {
+            "Parent": "x1000c7s3b0",
+            "Xname": "x1000c7s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1236,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001236"
+                ]
+            }
+        },
+        "x1000c7s3b0n1": {
+            "Parent": "x1000c7s3b0",
+            "Xname": "x1000c7s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1237,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001237"
+                ]
+            }
+        },
+        "x1000c7s3b1n0": {
+            "Parent": "x1000c7s3b1",
+            "Xname": "x1000c7s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1238,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001238"
+                ]
+            }
+        },
+        "x1000c7s3b1n1": {
+            "Parent": "x1000c7s3b1",
+            "Xname": "x1000c7s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1239,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001239"
+                ]
+            }
+        },
+        "x1000c7s4b0n0": {
+            "Parent": "x1000c7s4b0",
+            "Xname": "x1000c7s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1240,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001240"
+                ]
+            }
+        },
+        "x1000c7s4b0n1": {
+            "Parent": "x1000c7s4b0",
+            "Xname": "x1000c7s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1241,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001241"
+                ]
+            }
+        },
+        "x1000c7s4b1n0": {
+            "Parent": "x1000c7s4b1",
+            "Xname": "x1000c7s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1242,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001242"
+                ]
+            }
+        },
+        "x1000c7s4b1n1": {
+            "Parent": "x1000c7s4b1",
+            "Xname": "x1000c7s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1243,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001243"
+                ]
+            }
+        },
+        "x1000c7s5b0n0": {
+            "Parent": "x1000c7s5b0",
+            "Xname": "x1000c7s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1244,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001244"
+                ]
+            }
+        },
+        "x1000c7s5b0n1": {
+            "Parent": "x1000c7s5b0",
+            "Xname": "x1000c7s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1245,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001245"
+                ]
+            }
+        },
+        "x1000c7s5b1n0": {
+            "Parent": "x1000c7s5b1",
+            "Xname": "x1000c7s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1246,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001246"
+                ]
+            }
+        },
+        "x1000c7s5b1n1": {
+            "Parent": "x1000c7s5b1",
+            "Xname": "x1000c7s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1247,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001247"
+                ]
+            }
+        },
+        "x1000c7s6b0n0": {
+            "Parent": "x1000c7s6b0",
+            "Xname": "x1000c7s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1248,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001248"
+                ]
+            }
+        },
+        "x1000c7s6b0n1": {
+            "Parent": "x1000c7s6b0",
+            "Xname": "x1000c7s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1249,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001249"
+                ]
+            }
+        },
+        "x1000c7s6b1n0": {
+            "Parent": "x1000c7s6b1",
+            "Xname": "x1000c7s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1250,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001250"
+                ]
+            }
+        },
+        "x1000c7s6b1n1": {
+            "Parent": "x1000c7s6b1",
+            "Xname": "x1000c7s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1251,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001251"
+                ]
+            }
+        },
+        "x1000c7s7b0n0": {
+            "Parent": "x1000c7s7b0",
+            "Xname": "x1000c7s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1252,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001252"
+                ]
+            }
+        },
+        "x1000c7s7b0n1": {
+            "Parent": "x1000c7s7b0",
+            "Xname": "x1000c7s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1253,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001253"
+                ]
+            }
+        },
+        "x1000c7s7b1n0": {
+            "Parent": "x1000c7s7b1",
+            "Xname": "x1000c7s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1254,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001254"
+                ]
+            }
+        },
+        "x1000c7s7b1n1": {
+            "Parent": "x1000c7s7b1",
+            "Xname": "x1000c7s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1255,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001255"
+                ]
+            }
+        },
+        "x3000": {
+            "Parent": "s0",
+            "Xname": "x3000",
+            "Type": "comptype_cabinet",
+            "Class": "River",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    },
+                    "ncn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    }
+                }
+            }
+        },
+        "x3000c0h33s1": {
+            "Parent": "x3000c0h33",
+            "Xname": "x3000c0h33s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.4",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-001"
+                ]
+            }
+        },
+        "x3000c0h34s1": {
+            "Parent": "x3000c0h34",
+            "Xname": "x3000c0h34s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.5",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-002"
+                ]
+            }
+        },
+        "x3000c0h35s1": {
+            "Parent": "x3000c0h35",
+            "Xname": "x3000c0h35s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.6",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-003"
+                ]
+            }
+        },
+        "x3000c0h36s1": {
+            "Parent": "x3000c0h36",
+            "Xname": "x3000c0h36s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.7",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-004"
+                ]
+            }
+        },
+        "x3000c0h37s1": {
+            "Parent": "x3000c0h37",
+            "Xname": "x3000c0h37s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.2",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-001"
+                ]
+            }
+        },
+        "x3000c0h38s1": {
+            "Parent": "x3000c0h38",
+            "Xname": "x3000c0h38s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.3",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-002"
+                ]
+            }
+        },
+        "x3000c0r39b0": {
+            "Parent": "x3000c0r39",
+            "Xname": "x3000c0r39b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x3000c0r39b0",
+                "Password": "vault://hms-creds/x3000c0r39b0"
+            }
+        },
+        "x3000c0r40b0": {
+            "Parent": "x3000c0r40",
+            "Xname": "x3000c0r40b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x3000c0r40b0",
+                "Password": "vault://hms-creds/x3000c0r40b0"
+            }
+        },
+        "x3000c0s10b0n0": {
+            "Parent": "x3000c0s10b0",
+            "Xname": "x3000c0s10b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100001,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s003"
+                ]
+            }
+        },
+        "x3000c0s15b0n0": {
+            "Parent": "x3000c0s15b0",
+            "Xname": "x3000c0s15b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan01"
+                ]
+            }
+        },
+        "x3000c0s16b0n0": {
+            "Parent": "x3000c0s16b0",
+            "Xname": "x3000c0s16b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan02"
+                ]
+            }
+        },
+        "x3000c0s1b0n0": {
+            "Parent": "x3000c0s1b0",
+            "Xname": "x3000c0s1b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100010,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m001"
+                ]
+            }
+        },
+        "x3000c0s24b0n0": {
+            "Parent": "x3000c0s24b0",
+            "Xname": "x3000c0s24b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "@rie.mockup": "XL675d_A40",
+                "NID": 1,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid000001"
+                ]
+            }
+        },
+        "x3000c0s2b0n0": {
+            "Parent": "x3000c0s2b0",
+            "Xname": "x3000c0s2b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100009,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m002"
+                ]
+            }
+        },
+        "x3000c0s3b0n0": {
+            "Parent": "x3000c0s3b0",
+            "Xname": "x3000c0s3b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100008,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m003"
+                ]
+            }
+        },
+        "x3000c0s4b0n0": {
+            "Parent": "x3000c0s4b0",
+            "Xname": "x3000c0s4b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100007,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w001"
+                ]
+            }
+        },
+        "x3000c0s5b0n0": {
+            "Parent": "x3000c0s5b0",
+            "Xname": "x3000c0s5b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100006,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w002"
+                ]
+            }
+        },
+        "x3000c0s6b0n0": {
+            "Parent": "x3000c0s6b0",
+            "Xname": "x3000c0s6b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100005,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w003"
+                ]
+            }
+        },
+        "x3000c0s7b0n0": {
+            "Parent": "x3000c0s7b0",
+            "Xname": "x3000c0s7b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100004,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w004"
+                ]
+            }
+        },
+        "x3000c0s8b0n0": {
+            "Parent": "x3000c0s8b0",
+            "Xname": "x3000c0s8b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100003,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s001"
+                ]
+            }
+        },
+        "x3000c0s9b0n0": {
+            "Parent": "x3000c0s9b0",
+            "Xname": "x3000c0s9b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100002,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s002"
+                ]
+            }
+        },
+        "x3000c0w31": {
+            "Parent": "x3000c0",
+            "Xname": "x3000c0w31",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.8",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-001"
+                ]
+            }
+        },
+        "x3000c0w31j29": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j29",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s24b0"
+                ],
+                "VendorName": "1/1/29"
+            }
+        },
+        "x3000c0w31j34": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j34",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s2b0"
+                ],
+                "VendorName": "1/1/34"
+            }
+        },
+        "x3000c0w31j35": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j35",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s4b0"
+                ],
+                "VendorName": "1/1/35"
+            }
+        },
+        "x3000c0w31j36": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s5b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x3000c0w31j37": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s6b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x3000c0w31j38": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s8b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x3000c0w31j39": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j39",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s9b0"
+                ],
+                "VendorName": "1/1/39"
+            }
+        },
+        "x3000c0w31j40": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j40",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s15b0"
+                ],
+                "VendorName": "1/1/40"
+            }
+        },
+        "x3000c0w31j41": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j41",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s16b0"
+                ],
+                "VendorName": "1/1/41"
+            }
+        },
+        "x3000c0w31j47": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0r39b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x3000c0w31j48": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000m0"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x3000c0w32": {
+            "Parent": "x3000c0",
+            "Xname": "x3000c0w32",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.9",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x3000c0w32",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x3000c0w32",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-002"
+                ]
+            }
+        },
+        "x3000c0w32j36": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s3b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x3000c0w32j37": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s7b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x3000c0w32j38": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s10b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x3000c0w32j47": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0r40b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x3000c0w32j48": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000m1"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x3000m0": {
+            "Parent": "x3000",
+            "Xname": "x3000m0",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        },
+        "x3000m1": {
+            "Parent": "x3000",
+            "Xname": "x3000m1",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        }
+    },
+    "Networks": {}
+}

--- a/testdata/fixtures/sls/EX4000_River.json
+++ b/testdata/fixtures/sls/EX4000_River.json
@@ -1,0 +1,4345 @@
+{
+    "Hardware": {
+        "d0w1": {
+            "Parent": "d0",
+            "Xname": "d0w1",
+            "Type": "comptype_cdu_mgmt_switch",
+            "Class": "Mountain",
+            "TypeString": "CDUMgmtSwitch",
+            "ExtraProperties": {
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-cdu-001"
+                ]
+            }
+        },
+        "d0w2": {
+            "Parent": "d0",
+            "Xname": "d0w2",
+            "Type": "comptype_cdu_mgmt_switch",
+            "Class": "Mountain",
+            "TypeString": "CDUMgmtSwitch",
+            "ExtraProperties": {
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-cdu-002"
+                ]
+            }
+        },
+        "x1000": {
+            "Parent": "s0",
+            "Xname": "x1000",
+            "Type": "comptype_cabinet",
+            "Class": "Mountain",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Model": "EX4000",
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.104.0.0/22",
+                            "Gateway": "10.104.0.1",
+                            "VLan": 3000
+                        },
+                        "NMN": {
+                            "CIDR": "10.100.0.0/22",
+                            "Gateway": "10.100.0.1",
+                            "VLan": 2000
+                        }
+                    }
+                }
+            }
+        },
+        "x1000c0": {
+            "Parent": "x1000",
+            "Xname": "x1000c0",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c0b0": {
+            "Parent": "x1000c0",
+            "Xname": "x1000c0b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c0s0b0n0": {
+            "Parent": "x1000c0s0b0",
+            "Xname": "x1000c0s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1000,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001000"
+                ]
+            }
+        },
+        "x1000c0s0b0n1": {
+            "Parent": "x1000c0s0b0",
+            "Xname": "x1000c0s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1001,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001001"
+                ]
+            }
+        },
+        "x1000c0s0b1n0": {
+            "Parent": "x1000c0s0b1",
+            "Xname": "x1000c0s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1002,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001002"
+                ]
+            }
+        },
+        "x1000c0s0b1n1": {
+            "Parent": "x1000c0s0b1",
+            "Xname": "x1000c0s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1003,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001003"
+                ]
+            }
+        },
+        "x1000c0s1b0n0": {
+            "Parent": "x1000c0s1b0",
+            "Xname": "x1000c0s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1004,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001004"
+                ]
+            }
+        },
+        "x1000c0s1b0n1": {
+            "Parent": "x1000c0s1b0",
+            "Xname": "x1000c0s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1005,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001005"
+                ]
+            }
+        },
+        "x1000c0s1b1n0": {
+            "Parent": "x1000c0s1b1",
+            "Xname": "x1000c0s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1006,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001006"
+                ]
+            }
+        },
+        "x1000c0s1b1n1": {
+            "Parent": "x1000c0s1b1",
+            "Xname": "x1000c0s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1007,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001007"
+                ]
+            }
+        },
+        "x1000c0s2b0n0": {
+            "Parent": "x1000c0s2b0",
+            "Xname": "x1000c0s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1008,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001008"
+                ]
+            }
+        },
+        "x1000c0s2b0n1": {
+            "Parent": "x1000c0s2b0",
+            "Xname": "x1000c0s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1009,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001009"
+                ]
+            }
+        },
+        "x1000c0s2b1n0": {
+            "Parent": "x1000c0s2b1",
+            "Xname": "x1000c0s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1010,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001010"
+                ]
+            }
+        },
+        "x1000c0s2b1n1": {
+            "Parent": "x1000c0s2b1",
+            "Xname": "x1000c0s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1011,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001011"
+                ]
+            }
+        },
+        "x1000c0s3b0n0": {
+            "Parent": "x1000c0s3b0",
+            "Xname": "x1000c0s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1012,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001012"
+                ]
+            }
+        },
+        "x1000c0s3b0n1": {
+            "Parent": "x1000c0s3b0",
+            "Xname": "x1000c0s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1013,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001013"
+                ]
+            }
+        },
+        "x1000c0s3b1n0": {
+            "Parent": "x1000c0s3b1",
+            "Xname": "x1000c0s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1014,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001014"
+                ]
+            }
+        },
+        "x1000c0s3b1n1": {
+            "Parent": "x1000c0s3b1",
+            "Xname": "x1000c0s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1015,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001015"
+                ]
+            }
+        },
+        "x1000c0s4b0n0": {
+            "Parent": "x1000c0s4b0",
+            "Xname": "x1000c0s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1016,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001016"
+                ]
+            }
+        },
+        "x1000c0s4b0n1": {
+            "Parent": "x1000c0s4b0",
+            "Xname": "x1000c0s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1017,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001017"
+                ]
+            }
+        },
+        "x1000c0s4b1n0": {
+            "Parent": "x1000c0s4b1",
+            "Xname": "x1000c0s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1018,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001018"
+                ]
+            }
+        },
+        "x1000c0s4b1n1": {
+            "Parent": "x1000c0s4b1",
+            "Xname": "x1000c0s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1019,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001019"
+                ]
+            }
+        },
+        "x1000c0s5b0n0": {
+            "Parent": "x1000c0s5b0",
+            "Xname": "x1000c0s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1020,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001020"
+                ]
+            }
+        },
+        "x1000c0s5b0n1": {
+            "Parent": "x1000c0s5b0",
+            "Xname": "x1000c0s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1021,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001021"
+                ]
+            }
+        },
+        "x1000c0s5b1n0": {
+            "Parent": "x1000c0s5b1",
+            "Xname": "x1000c0s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1022,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001022"
+                ]
+            }
+        },
+        "x1000c0s5b1n1": {
+            "Parent": "x1000c0s5b1",
+            "Xname": "x1000c0s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1023,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001023"
+                ]
+            }
+        },
+        "x1000c0s6b0n0": {
+            "Parent": "x1000c0s6b0",
+            "Xname": "x1000c0s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1024,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001024"
+                ]
+            }
+        },
+        "x1000c0s6b0n1": {
+            "Parent": "x1000c0s6b0",
+            "Xname": "x1000c0s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1025,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001025"
+                ]
+            }
+        },
+        "x1000c0s6b1n0": {
+            "Parent": "x1000c0s6b1",
+            "Xname": "x1000c0s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1026,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001026"
+                ]
+            }
+        },
+        "x1000c0s6b1n1": {
+            "Parent": "x1000c0s6b1",
+            "Xname": "x1000c0s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1027,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001027"
+                ]
+            }
+        },
+        "x1000c0s7b0n0": {
+            "Parent": "x1000c0s7b0",
+            "Xname": "x1000c0s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1028,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001028"
+                ]
+            }
+        },
+        "x1000c0s7b0n1": {
+            "Parent": "x1000c0s7b0",
+            "Xname": "x1000c0s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1029,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001029"
+                ]
+            }
+        },
+        "x1000c0s7b1n0": {
+            "Parent": "x1000c0s7b1",
+            "Xname": "x1000c0s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1030,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001030"
+                ]
+            }
+        },
+        "x1000c0s7b1n1": {
+            "Parent": "x1000c0s7b1",
+            "Xname": "x1000c0s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1031,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001031"
+                ]
+            }
+        },
+        "x1000c1": {
+            "Parent": "x1000",
+            "Xname": "x1000c1",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c1b0": {
+            "Parent": "x1000c1",
+            "Xname": "x1000c1b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c1s0b0n0": {
+            "Parent": "x1000c1s0b0",
+            "Xname": "x1000c1s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1032,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001032"
+                ]
+            }
+        },
+        "x1000c1s0b0n1": {
+            "Parent": "x1000c1s0b0",
+            "Xname": "x1000c1s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1033,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001033"
+                ]
+            }
+        },
+        "x1000c1s0b1n0": {
+            "Parent": "x1000c1s0b1",
+            "Xname": "x1000c1s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1034,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001034"
+                ]
+            }
+        },
+        "x1000c1s0b1n1": {
+            "Parent": "x1000c1s0b1",
+            "Xname": "x1000c1s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1035,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001035"
+                ]
+            }
+        },
+        "x1000c1s1b0n0": {
+            "Parent": "x1000c1s1b0",
+            "Xname": "x1000c1s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1036,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001036"
+                ]
+            }
+        },
+        "x1000c1s1b0n1": {
+            "Parent": "x1000c1s1b0",
+            "Xname": "x1000c1s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1037,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001037"
+                ]
+            }
+        },
+        "x1000c1s1b1n0": {
+            "Parent": "x1000c1s1b1",
+            "Xname": "x1000c1s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1038,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001038"
+                ]
+            }
+        },
+        "x1000c1s1b1n1": {
+            "Parent": "x1000c1s1b1",
+            "Xname": "x1000c1s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1039,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001039"
+                ]
+            }
+        },
+        "x1000c1s2b0n0": {
+            "Parent": "x1000c1s2b0",
+            "Xname": "x1000c1s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1040,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001040"
+                ]
+            }
+        },
+        "x1000c1s2b0n1": {
+            "Parent": "x1000c1s2b0",
+            "Xname": "x1000c1s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1041,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001041"
+                ]
+            }
+        },
+        "x1000c1s2b1n0": {
+            "Parent": "x1000c1s2b1",
+            "Xname": "x1000c1s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1042,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001042"
+                ]
+            }
+        },
+        "x1000c1s2b1n1": {
+            "Parent": "x1000c1s2b1",
+            "Xname": "x1000c1s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1043,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001043"
+                ]
+            }
+        },
+        "x1000c1s3b0n0": {
+            "Parent": "x1000c1s3b0",
+            "Xname": "x1000c1s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1044,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001044"
+                ]
+            }
+        },
+        "x1000c1s3b0n1": {
+            "Parent": "x1000c1s3b0",
+            "Xname": "x1000c1s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1045,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001045"
+                ]
+            }
+        },
+        "x1000c1s3b1n0": {
+            "Parent": "x1000c1s3b1",
+            "Xname": "x1000c1s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1046,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001046"
+                ]
+            }
+        },
+        "x1000c1s3b1n1": {
+            "Parent": "x1000c1s3b1",
+            "Xname": "x1000c1s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1047,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001047"
+                ]
+            }
+        },
+        "x1000c1s4b0n0": {
+            "Parent": "x1000c1s4b0",
+            "Xname": "x1000c1s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1048,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001048"
+                ]
+            }
+        },
+        "x1000c1s4b0n1": {
+            "Parent": "x1000c1s4b0",
+            "Xname": "x1000c1s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1049,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001049"
+                ]
+            }
+        },
+        "x1000c1s4b1n0": {
+            "Parent": "x1000c1s4b1",
+            "Xname": "x1000c1s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1050,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001050"
+                ]
+            }
+        },
+        "x1000c1s4b1n1": {
+            "Parent": "x1000c1s4b1",
+            "Xname": "x1000c1s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1051,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001051"
+                ]
+            }
+        },
+        "x1000c1s5b0n0": {
+            "Parent": "x1000c1s5b0",
+            "Xname": "x1000c1s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1052,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001052"
+                ]
+            }
+        },
+        "x1000c1s5b0n1": {
+            "Parent": "x1000c1s5b0",
+            "Xname": "x1000c1s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1053,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001053"
+                ]
+            }
+        },
+        "x1000c1s5b1n0": {
+            "Parent": "x1000c1s5b1",
+            "Xname": "x1000c1s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1054,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001054"
+                ]
+            }
+        },
+        "x1000c1s5b1n1": {
+            "Parent": "x1000c1s5b1",
+            "Xname": "x1000c1s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1055,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001055"
+                ]
+            }
+        },
+        "x1000c1s6b0n0": {
+            "Parent": "x1000c1s6b0",
+            "Xname": "x1000c1s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1056,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001056"
+                ]
+            }
+        },
+        "x1000c1s6b0n1": {
+            "Parent": "x1000c1s6b0",
+            "Xname": "x1000c1s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1057,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001057"
+                ]
+            }
+        },
+        "x1000c1s6b1n0": {
+            "Parent": "x1000c1s6b1",
+            "Xname": "x1000c1s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1058,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001058"
+                ]
+            }
+        },
+        "x1000c1s6b1n1": {
+            "Parent": "x1000c1s6b1",
+            "Xname": "x1000c1s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1059,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001059"
+                ]
+            }
+        },
+        "x1000c1s7b0n0": {
+            "Parent": "x1000c1s7b0",
+            "Xname": "x1000c1s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1060,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001060"
+                ]
+            }
+        },
+        "x1000c1s7b0n1": {
+            "Parent": "x1000c1s7b0",
+            "Xname": "x1000c1s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1061,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001061"
+                ]
+            }
+        },
+        "x1000c1s7b1n0": {
+            "Parent": "x1000c1s7b1",
+            "Xname": "x1000c1s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1062,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001062"
+                ]
+            }
+        },
+        "x1000c1s7b1n1": {
+            "Parent": "x1000c1s7b1",
+            "Xname": "x1000c1s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1063,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001063"
+                ]
+            }
+        },
+        "x1000c2": {
+            "Parent": "x1000",
+            "Xname": "x1000c2",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c2b0": {
+            "Parent": "x1000c2",
+            "Xname": "x1000c2b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c2s0b0n0": {
+            "Parent": "x1000c2s0b0",
+            "Xname": "x1000c2s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1064,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001064"
+                ]
+            }
+        },
+        "x1000c2s0b0n1": {
+            "Parent": "x1000c2s0b0",
+            "Xname": "x1000c2s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1065,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001065"
+                ]
+            }
+        },
+        "x1000c2s0b1n0": {
+            "Parent": "x1000c2s0b1",
+            "Xname": "x1000c2s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1066,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001066"
+                ]
+            }
+        },
+        "x1000c2s0b1n1": {
+            "Parent": "x1000c2s0b1",
+            "Xname": "x1000c2s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1067,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001067"
+                ]
+            }
+        },
+        "x1000c2s1b0n0": {
+            "Parent": "x1000c2s1b0",
+            "Xname": "x1000c2s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1068,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001068"
+                ]
+            }
+        },
+        "x1000c2s1b0n1": {
+            "Parent": "x1000c2s1b0",
+            "Xname": "x1000c2s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1069,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001069"
+                ]
+            }
+        },
+        "x1000c2s1b1n0": {
+            "Parent": "x1000c2s1b1",
+            "Xname": "x1000c2s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1070,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001070"
+                ]
+            }
+        },
+        "x1000c2s1b1n1": {
+            "Parent": "x1000c2s1b1",
+            "Xname": "x1000c2s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1071,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001071"
+                ]
+            }
+        },
+        "x1000c2s2b0n0": {
+            "Parent": "x1000c2s2b0",
+            "Xname": "x1000c2s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1072,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001072"
+                ]
+            }
+        },
+        "x1000c2s2b0n1": {
+            "Parent": "x1000c2s2b0",
+            "Xname": "x1000c2s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1073,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001073"
+                ]
+            }
+        },
+        "x1000c2s2b1n0": {
+            "Parent": "x1000c2s2b1",
+            "Xname": "x1000c2s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1074,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001074"
+                ]
+            }
+        },
+        "x1000c2s2b1n1": {
+            "Parent": "x1000c2s2b1",
+            "Xname": "x1000c2s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1075,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001075"
+                ]
+            }
+        },
+        "x1000c2s3b0n0": {
+            "Parent": "x1000c2s3b0",
+            "Xname": "x1000c2s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1076,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001076"
+                ]
+            }
+        },
+        "x1000c2s3b0n1": {
+            "Parent": "x1000c2s3b0",
+            "Xname": "x1000c2s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1077,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001077"
+                ]
+            }
+        },
+        "x1000c2s3b1n0": {
+            "Parent": "x1000c2s3b1",
+            "Xname": "x1000c2s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1078,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001078"
+                ]
+            }
+        },
+        "x1000c2s3b1n1": {
+            "Parent": "x1000c2s3b1",
+            "Xname": "x1000c2s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1079,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001079"
+                ]
+            }
+        },
+        "x1000c2s4b0n0": {
+            "Parent": "x1000c2s4b0",
+            "Xname": "x1000c2s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1080,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001080"
+                ]
+            }
+        },
+        "x1000c2s4b0n1": {
+            "Parent": "x1000c2s4b0",
+            "Xname": "x1000c2s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1081,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001081"
+                ]
+            }
+        },
+        "x1000c2s4b1n0": {
+            "Parent": "x1000c2s4b1",
+            "Xname": "x1000c2s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1082,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001082"
+                ]
+            }
+        },
+        "x1000c2s4b1n1": {
+            "Parent": "x1000c2s4b1",
+            "Xname": "x1000c2s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1083,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001083"
+                ]
+            }
+        },
+        "x1000c2s5b0n0": {
+            "Parent": "x1000c2s5b0",
+            "Xname": "x1000c2s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1084,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001084"
+                ]
+            }
+        },
+        "x1000c2s5b0n1": {
+            "Parent": "x1000c2s5b0",
+            "Xname": "x1000c2s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1085,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001085"
+                ]
+            }
+        },
+        "x1000c2s5b1n0": {
+            "Parent": "x1000c2s5b1",
+            "Xname": "x1000c2s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1086,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001086"
+                ]
+            }
+        },
+        "x1000c2s5b1n1": {
+            "Parent": "x1000c2s5b1",
+            "Xname": "x1000c2s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1087,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001087"
+                ]
+            }
+        },
+        "x1000c2s6b0n0": {
+            "Parent": "x1000c2s6b0",
+            "Xname": "x1000c2s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1088,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001088"
+                ]
+            }
+        },
+        "x1000c2s6b0n1": {
+            "Parent": "x1000c2s6b0",
+            "Xname": "x1000c2s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1089,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001089"
+                ]
+            }
+        },
+        "x1000c2s6b1n0": {
+            "Parent": "x1000c2s6b1",
+            "Xname": "x1000c2s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1090,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001090"
+                ]
+            }
+        },
+        "x1000c2s6b1n1": {
+            "Parent": "x1000c2s6b1",
+            "Xname": "x1000c2s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1091,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001091"
+                ]
+            }
+        },
+        "x1000c2s7b0n0": {
+            "Parent": "x1000c2s7b0",
+            "Xname": "x1000c2s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1092,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001092"
+                ]
+            }
+        },
+        "x1000c2s7b0n1": {
+            "Parent": "x1000c2s7b0",
+            "Xname": "x1000c2s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1093,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001093"
+                ]
+            }
+        },
+        "x1000c2s7b1n0": {
+            "Parent": "x1000c2s7b1",
+            "Xname": "x1000c2s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1094,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001094"
+                ]
+            }
+        },
+        "x1000c2s7b1n1": {
+            "Parent": "x1000c2s7b1",
+            "Xname": "x1000c2s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1095,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001095"
+                ]
+            }
+        },
+        "x1000c3": {
+            "Parent": "x1000",
+            "Xname": "x1000c3",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c3b0": {
+            "Parent": "x1000c3",
+            "Xname": "x1000c3b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c3s0b0n0": {
+            "Parent": "x1000c3s0b0",
+            "Xname": "x1000c3s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1096,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001096"
+                ]
+            }
+        },
+        "x1000c3s0b0n1": {
+            "Parent": "x1000c3s0b0",
+            "Xname": "x1000c3s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1097,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001097"
+                ]
+            }
+        },
+        "x1000c3s0b1n0": {
+            "Parent": "x1000c3s0b1",
+            "Xname": "x1000c3s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1098,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001098"
+                ]
+            }
+        },
+        "x1000c3s0b1n1": {
+            "Parent": "x1000c3s0b1",
+            "Xname": "x1000c3s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1099,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001099"
+                ]
+            }
+        },
+        "x1000c3s1b0n0": {
+            "Parent": "x1000c3s1b0",
+            "Xname": "x1000c3s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1100,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001100"
+                ]
+            }
+        },
+        "x1000c3s1b0n1": {
+            "Parent": "x1000c3s1b0",
+            "Xname": "x1000c3s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1101,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001101"
+                ]
+            }
+        },
+        "x1000c3s1b1n0": {
+            "Parent": "x1000c3s1b1",
+            "Xname": "x1000c3s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1102,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001102"
+                ]
+            }
+        },
+        "x1000c3s1b1n1": {
+            "Parent": "x1000c3s1b1",
+            "Xname": "x1000c3s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1103,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001103"
+                ]
+            }
+        },
+        "x1000c3s2b0n0": {
+            "Parent": "x1000c3s2b0",
+            "Xname": "x1000c3s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1104,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001104"
+                ]
+            }
+        },
+        "x1000c3s2b0n1": {
+            "Parent": "x1000c3s2b0",
+            "Xname": "x1000c3s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1105,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001105"
+                ]
+            }
+        },
+        "x1000c3s2b1n0": {
+            "Parent": "x1000c3s2b1",
+            "Xname": "x1000c3s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1106,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001106"
+                ]
+            }
+        },
+        "x1000c3s2b1n1": {
+            "Parent": "x1000c3s2b1",
+            "Xname": "x1000c3s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1107,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001107"
+                ]
+            }
+        },
+        "x1000c3s3b0n0": {
+            "Parent": "x1000c3s3b0",
+            "Xname": "x1000c3s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1108,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001108"
+                ]
+            }
+        },
+        "x1000c3s3b0n1": {
+            "Parent": "x1000c3s3b0",
+            "Xname": "x1000c3s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1109,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001109"
+                ]
+            }
+        },
+        "x1000c3s3b1n0": {
+            "Parent": "x1000c3s3b1",
+            "Xname": "x1000c3s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1110,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001110"
+                ]
+            }
+        },
+        "x1000c3s3b1n1": {
+            "Parent": "x1000c3s3b1",
+            "Xname": "x1000c3s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1111,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001111"
+                ]
+            }
+        },
+        "x1000c3s4b0n0": {
+            "Parent": "x1000c3s4b0",
+            "Xname": "x1000c3s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1112,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001112"
+                ]
+            }
+        },
+        "x1000c3s4b0n1": {
+            "Parent": "x1000c3s4b0",
+            "Xname": "x1000c3s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1113,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001113"
+                ]
+            }
+        },
+        "x1000c3s4b1n0": {
+            "Parent": "x1000c3s4b1",
+            "Xname": "x1000c3s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1114,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001114"
+                ]
+            }
+        },
+        "x1000c3s4b1n1": {
+            "Parent": "x1000c3s4b1",
+            "Xname": "x1000c3s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1115,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001115"
+                ]
+            }
+        },
+        "x1000c3s5b0n0": {
+            "Parent": "x1000c3s5b0",
+            "Xname": "x1000c3s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1116,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001116"
+                ]
+            }
+        },
+        "x1000c3s5b0n1": {
+            "Parent": "x1000c3s5b0",
+            "Xname": "x1000c3s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1117,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001117"
+                ]
+            }
+        },
+        "x1000c3s5b1n0": {
+            "Parent": "x1000c3s5b1",
+            "Xname": "x1000c3s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1118,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001118"
+                ]
+            }
+        },
+        "x1000c3s5b1n1": {
+            "Parent": "x1000c3s5b1",
+            "Xname": "x1000c3s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1119,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001119"
+                ]
+            }
+        },
+        "x1000c3s6b0n0": {
+            "Parent": "x1000c3s6b0",
+            "Xname": "x1000c3s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1120,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001120"
+                ]
+            }
+        },
+        "x1000c3s6b0n1": {
+            "Parent": "x1000c3s6b0",
+            "Xname": "x1000c3s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1121,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001121"
+                ]
+            }
+        },
+        "x1000c3s6b1n0": {
+            "Parent": "x1000c3s6b1",
+            "Xname": "x1000c3s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1122,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001122"
+                ]
+            }
+        },
+        "x1000c3s6b1n1": {
+            "Parent": "x1000c3s6b1",
+            "Xname": "x1000c3s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1123,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001123"
+                ]
+            }
+        },
+        "x1000c3s7b0n0": {
+            "Parent": "x1000c3s7b0",
+            "Xname": "x1000c3s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1124,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001124"
+                ]
+            }
+        },
+        "x1000c3s7b0n1": {
+            "Parent": "x1000c3s7b0",
+            "Xname": "x1000c3s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1125,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001125"
+                ]
+            }
+        },
+        "x1000c3s7b1n0": {
+            "Parent": "x1000c3s7b1",
+            "Xname": "x1000c3s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1126,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001126"
+                ]
+            }
+        },
+        "x1000c3s7b1n1": {
+            "Parent": "x1000c3s7b1",
+            "Xname": "x1000c3s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1127,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001127"
+                ]
+            }
+        },
+        "x1000c4": {
+            "Parent": "x1000",
+            "Xname": "x1000c4",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c4b0": {
+            "Parent": "x1000c4",
+            "Xname": "x1000c4b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c4s0b0n0": {
+            "Parent": "x1000c4s0b0",
+            "Xname": "x1000c4s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1128,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001128"
+                ]
+            }
+        },
+        "x1000c4s0b0n1": {
+            "Parent": "x1000c4s0b0",
+            "Xname": "x1000c4s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1129,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001129"
+                ]
+            }
+        },
+        "x1000c4s0b1n0": {
+            "Parent": "x1000c4s0b1",
+            "Xname": "x1000c4s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1130,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001130"
+                ]
+            }
+        },
+        "x1000c4s0b1n1": {
+            "Parent": "x1000c4s0b1",
+            "Xname": "x1000c4s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1131,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001131"
+                ]
+            }
+        },
+        "x1000c4s1b0n0": {
+            "Parent": "x1000c4s1b0",
+            "Xname": "x1000c4s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1132,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001132"
+                ]
+            }
+        },
+        "x1000c4s1b0n1": {
+            "Parent": "x1000c4s1b0",
+            "Xname": "x1000c4s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1133,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001133"
+                ]
+            }
+        },
+        "x1000c4s1b1n0": {
+            "Parent": "x1000c4s1b1",
+            "Xname": "x1000c4s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1134,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001134"
+                ]
+            }
+        },
+        "x1000c4s1b1n1": {
+            "Parent": "x1000c4s1b1",
+            "Xname": "x1000c4s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1135,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001135"
+                ]
+            }
+        },
+        "x1000c4s2b0n0": {
+            "Parent": "x1000c4s2b0",
+            "Xname": "x1000c4s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1136,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001136"
+                ]
+            }
+        },
+        "x1000c4s2b0n1": {
+            "Parent": "x1000c4s2b0",
+            "Xname": "x1000c4s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1137,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001137"
+                ]
+            }
+        },
+        "x1000c4s2b1n0": {
+            "Parent": "x1000c4s2b1",
+            "Xname": "x1000c4s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1138,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001138"
+                ]
+            }
+        },
+        "x1000c4s2b1n1": {
+            "Parent": "x1000c4s2b1",
+            "Xname": "x1000c4s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1139,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001139"
+                ]
+            }
+        },
+        "x1000c4s3b0n0": {
+            "Parent": "x1000c4s3b0",
+            "Xname": "x1000c4s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1140,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001140"
+                ]
+            }
+        },
+        "x1000c4s3b0n1": {
+            "Parent": "x1000c4s3b0",
+            "Xname": "x1000c4s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1141,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001141"
+                ]
+            }
+        },
+        "x1000c4s3b1n0": {
+            "Parent": "x1000c4s3b1",
+            "Xname": "x1000c4s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1142,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001142"
+                ]
+            }
+        },
+        "x1000c4s3b1n1": {
+            "Parent": "x1000c4s3b1",
+            "Xname": "x1000c4s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1143,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001143"
+                ]
+            }
+        },
+        "x1000c4s4b0n0": {
+            "Parent": "x1000c4s4b0",
+            "Xname": "x1000c4s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1144,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001144"
+                ]
+            }
+        },
+        "x1000c4s4b0n1": {
+            "Parent": "x1000c4s4b0",
+            "Xname": "x1000c4s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1145,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001145"
+                ]
+            }
+        },
+        "x1000c4s4b1n0": {
+            "Parent": "x1000c4s4b1",
+            "Xname": "x1000c4s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1146,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001146"
+                ]
+            }
+        },
+        "x1000c4s4b1n1": {
+            "Parent": "x1000c4s4b1",
+            "Xname": "x1000c4s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1147,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001147"
+                ]
+            }
+        },
+        "x1000c4s5b0n0": {
+            "Parent": "x1000c4s5b0",
+            "Xname": "x1000c4s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1148,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001148"
+                ]
+            }
+        },
+        "x1000c4s5b0n1": {
+            "Parent": "x1000c4s5b0",
+            "Xname": "x1000c4s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1149,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001149"
+                ]
+            }
+        },
+        "x1000c4s5b1n0": {
+            "Parent": "x1000c4s5b1",
+            "Xname": "x1000c4s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1150,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001150"
+                ]
+            }
+        },
+        "x1000c4s5b1n1": {
+            "Parent": "x1000c4s5b1",
+            "Xname": "x1000c4s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1151,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001151"
+                ]
+            }
+        },
+        "x1000c4s6b0n0": {
+            "Parent": "x1000c4s6b0",
+            "Xname": "x1000c4s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1152,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001152"
+                ]
+            }
+        },
+        "x1000c4s6b0n1": {
+            "Parent": "x1000c4s6b0",
+            "Xname": "x1000c4s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1153,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001153"
+                ]
+            }
+        },
+        "x1000c4s6b1n0": {
+            "Parent": "x1000c4s6b1",
+            "Xname": "x1000c4s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1154,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001154"
+                ]
+            }
+        },
+        "x1000c4s6b1n1": {
+            "Parent": "x1000c4s6b1",
+            "Xname": "x1000c4s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1155,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001155"
+                ]
+            }
+        },
+        "x1000c4s7b0n0": {
+            "Parent": "x1000c4s7b0",
+            "Xname": "x1000c4s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1156,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001156"
+                ]
+            }
+        },
+        "x1000c4s7b0n1": {
+            "Parent": "x1000c4s7b0",
+            "Xname": "x1000c4s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1157,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001157"
+                ]
+            }
+        },
+        "x1000c4s7b1n0": {
+            "Parent": "x1000c4s7b1",
+            "Xname": "x1000c4s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1158,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001158"
+                ]
+            }
+        },
+        "x1000c4s7b1n1": {
+            "Parent": "x1000c4s7b1",
+            "Xname": "x1000c4s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1159,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001159"
+                ]
+            }
+        },
+        "x1000c5": {
+            "Parent": "x1000",
+            "Xname": "x1000c5",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c5b0": {
+            "Parent": "x1000c5",
+            "Xname": "x1000c5b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c5s0b0n0": {
+            "Parent": "x1000c5s0b0",
+            "Xname": "x1000c5s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1160,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001160"
+                ]
+            }
+        },
+        "x1000c5s0b0n1": {
+            "Parent": "x1000c5s0b0",
+            "Xname": "x1000c5s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1161,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001161"
+                ]
+            }
+        },
+        "x1000c5s0b1n0": {
+            "Parent": "x1000c5s0b1",
+            "Xname": "x1000c5s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1162,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001162"
+                ]
+            }
+        },
+        "x1000c5s0b1n1": {
+            "Parent": "x1000c5s0b1",
+            "Xname": "x1000c5s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1163,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001163"
+                ]
+            }
+        },
+        "x1000c5s1b0n0": {
+            "Parent": "x1000c5s1b0",
+            "Xname": "x1000c5s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1164,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001164"
+                ]
+            }
+        },
+        "x1000c5s1b0n1": {
+            "Parent": "x1000c5s1b0",
+            "Xname": "x1000c5s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1165,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001165"
+                ]
+            }
+        },
+        "x1000c5s1b1n0": {
+            "Parent": "x1000c5s1b1",
+            "Xname": "x1000c5s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1166,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001166"
+                ]
+            }
+        },
+        "x1000c5s1b1n1": {
+            "Parent": "x1000c5s1b1",
+            "Xname": "x1000c5s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1167,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001167"
+                ]
+            }
+        },
+        "x1000c5s2b0n0": {
+            "Parent": "x1000c5s2b0",
+            "Xname": "x1000c5s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1168,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001168"
+                ]
+            }
+        },
+        "x1000c5s2b0n1": {
+            "Parent": "x1000c5s2b0",
+            "Xname": "x1000c5s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1169,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001169"
+                ]
+            }
+        },
+        "x1000c5s2b1n0": {
+            "Parent": "x1000c5s2b1",
+            "Xname": "x1000c5s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1170,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001170"
+                ]
+            }
+        },
+        "x1000c5s2b1n1": {
+            "Parent": "x1000c5s2b1",
+            "Xname": "x1000c5s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1171,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001171"
+                ]
+            }
+        },
+        "x1000c5s3b0n0": {
+            "Parent": "x1000c5s3b0",
+            "Xname": "x1000c5s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1172,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001172"
+                ]
+            }
+        },
+        "x1000c5s3b0n1": {
+            "Parent": "x1000c5s3b0",
+            "Xname": "x1000c5s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1173,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001173"
+                ]
+            }
+        },
+        "x1000c5s3b1n0": {
+            "Parent": "x1000c5s3b1",
+            "Xname": "x1000c5s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1174,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001174"
+                ]
+            }
+        },
+        "x1000c5s3b1n1": {
+            "Parent": "x1000c5s3b1",
+            "Xname": "x1000c5s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1175,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001175"
+                ]
+            }
+        },
+        "x1000c5s4b0n0": {
+            "Parent": "x1000c5s4b0",
+            "Xname": "x1000c5s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1176,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001176"
+                ]
+            }
+        },
+        "x1000c5s4b0n1": {
+            "Parent": "x1000c5s4b0",
+            "Xname": "x1000c5s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1177,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001177"
+                ]
+            }
+        },
+        "x1000c5s4b1n0": {
+            "Parent": "x1000c5s4b1",
+            "Xname": "x1000c5s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1178,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001178"
+                ]
+            }
+        },
+        "x1000c5s4b1n1": {
+            "Parent": "x1000c5s4b1",
+            "Xname": "x1000c5s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1179,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001179"
+                ]
+            }
+        },
+        "x1000c5s5b0n0": {
+            "Parent": "x1000c5s5b0",
+            "Xname": "x1000c5s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1180,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001180"
+                ]
+            }
+        },
+        "x1000c5s5b0n1": {
+            "Parent": "x1000c5s5b0",
+            "Xname": "x1000c5s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1181,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001181"
+                ]
+            }
+        },
+        "x1000c5s5b1n0": {
+            "Parent": "x1000c5s5b1",
+            "Xname": "x1000c5s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1182,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001182"
+                ]
+            }
+        },
+        "x1000c5s5b1n1": {
+            "Parent": "x1000c5s5b1",
+            "Xname": "x1000c5s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1183,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001183"
+                ]
+            }
+        },
+        "x1000c5s6b0n0": {
+            "Parent": "x1000c5s6b0",
+            "Xname": "x1000c5s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1184,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001184"
+                ]
+            }
+        },
+        "x1000c5s6b0n1": {
+            "Parent": "x1000c5s6b0",
+            "Xname": "x1000c5s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1185,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001185"
+                ]
+            }
+        },
+        "x1000c5s6b1n0": {
+            "Parent": "x1000c5s6b1",
+            "Xname": "x1000c5s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1186,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001186"
+                ]
+            }
+        },
+        "x1000c5s6b1n1": {
+            "Parent": "x1000c5s6b1",
+            "Xname": "x1000c5s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1187,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001187"
+                ]
+            }
+        },
+        "x1000c5s7b0n0": {
+            "Parent": "x1000c5s7b0",
+            "Xname": "x1000c5s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1188,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001188"
+                ]
+            }
+        },
+        "x1000c5s7b0n1": {
+            "Parent": "x1000c5s7b0",
+            "Xname": "x1000c5s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1189,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001189"
+                ]
+            }
+        },
+        "x1000c5s7b1n0": {
+            "Parent": "x1000c5s7b1",
+            "Xname": "x1000c5s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1190,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001190"
+                ]
+            }
+        },
+        "x1000c5s7b1n1": {
+            "Parent": "x1000c5s7b1",
+            "Xname": "x1000c5s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1191,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001191"
+                ]
+            }
+        },
+        "x1000c6": {
+            "Parent": "x1000",
+            "Xname": "x1000c6",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c6b0": {
+            "Parent": "x1000c6",
+            "Xname": "x1000c6b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c6s0b0n0": {
+            "Parent": "x1000c6s0b0",
+            "Xname": "x1000c6s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1192,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001192"
+                ]
+            }
+        },
+        "x1000c6s0b0n1": {
+            "Parent": "x1000c6s0b0",
+            "Xname": "x1000c6s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1193,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001193"
+                ]
+            }
+        },
+        "x1000c6s0b1n0": {
+            "Parent": "x1000c6s0b1",
+            "Xname": "x1000c6s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1194,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001194"
+                ]
+            }
+        },
+        "x1000c6s0b1n1": {
+            "Parent": "x1000c6s0b1",
+            "Xname": "x1000c6s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1195,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001195"
+                ]
+            }
+        },
+        "x1000c6s1b0n0": {
+            "Parent": "x1000c6s1b0",
+            "Xname": "x1000c6s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1196,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001196"
+                ]
+            }
+        },
+        "x1000c6s1b0n1": {
+            "Parent": "x1000c6s1b0",
+            "Xname": "x1000c6s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1197,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001197"
+                ]
+            }
+        },
+        "x1000c6s1b1n0": {
+            "Parent": "x1000c6s1b1",
+            "Xname": "x1000c6s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1198,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001198"
+                ]
+            }
+        },
+        "x1000c6s1b1n1": {
+            "Parent": "x1000c6s1b1",
+            "Xname": "x1000c6s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1199,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001199"
+                ]
+            }
+        },
+        "x1000c6s2b0n0": {
+            "Parent": "x1000c6s2b0",
+            "Xname": "x1000c6s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1200,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001200"
+                ]
+            }
+        },
+        "x1000c6s2b0n1": {
+            "Parent": "x1000c6s2b0",
+            "Xname": "x1000c6s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1201,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001201"
+                ]
+            }
+        },
+        "x1000c6s2b1n0": {
+            "Parent": "x1000c6s2b1",
+            "Xname": "x1000c6s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1202,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001202"
+                ]
+            }
+        },
+        "x1000c6s2b1n1": {
+            "Parent": "x1000c6s2b1",
+            "Xname": "x1000c6s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1203,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001203"
+                ]
+            }
+        },
+        "x1000c6s3b0n0": {
+            "Parent": "x1000c6s3b0",
+            "Xname": "x1000c6s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1204,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001204"
+                ]
+            }
+        },
+        "x1000c6s3b0n1": {
+            "Parent": "x1000c6s3b0",
+            "Xname": "x1000c6s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1205,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001205"
+                ]
+            }
+        },
+        "x1000c6s3b1n0": {
+            "Parent": "x1000c6s3b1",
+            "Xname": "x1000c6s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1206,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001206"
+                ]
+            }
+        },
+        "x1000c6s3b1n1": {
+            "Parent": "x1000c6s3b1",
+            "Xname": "x1000c6s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1207,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001207"
+                ]
+            }
+        },
+        "x1000c6s4b0n0": {
+            "Parent": "x1000c6s4b0",
+            "Xname": "x1000c6s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1208,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001208"
+                ]
+            }
+        },
+        "x1000c6s4b0n1": {
+            "Parent": "x1000c6s4b0",
+            "Xname": "x1000c6s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1209,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001209"
+                ]
+            }
+        },
+        "x1000c6s4b1n0": {
+            "Parent": "x1000c6s4b1",
+            "Xname": "x1000c6s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1210,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001210"
+                ]
+            }
+        },
+        "x1000c6s4b1n1": {
+            "Parent": "x1000c6s4b1",
+            "Xname": "x1000c6s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1211,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001211"
+                ]
+            }
+        },
+        "x1000c6s5b0n0": {
+            "Parent": "x1000c6s5b0",
+            "Xname": "x1000c6s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1212,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001212"
+                ]
+            }
+        },
+        "x1000c6s5b0n1": {
+            "Parent": "x1000c6s5b0",
+            "Xname": "x1000c6s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1213,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001213"
+                ]
+            }
+        },
+        "x1000c6s5b1n0": {
+            "Parent": "x1000c6s5b1",
+            "Xname": "x1000c6s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1214,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001214"
+                ]
+            }
+        },
+        "x1000c6s5b1n1": {
+            "Parent": "x1000c6s5b1",
+            "Xname": "x1000c6s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1215,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001215"
+                ]
+            }
+        },
+        "x1000c6s6b0n0": {
+            "Parent": "x1000c6s6b0",
+            "Xname": "x1000c6s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1216,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001216"
+                ]
+            }
+        },
+        "x1000c6s6b0n1": {
+            "Parent": "x1000c6s6b0",
+            "Xname": "x1000c6s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1217,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001217"
+                ]
+            }
+        },
+        "x1000c6s6b1n0": {
+            "Parent": "x1000c6s6b1",
+            "Xname": "x1000c6s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1218,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001218"
+                ]
+            }
+        },
+        "x1000c6s6b1n1": {
+            "Parent": "x1000c6s6b1",
+            "Xname": "x1000c6s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1219,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001219"
+                ]
+            }
+        },
+        "x1000c6s7b0n0": {
+            "Parent": "x1000c6s7b0",
+            "Xname": "x1000c6s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1220,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001220"
+                ]
+            }
+        },
+        "x1000c6s7b0n1": {
+            "Parent": "x1000c6s7b0",
+            "Xname": "x1000c6s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1221,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001221"
+                ]
+            }
+        },
+        "x1000c6s7b1n0": {
+            "Parent": "x1000c6s7b1",
+            "Xname": "x1000c6s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1222,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001222"
+                ]
+            }
+        },
+        "x1000c6s7b1n1": {
+            "Parent": "x1000c6s7b1",
+            "Xname": "x1000c6s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1223,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001223"
+                ]
+            }
+        },
+        "x1000c7": {
+            "Parent": "x1000",
+            "Xname": "x1000c7",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c7b0": {
+            "Parent": "x1000c7",
+            "Xname": "x1000c7b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c7s0b0n0": {
+            "Parent": "x1000c7s0b0",
+            "Xname": "x1000c7s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1224,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001224"
+                ]
+            }
+        },
+        "x1000c7s0b0n1": {
+            "Parent": "x1000c7s0b0",
+            "Xname": "x1000c7s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1225,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001225"
+                ]
+            }
+        },
+        "x1000c7s0b1n0": {
+            "Parent": "x1000c7s0b1",
+            "Xname": "x1000c7s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1226,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001226"
+                ]
+            }
+        },
+        "x1000c7s0b1n1": {
+            "Parent": "x1000c7s0b1",
+            "Xname": "x1000c7s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1227,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001227"
+                ]
+            }
+        },
+        "x1000c7s1b0n0": {
+            "Parent": "x1000c7s1b0",
+            "Xname": "x1000c7s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1228,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001228"
+                ]
+            }
+        },
+        "x1000c7s1b0n1": {
+            "Parent": "x1000c7s1b0",
+            "Xname": "x1000c7s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1229,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001229"
+                ]
+            }
+        },
+        "x1000c7s1b1n0": {
+            "Parent": "x1000c7s1b1",
+            "Xname": "x1000c7s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1230,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001230"
+                ]
+            }
+        },
+        "x1000c7s1b1n1": {
+            "Parent": "x1000c7s1b1",
+            "Xname": "x1000c7s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1231,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001231"
+                ]
+            }
+        },
+        "x1000c7s2b0n0": {
+            "Parent": "x1000c7s2b0",
+            "Xname": "x1000c7s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1232,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001232"
+                ]
+            }
+        },
+        "x1000c7s2b0n1": {
+            "Parent": "x1000c7s2b0",
+            "Xname": "x1000c7s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1233,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001233"
+                ]
+            }
+        },
+        "x1000c7s2b1n0": {
+            "Parent": "x1000c7s2b1",
+            "Xname": "x1000c7s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1234,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001234"
+                ]
+            }
+        },
+        "x1000c7s2b1n1": {
+            "Parent": "x1000c7s2b1",
+            "Xname": "x1000c7s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1235,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001235"
+                ]
+            }
+        },
+        "x1000c7s3b0n0": {
+            "Parent": "x1000c7s3b0",
+            "Xname": "x1000c7s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1236,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001236"
+                ]
+            }
+        },
+        "x1000c7s3b0n1": {
+            "Parent": "x1000c7s3b0",
+            "Xname": "x1000c7s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1237,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001237"
+                ]
+            }
+        },
+        "x1000c7s3b1n0": {
+            "Parent": "x1000c7s3b1",
+            "Xname": "x1000c7s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1238,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001238"
+                ]
+            }
+        },
+        "x1000c7s3b1n1": {
+            "Parent": "x1000c7s3b1",
+            "Xname": "x1000c7s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1239,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001239"
+                ]
+            }
+        },
+        "x1000c7s4b0n0": {
+            "Parent": "x1000c7s4b0",
+            "Xname": "x1000c7s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1240,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001240"
+                ]
+            }
+        },
+        "x1000c7s4b0n1": {
+            "Parent": "x1000c7s4b0",
+            "Xname": "x1000c7s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1241,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001241"
+                ]
+            }
+        },
+        "x1000c7s4b1n0": {
+            "Parent": "x1000c7s4b1",
+            "Xname": "x1000c7s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1242,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001242"
+                ]
+            }
+        },
+        "x1000c7s4b1n1": {
+            "Parent": "x1000c7s4b1",
+            "Xname": "x1000c7s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1243,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001243"
+                ]
+            }
+        },
+        "x1000c7s5b0n0": {
+            "Parent": "x1000c7s5b0",
+            "Xname": "x1000c7s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1244,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001244"
+                ]
+            }
+        },
+        "x1000c7s5b0n1": {
+            "Parent": "x1000c7s5b0",
+            "Xname": "x1000c7s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1245,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001245"
+                ]
+            }
+        },
+        "x1000c7s5b1n0": {
+            "Parent": "x1000c7s5b1",
+            "Xname": "x1000c7s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1246,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001246"
+                ]
+            }
+        },
+        "x1000c7s5b1n1": {
+            "Parent": "x1000c7s5b1",
+            "Xname": "x1000c7s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1247,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001247"
+                ]
+            }
+        },
+        "x1000c7s6b0n0": {
+            "Parent": "x1000c7s6b0",
+            "Xname": "x1000c7s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1248,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001248"
+                ]
+            }
+        },
+        "x1000c7s6b0n1": {
+            "Parent": "x1000c7s6b0",
+            "Xname": "x1000c7s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1249,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001249"
+                ]
+            }
+        },
+        "x1000c7s6b1n0": {
+            "Parent": "x1000c7s6b1",
+            "Xname": "x1000c7s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1250,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001250"
+                ]
+            }
+        },
+        "x1000c7s6b1n1": {
+            "Parent": "x1000c7s6b1",
+            "Xname": "x1000c7s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1251,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001251"
+                ]
+            }
+        },
+        "x1000c7s7b0n0": {
+            "Parent": "x1000c7s7b0",
+            "Xname": "x1000c7s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1252,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001252"
+                ]
+            }
+        },
+        "x1000c7s7b0n1": {
+            "Parent": "x1000c7s7b0",
+            "Xname": "x1000c7s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1253,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001253"
+                ]
+            }
+        },
+        "x1000c7s7b1n0": {
+            "Parent": "x1000c7s7b1",
+            "Xname": "x1000c7s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1254,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001254"
+                ]
+            }
+        },
+        "x1000c7s7b1n1": {
+            "Parent": "x1000c7s7b1",
+            "Xname": "x1000c7s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1255,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001255"
+                ]
+            }
+        },
+        "x3000": {
+            "Parent": "s0",
+            "Xname": "x3000",
+            "Type": "comptype_cabinet",
+            "Class": "River",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    },
+                    "ncn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    }
+                }
+            }
+        },
+        "x3000c0h33s1": {
+            "Parent": "x3000c0h33",
+            "Xname": "x3000c0h33s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.4",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-001"
+                ]
+            }
+        },
+        "x3000c0h34s1": {
+            "Parent": "x3000c0h34",
+            "Xname": "x3000c0h34s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.5",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-002"
+                ]
+            }
+        },
+        "x3000c0h35s1": {
+            "Parent": "x3000c0h35",
+            "Xname": "x3000c0h35s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.6",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-003"
+                ]
+            }
+        },
+        "x3000c0h36s1": {
+            "Parent": "x3000c0h36",
+            "Xname": "x3000c0h36s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.7",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-004"
+                ]
+            }
+        },
+        "x3000c0h37s1": {
+            "Parent": "x3000c0h37",
+            "Xname": "x3000c0h37s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.2",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-001"
+                ]
+            }
+        },
+        "x3000c0h38s1": {
+            "Parent": "x3000c0h38",
+            "Xname": "x3000c0h38s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.3",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-002"
+                ]
+            }
+        },
+        "x3000c0r39b0": {
+            "Parent": "x3000c0r39",
+            "Xname": "x3000c0r39b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x3000c0r39b0",
+                "Password": "vault://hms-creds/x3000c0r39b0"
+            }
+        },
+        "x3000c0r40b0": {
+            "Parent": "x3000c0r40",
+            "Xname": "x3000c0r40b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x3000c0r40b0",
+                "Password": "vault://hms-creds/x3000c0r40b0"
+            }
+        },
+        "x3000c0s10b0n0": {
+            "Parent": "x3000c0s10b0",
+            "Xname": "x3000c0s10b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100001,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s003"
+                ]
+            }
+        },
+        "x3000c0s15b0n0": {
+            "Parent": "x3000c0s15b0",
+            "Xname": "x3000c0s15b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan01"
+                ]
+            }
+        },
+        "x3000c0s16b0n0": {
+            "Parent": "x3000c0s16b0",
+            "Xname": "x3000c0s16b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan02"
+                ]
+            }
+        },
+        "x3000c0s1b0n0": {
+            "Parent": "x3000c0s1b0",
+            "Xname": "x3000c0s1b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100010,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m001"
+                ]
+            }
+        },
+        "x3000c0s24b0n0": {
+            "Parent": "x3000c0s24b0",
+            "Xname": "x3000c0s24b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "@rie.mockup": "XL675d_A40",
+                "NID": 1,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid000001"
+                ]
+            }
+        },
+        "x3000c0s2b0n0": {
+            "Parent": "x3000c0s2b0",
+            "Xname": "x3000c0s2b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100009,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m002"
+                ]
+            }
+        },
+        "x3000c0s3b0n0": {
+            "Parent": "x3000c0s3b0",
+            "Xname": "x3000c0s3b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100008,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m003"
+                ]
+            }
+        },
+        "x3000c0s4b0n0": {
+            "Parent": "x3000c0s4b0",
+            "Xname": "x3000c0s4b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100007,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w001"
+                ]
+            }
+        },
+        "x3000c0s5b0n0": {
+            "Parent": "x3000c0s5b0",
+            "Xname": "x3000c0s5b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100006,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w002"
+                ]
+            }
+        },
+        "x3000c0s6b0n0": {
+            "Parent": "x3000c0s6b0",
+            "Xname": "x3000c0s6b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100005,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w003"
+                ]
+            }
+        },
+        "x3000c0s7b0n0": {
+            "Parent": "x3000c0s7b0",
+            "Xname": "x3000c0s7b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100004,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w004"
+                ]
+            }
+        },
+        "x3000c0s8b0n0": {
+            "Parent": "x3000c0s8b0",
+            "Xname": "x3000c0s8b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100003,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s001"
+                ]
+            }
+        },
+        "x3000c0s9b0n0": {
+            "Parent": "x3000c0s9b0",
+            "Xname": "x3000c0s9b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100002,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s002"
+                ]
+            }
+        },
+        "x3000c0w31": {
+            "Parent": "x3000c0",
+            "Xname": "x3000c0w31",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.8",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-001"
+                ]
+            }
+        },
+        "x3000c0w31j29": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j29",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s24b0"
+                ],
+                "VendorName": "1/1/29"
+            }
+        },
+        "x3000c0w31j34": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j34",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s2b0"
+                ],
+                "VendorName": "1/1/34"
+            }
+        },
+        "x3000c0w31j35": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j35",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s4b0"
+                ],
+                "VendorName": "1/1/35"
+            }
+        },
+        "x3000c0w31j36": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s5b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x3000c0w31j37": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s6b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x3000c0w31j38": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s8b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x3000c0w31j39": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j39",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s9b0"
+                ],
+                "VendorName": "1/1/39"
+            }
+        },
+        "x3000c0w31j40": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j40",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s15b0"
+                ],
+                "VendorName": "1/1/40"
+            }
+        },
+        "x3000c0w31j41": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j41",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s16b0"
+                ],
+                "VendorName": "1/1/41"
+            }
+        },
+        "x3000c0w31j47": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0r39b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x3000c0w31j48": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000m0"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x3000c0w32": {
+            "Parent": "x3000c0",
+            "Xname": "x3000c0w32",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.9",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x3000c0w32",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x3000c0w32",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-002"
+                ]
+            }
+        },
+        "x3000c0w32j36": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s3b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x3000c0w32j37": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s7b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x3000c0w32j38": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s10b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x3000c0w32j47": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0r40b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x3000c0w32j48": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000m1"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x3000m0": {
+            "Parent": "x3000",
+            "Xname": "x3000m0",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        },
+        "x3000m1": {
+            "Parent": "x3000",
+            "Xname": "x3000m1",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        }
+    },
+    "Networks":{}
+}

--- a/testdata/fixtures/sls/Hill_River.json
+++ b/testdata/fixtures/sls/Hill_River.json
@@ -1,0 +1,1572 @@
+{
+    "Hardware": {
+        "d0w1": {
+            "Parent": "d0",
+            "Xname": "d0w1",
+            "Type": "comptype_cdu_mgmt_switch",
+            "Class": "Mountain",
+            "TypeString": "CDUMgmtSwitch",
+            "ExtraProperties": {
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-cdu-001"
+                ]
+            }
+        },
+        "d0w2": {
+            "Parent": "d0",
+            "Xname": "d0w2",
+            "Type": "comptype_cdu_mgmt_switch",
+            "Class": "Mountain",
+            "TypeString": "CDUMgmtSwitch",
+            "ExtraProperties": {
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-cdu-002"
+                ]
+            }
+        },
+        "x3000": {
+            "Parent": "s0",
+            "Xname": "x3000",
+            "Type": "comptype_cabinet",
+            "Class": "River",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    },
+                    "ncn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    }
+                }
+            }
+        },
+        "x3000c0h33s1": {
+            "Parent": "x3000c0h33",
+            "Xname": "x3000c0h33s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.4",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-001"
+                ]
+            }
+        },
+        "x3000c0h34s1": {
+            "Parent": "x3000c0h34",
+            "Xname": "x3000c0h34s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.5",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-002"
+                ]
+            }
+        },
+        "x3000c0h35s1": {
+            "Parent": "x3000c0h35",
+            "Xname": "x3000c0h35s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.6",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-003"
+                ]
+            }
+        },
+        "x3000c0h36s1": {
+            "Parent": "x3000c0h36",
+            "Xname": "x3000c0h36s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.7",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-004"
+                ]
+            }
+        },
+        "x3000c0h37s1": {
+            "Parent": "x3000c0h37",
+            "Xname": "x3000c0h37s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.2",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-001"
+                ]
+            }
+        },
+        "x3000c0h38s1": {
+            "Parent": "x3000c0h38",
+            "Xname": "x3000c0h38s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.3",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-002"
+                ]
+            }
+        },
+        "x3000c0r39b0": {
+            "Parent": "x3000c0r39",
+            "Xname": "x3000c0r39b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x3000c0r39b0",
+                "Password": "vault://hms-creds/x3000c0r39b0"
+            }
+        },
+        "x3000c0r40b0": {
+            "Parent": "x3000c0r40",
+            "Xname": "x3000c0r40b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x3000c0r40b0",
+                "Password": "vault://hms-creds/x3000c0r40b0"
+            }
+        },
+        "x3000c0s10b0n0": {
+            "Parent": "x3000c0s10b0",
+            "Xname": "x3000c0s10b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100001,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s003"
+                ]
+            }
+        },
+        "x3000c0s15b0n0": {
+            "Parent": "x3000c0s15b0",
+            "Xname": "x3000c0s15b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan01"
+                ]
+            }
+        },
+        "x3000c0s16b0n0": {
+            "Parent": "x3000c0s16b0",
+            "Xname": "x3000c0s16b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan02"
+                ]
+            }
+        },
+        "x3000c0s1b0n0": {
+            "Parent": "x3000c0s1b0",
+            "Xname": "x3000c0s1b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100010,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m001"
+                ]
+            }
+        },
+        "x3000c0s24b0n0": {
+            "Parent": "x3000c0s24b0",
+            "Xname": "x3000c0s24b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "@rie.mockup": "XL675d_A40",
+                "NID": 1,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid000001"
+                ]
+            }
+        },
+        "x3000c0s2b0n0": {
+            "Parent": "x3000c0s2b0",
+            "Xname": "x3000c0s2b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100009,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m002"
+                ]
+            }
+        },
+        "x3000c0s3b0n0": {
+            "Parent": "x3000c0s3b0",
+            "Xname": "x3000c0s3b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100008,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m003"
+                ]
+            }
+        },
+        "x3000c0s4b0n0": {
+            "Parent": "x3000c0s4b0",
+            "Xname": "x3000c0s4b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100007,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w001"
+                ]
+            }
+        },
+        "x3000c0s5b0n0": {
+            "Parent": "x3000c0s5b0",
+            "Xname": "x3000c0s5b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100006,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w002"
+                ]
+            }
+        },
+        "x3000c0s6b0n0": {
+            "Parent": "x3000c0s6b0",
+            "Xname": "x3000c0s6b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100005,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w003"
+                ]
+            }
+        },
+        "x3000c0s7b0n0": {
+            "Parent": "x3000c0s7b0",
+            "Xname": "x3000c0s7b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100004,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w004"
+                ]
+            }
+        },
+        "x3000c0s8b0n0": {
+            "Parent": "x3000c0s8b0",
+            "Xname": "x3000c0s8b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100003,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s001"
+                ]
+            }
+        },
+        "x3000c0s9b0n0": {
+            "Parent": "x3000c0s9b0",
+            "Xname": "x3000c0s9b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100002,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s002"
+                ]
+            }
+        },
+        "x3000c0w31": {
+            "Parent": "x3000c0",
+            "Xname": "x3000c0w31",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.8",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-001"
+                ]
+            }
+        },
+        "x3000c0w31j29": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j29",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s24b0"
+                ],
+                "VendorName": "1/1/29"
+            }
+        },
+        "x3000c0w31j34": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j34",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s2b0"
+                ],
+                "VendorName": "1/1/34"
+            }
+        },
+        "x3000c0w31j35": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j35",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s4b0"
+                ],
+                "VendorName": "1/1/35"
+            }
+        },
+        "x3000c0w31j36": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s5b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x3000c0w31j37": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s6b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x3000c0w31j38": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s8b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x3000c0w31j39": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j39",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s9b0"
+                ],
+                "VendorName": "1/1/39"
+            }
+        },
+        "x3000c0w31j40": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j40",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s15b0"
+                ],
+                "VendorName": "1/1/40"
+            }
+        },
+        "x3000c0w31j41": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j41",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s16b0"
+                ],
+                "VendorName": "1/1/41"
+            }
+        },
+        "x3000c0w31j47": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0r39b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x3000c0w31j48": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000m0"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x3000c0w32": {
+            "Parent": "x3000c0",
+            "Xname": "x3000c0w32",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.9",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x3000c0w32",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x3000c0w32",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-002"
+                ]
+            }
+        },
+        "x3000c0w32j36": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s3b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x3000c0w32j37": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s7b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x3000c0w32j38": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s10b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x3000c0w32j47": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0r40b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x3000c0w32j48": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000m1"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x3000m0": {
+            "Parent": "x3000",
+            "Xname": "x3000m0",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        },
+        "x3000m1": {
+            "Parent": "x3000",
+            "Xname": "x3000m1",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        },
+        "x9000": {
+            "Parent": "s0",
+            "Xname": "x9000",
+            "Type": "comptype_cabinet",
+            "Class": "Hill",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.104.0.0/22",
+                            "Gateway": "10.104.0.1",
+                            "VLan": 3002
+                        },
+                        "NMN": {
+                            "CIDR": "10.100.0.0/22",
+                            "Gateway": "10.100.0.1",
+                            "VLan": 2002
+                        }
+                    }
+                }
+            }
+        },
+        "x9000c1": {
+            "Parent": "x9000",
+            "Xname": "x9000c1",
+            "Type": "comptype_chassis",
+            "Class": "Hill",
+            "TypeString": "Chassis"
+        },
+        "x9000c1b0": {
+            "Parent": "x9000c1",
+            "Xname": "x9000c1b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Hill",
+            "TypeString": "ChassisBMC"
+        },
+        "x9000c1s0b0n0": {
+            "Parent": "x9000c1s0b0",
+            "Xname": "x9000c1s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1000,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001000"
+                ]
+            }
+        },
+        "x9000c1s0b0n1": {
+            "Parent": "x9000c1s0b0",
+            "Xname": "x9000c1s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1001,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001001"
+                ]
+            }
+        },
+        "x9000c1s0b1n0": {
+            "Parent": "x9000c1s0b1",
+            "Xname": "x9000c1s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1002,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001002"
+                ]
+            }
+        },
+        "x9000c1s0b1n1": {
+            "Parent": "x9000c1s0b1",
+            "Xname": "x9000c1s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1003,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001003"
+                ]
+            }
+        },
+        "x9000c1s1b0n0": {
+            "Parent": "x9000c1s1b0",
+            "Xname": "x9000c1s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1004,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001004"
+                ]
+            }
+        },
+        "x9000c1s1b0n1": {
+            "Parent": "x9000c1s1b0",
+            "Xname": "x9000c1s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1005,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001005"
+                ]
+            }
+        },
+        "x9000c1s1b1n0": {
+            "Parent": "x9000c1s1b1",
+            "Xname": "x9000c1s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1006,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001006"
+                ]
+            }
+        },
+        "x9000c1s1b1n1": {
+            "Parent": "x9000c1s1b1",
+            "Xname": "x9000c1s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1007,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001007"
+                ]
+            }
+        },
+        "x9000c1s2b0n0": {
+            "Parent": "x9000c1s2b0",
+            "Xname": "x9000c1s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1008,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001008"
+                ]
+            }
+        },
+        "x9000c1s2b0n1": {
+            "Parent": "x9000c1s2b0",
+            "Xname": "x9000c1s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1009,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001009"
+                ]
+            }
+        },
+        "x9000c1s2b1n0": {
+            "Parent": "x9000c1s2b1",
+            "Xname": "x9000c1s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1010,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001010"
+                ]
+            }
+        },
+        "x9000c1s2b1n1": {
+            "Parent": "x9000c1s2b1",
+            "Xname": "x9000c1s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1011,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001011"
+                ]
+            }
+        },
+        "x9000c1s3b0n0": {
+            "Parent": "x9000c1s3b0",
+            "Xname": "x9000c1s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1012,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001012"
+                ]
+            }
+        },
+        "x9000c1s3b0n1": {
+            "Parent": "x9000c1s3b0",
+            "Xname": "x9000c1s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1013,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001013"
+                ]
+            }
+        },
+        "x9000c1s3b1n0": {
+            "Parent": "x9000c1s3b1",
+            "Xname": "x9000c1s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1014,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001014"
+                ]
+            }
+        },
+        "x9000c1s3b1n1": {
+            "Parent": "x9000c1s3b1",
+            "Xname": "x9000c1s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1015,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001015"
+                ]
+            }
+        },
+        "x9000c1s4b0n0": {
+            "Parent": "x9000c1s4b0",
+            "Xname": "x9000c1s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1016,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001016"
+                ]
+            }
+        },
+        "x9000c1s4b0n1": {
+            "Parent": "x9000c1s4b0",
+            "Xname": "x9000c1s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1017,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001017"
+                ]
+            }
+        },
+        "x9000c1s4b1n0": {
+            "Parent": "x9000c1s4b1",
+            "Xname": "x9000c1s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1018,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001018"
+                ]
+            }
+        },
+        "x9000c1s4b1n1": {
+            "Parent": "x9000c1s4b1",
+            "Xname": "x9000c1s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1019,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001019"
+                ]
+            }
+        },
+        "x9000c1s5b0n0": {
+            "Parent": "x9000c1s5b0",
+            "Xname": "x9000c1s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1020,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001020"
+                ]
+            }
+        },
+        "x9000c1s5b0n1": {
+            "Parent": "x9000c1s5b0",
+            "Xname": "x9000c1s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1021,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001021"
+                ]
+            }
+        },
+        "x9000c1s5b1n0": {
+            "Parent": "x9000c1s5b1",
+            "Xname": "x9000c1s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1022,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001022"
+                ]
+            }
+        },
+        "x9000c1s5b1n1": {
+            "Parent": "x9000c1s5b1",
+            "Xname": "x9000c1s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1023,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001023"
+                ]
+            }
+        },
+        "x9000c1s6b0n0": {
+            "Parent": "x9000c1s6b0",
+            "Xname": "x9000c1s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1024,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001024"
+                ]
+            }
+        },
+        "x9000c1s6b0n1": {
+            "Parent": "x9000c1s6b0",
+            "Xname": "x9000c1s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1025,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001025"
+                ]
+            }
+        },
+        "x9000c1s6b1n0": {
+            "Parent": "x9000c1s6b1",
+            "Xname": "x9000c1s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1026,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001026"
+                ]
+            }
+        },
+        "x9000c1s6b1n1": {
+            "Parent": "x9000c1s6b1",
+            "Xname": "x9000c1s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1027,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001027"
+                ]
+            }
+        },
+        "x9000c1s7b0n0": {
+            "Parent": "x9000c1s7b0",
+            "Xname": "x9000c1s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1028,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001028"
+                ]
+            }
+        },
+        "x9000c1s7b0n1": {
+            "Parent": "x9000c1s7b0",
+            "Xname": "x9000c1s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1029,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001029"
+                ]
+            }
+        },
+        "x9000c1s7b1n0": {
+            "Parent": "x9000c1s7b1",
+            "Xname": "x9000c1s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1030,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001030"
+                ]
+            }
+        },
+        "x9000c1s7b1n1": {
+            "Parent": "x9000c1s7b1",
+            "Xname": "x9000c1s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1031,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001031"
+                ]
+            }
+        },
+        "x9000c3": {
+            "Parent": "x9000",
+            "Xname": "x9000c3",
+            "Type": "comptype_chassis",
+            "Class": "Hill",
+            "TypeString": "Chassis"
+        },
+        "x9000c3b0": {
+            "Parent": "x9000c3",
+            "Xname": "x9000c3b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Hill",
+            "TypeString": "ChassisBMC"
+        },
+        "x9000c3s0b0n0": {
+            "Parent": "x9000c3s0b0",
+            "Xname": "x9000c3s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1032,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001032"
+                ]
+            }
+        },
+        "x9000c3s0b0n1": {
+            "Parent": "x9000c3s0b0",
+            "Xname": "x9000c3s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1033,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001033"
+                ]
+            }
+        },
+        "x9000c3s0b1n0": {
+            "Parent": "x9000c3s0b1",
+            "Xname": "x9000c3s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1034,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001034"
+                ]
+            }
+        },
+        "x9000c3s0b1n1": {
+            "Parent": "x9000c3s0b1",
+            "Xname": "x9000c3s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1035,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001035"
+                ]
+            }
+        },
+        "x9000c3s1b0n0": {
+            "Parent": "x9000c3s1b0",
+            "Xname": "x9000c3s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1036,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001036"
+                ]
+            }
+        },
+        "x9000c3s1b0n1": {
+            "Parent": "x9000c3s1b0",
+            "Xname": "x9000c3s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1037,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001037"
+                ]
+            }
+        },
+        "x9000c3s1b1n0": {
+            "Parent": "x9000c3s1b1",
+            "Xname": "x9000c3s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1038,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001038"
+                ]
+            }
+        },
+        "x9000c3s1b1n1": {
+            "Parent": "x9000c3s1b1",
+            "Xname": "x9000c3s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1039,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001039"
+                ]
+            }
+        },
+        "x9000c3s2b0n0": {
+            "Parent": "x9000c3s2b0",
+            "Xname": "x9000c3s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1040,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001040"
+                ]
+            }
+        },
+        "x9000c3s2b0n1": {
+            "Parent": "x9000c3s2b0",
+            "Xname": "x9000c3s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1041,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001041"
+                ]
+            }
+        },
+        "x9000c3s2b1n0": {
+            "Parent": "x9000c3s2b1",
+            "Xname": "x9000c3s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1042,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001042"
+                ]
+            }
+        },
+        "x9000c3s2b1n1": {
+            "Parent": "x9000c3s2b1",
+            "Xname": "x9000c3s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1043,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001043"
+                ]
+            }
+        },
+        "x9000c3s3b0n0": {
+            "Parent": "x9000c3s3b0",
+            "Xname": "x9000c3s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1044,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001044"
+                ]
+            }
+        },
+        "x9000c3s3b0n1": {
+            "Parent": "x9000c3s3b0",
+            "Xname": "x9000c3s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1045,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001045"
+                ]
+            }
+        },
+        "x9000c3s3b1n0": {
+            "Parent": "x9000c3s3b1",
+            "Xname": "x9000c3s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1046,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001046"
+                ]
+            }
+        },
+        "x9000c3s3b1n1": {
+            "Parent": "x9000c3s3b1",
+            "Xname": "x9000c3s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1047,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001047"
+                ]
+            }
+        },
+        "x9000c3s4b0n0": {
+            "Parent": "x9000c3s4b0",
+            "Xname": "x9000c3s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1048,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001048"
+                ]
+            }
+        },
+        "x9000c3s4b0n1": {
+            "Parent": "x9000c3s4b0",
+            "Xname": "x9000c3s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1049,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001049"
+                ]
+            }
+        },
+        "x9000c3s4b1n0": {
+            "Parent": "x9000c3s4b1",
+            "Xname": "x9000c3s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1050,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001050"
+                ]
+            }
+        },
+        "x9000c3s4b1n1": {
+            "Parent": "x9000c3s4b1",
+            "Xname": "x9000c3s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1051,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001051"
+                ]
+            }
+        },
+        "x9000c3s5b0n0": {
+            "Parent": "x9000c3s5b0",
+            "Xname": "x9000c3s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1052,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001052"
+                ]
+            }
+        },
+        "x9000c3s5b0n1": {
+            "Parent": "x9000c3s5b0",
+            "Xname": "x9000c3s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1053,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001053"
+                ]
+            }
+        },
+        "x9000c3s5b1n0": {
+            "Parent": "x9000c3s5b1",
+            "Xname": "x9000c3s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1054,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001054"
+                ]
+            }
+        },
+        "x9000c3s5b1n1": {
+            "Parent": "x9000c3s5b1",
+            "Xname": "x9000c3s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1055,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001055"
+                ]
+            }
+        },
+        "x9000c3s6b0n0": {
+            "Parent": "x9000c3s6b0",
+            "Xname": "x9000c3s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1056,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001056"
+                ]
+            }
+        },
+        "x9000c3s6b0n1": {
+            "Parent": "x9000c3s6b0",
+            "Xname": "x9000c3s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1057,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001057"
+                ]
+            }
+        },
+        "x9000c3s6b1n0": {
+            "Parent": "x9000c3s6b1",
+            "Xname": "x9000c3s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1058,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001058"
+                ]
+            }
+        },
+        "x9000c3s6b1n1": {
+            "Parent": "x9000c3s6b1",
+            "Xname": "x9000c3s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1059,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001059"
+                ]
+            }
+        },
+        "x9000c3s7b0n0": {
+            "Parent": "x9000c3s7b0",
+            "Xname": "x9000c3s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1060,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001060"
+                ]
+            }
+        },
+        "x9000c3s7b0n1": {
+            "Parent": "x9000c3s7b0",
+            "Xname": "x9000c3s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1061,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001061"
+                ]
+            }
+        },
+        "x9000c3s7b1n0": {
+            "Parent": "x9000c3s7b1",
+            "Xname": "x9000c3s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1062,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001062"
+                ]
+            }
+        },
+        "x9000c3s7b1n1": {
+            "Parent": "x9000c3s7b1",
+            "Xname": "x9000c3s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Hill",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1063,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001063"
+                ]
+            }
+        }
+    },
+    "Networks": {}
+}

--- a/testdata/fixtures/sls/Mountain_River.json
+++ b/testdata/fixtures/sls/Mountain_River.json
@@ -1,0 +1,4344 @@
+{
+    "Hardware": {
+        "d0w1": {
+            "Parent": "d0",
+            "Xname": "d0w1",
+            "Type": "comptype_cdu_mgmt_switch",
+            "Class": "Mountain",
+            "TypeString": "CDUMgmtSwitch",
+            "ExtraProperties": {
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-cdu-001"
+                ]
+            }
+        },
+        "d0w2": {
+            "Parent": "d0",
+            "Xname": "d0w2",
+            "Type": "comptype_cdu_mgmt_switch",
+            "Class": "Mountain",
+            "TypeString": "CDUMgmtSwitch",
+            "ExtraProperties": {
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-cdu-002"
+                ]
+            }
+        },
+        "x1000": {
+            "Parent": "s0",
+            "Xname": "x1000",
+            "Type": "comptype_cabinet",
+            "Class": "Mountain",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.104.0.0/22",
+                            "Gateway": "10.104.0.1",
+                            "VLan": 3001
+                        },
+                        "NMN": {
+                            "CIDR": "10.100.0.0/22",
+                            "Gateway": "10.100.0.1",
+                            "VLan": 2001
+                        }
+                    }
+                }
+            }
+        },
+        "x1000c0": {
+            "Parent": "x1000",
+            "Xname": "x1000c0",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c0b0": {
+            "Parent": "x1000c0",
+            "Xname": "x1000c0b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c0s0b0n0": {
+            "Parent": "x1000c0s0b0",
+            "Xname": "x1000c0s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1000,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001000"
+                ]
+            }
+        },
+        "x1000c0s0b0n1": {
+            "Parent": "x1000c0s0b0",
+            "Xname": "x1000c0s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1001,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001001"
+                ]
+            }
+        },
+        "x1000c0s0b1n0": {
+            "Parent": "x1000c0s0b1",
+            "Xname": "x1000c0s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1002,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001002"
+                ]
+            }
+        },
+        "x1000c0s0b1n1": {
+            "Parent": "x1000c0s0b1",
+            "Xname": "x1000c0s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1003,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001003"
+                ]
+            }
+        },
+        "x1000c0s1b0n0": {
+            "Parent": "x1000c0s1b0",
+            "Xname": "x1000c0s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1004,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001004"
+                ]
+            }
+        },
+        "x1000c0s1b0n1": {
+            "Parent": "x1000c0s1b0",
+            "Xname": "x1000c0s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1005,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001005"
+                ]
+            }
+        },
+        "x1000c0s1b1n0": {
+            "Parent": "x1000c0s1b1",
+            "Xname": "x1000c0s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1006,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001006"
+                ]
+            }
+        },
+        "x1000c0s1b1n1": {
+            "Parent": "x1000c0s1b1",
+            "Xname": "x1000c0s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1007,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001007"
+                ]
+            }
+        },
+        "x1000c0s2b0n0": {
+            "Parent": "x1000c0s2b0",
+            "Xname": "x1000c0s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1008,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001008"
+                ]
+            }
+        },
+        "x1000c0s2b0n1": {
+            "Parent": "x1000c0s2b0",
+            "Xname": "x1000c0s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1009,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001009"
+                ]
+            }
+        },
+        "x1000c0s2b1n0": {
+            "Parent": "x1000c0s2b1",
+            "Xname": "x1000c0s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1010,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001010"
+                ]
+            }
+        },
+        "x1000c0s2b1n1": {
+            "Parent": "x1000c0s2b1",
+            "Xname": "x1000c0s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1011,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001011"
+                ]
+            }
+        },
+        "x1000c0s3b0n0": {
+            "Parent": "x1000c0s3b0",
+            "Xname": "x1000c0s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1012,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001012"
+                ]
+            }
+        },
+        "x1000c0s3b0n1": {
+            "Parent": "x1000c0s3b0",
+            "Xname": "x1000c0s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1013,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001013"
+                ]
+            }
+        },
+        "x1000c0s3b1n0": {
+            "Parent": "x1000c0s3b1",
+            "Xname": "x1000c0s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1014,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001014"
+                ]
+            }
+        },
+        "x1000c0s3b1n1": {
+            "Parent": "x1000c0s3b1",
+            "Xname": "x1000c0s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1015,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001015"
+                ]
+            }
+        },
+        "x1000c0s4b0n0": {
+            "Parent": "x1000c0s4b0",
+            "Xname": "x1000c0s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1016,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001016"
+                ]
+            }
+        },
+        "x1000c0s4b0n1": {
+            "Parent": "x1000c0s4b0",
+            "Xname": "x1000c0s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1017,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001017"
+                ]
+            }
+        },
+        "x1000c0s4b1n0": {
+            "Parent": "x1000c0s4b1",
+            "Xname": "x1000c0s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1018,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001018"
+                ]
+            }
+        },
+        "x1000c0s4b1n1": {
+            "Parent": "x1000c0s4b1",
+            "Xname": "x1000c0s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1019,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001019"
+                ]
+            }
+        },
+        "x1000c0s5b0n0": {
+            "Parent": "x1000c0s5b0",
+            "Xname": "x1000c0s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1020,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001020"
+                ]
+            }
+        },
+        "x1000c0s5b0n1": {
+            "Parent": "x1000c0s5b0",
+            "Xname": "x1000c0s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1021,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001021"
+                ]
+            }
+        },
+        "x1000c0s5b1n0": {
+            "Parent": "x1000c0s5b1",
+            "Xname": "x1000c0s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1022,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001022"
+                ]
+            }
+        },
+        "x1000c0s5b1n1": {
+            "Parent": "x1000c0s5b1",
+            "Xname": "x1000c0s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1023,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001023"
+                ]
+            }
+        },
+        "x1000c0s6b0n0": {
+            "Parent": "x1000c0s6b0",
+            "Xname": "x1000c0s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1024,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001024"
+                ]
+            }
+        },
+        "x1000c0s6b0n1": {
+            "Parent": "x1000c0s6b0",
+            "Xname": "x1000c0s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1025,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001025"
+                ]
+            }
+        },
+        "x1000c0s6b1n0": {
+            "Parent": "x1000c0s6b1",
+            "Xname": "x1000c0s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1026,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001026"
+                ]
+            }
+        },
+        "x1000c0s6b1n1": {
+            "Parent": "x1000c0s6b1",
+            "Xname": "x1000c0s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1027,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001027"
+                ]
+            }
+        },
+        "x1000c0s7b0n0": {
+            "Parent": "x1000c0s7b0",
+            "Xname": "x1000c0s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1028,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001028"
+                ]
+            }
+        },
+        "x1000c0s7b0n1": {
+            "Parent": "x1000c0s7b0",
+            "Xname": "x1000c0s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1029,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001029"
+                ]
+            }
+        },
+        "x1000c0s7b1n0": {
+            "Parent": "x1000c0s7b1",
+            "Xname": "x1000c0s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1030,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001030"
+                ]
+            }
+        },
+        "x1000c0s7b1n1": {
+            "Parent": "x1000c0s7b1",
+            "Xname": "x1000c0s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1031,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001031"
+                ]
+            }
+        },
+        "x1000c1": {
+            "Parent": "x1000",
+            "Xname": "x1000c1",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c1b0": {
+            "Parent": "x1000c1",
+            "Xname": "x1000c1b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c1s0b0n0": {
+            "Parent": "x1000c1s0b0",
+            "Xname": "x1000c1s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1032,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001032"
+                ]
+            }
+        },
+        "x1000c1s0b0n1": {
+            "Parent": "x1000c1s0b0",
+            "Xname": "x1000c1s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1033,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001033"
+                ]
+            }
+        },
+        "x1000c1s0b1n0": {
+            "Parent": "x1000c1s0b1",
+            "Xname": "x1000c1s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1034,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001034"
+                ]
+            }
+        },
+        "x1000c1s0b1n1": {
+            "Parent": "x1000c1s0b1",
+            "Xname": "x1000c1s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1035,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001035"
+                ]
+            }
+        },
+        "x1000c1s1b0n0": {
+            "Parent": "x1000c1s1b0",
+            "Xname": "x1000c1s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1036,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001036"
+                ]
+            }
+        },
+        "x1000c1s1b0n1": {
+            "Parent": "x1000c1s1b0",
+            "Xname": "x1000c1s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1037,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001037"
+                ]
+            }
+        },
+        "x1000c1s1b1n0": {
+            "Parent": "x1000c1s1b1",
+            "Xname": "x1000c1s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1038,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001038"
+                ]
+            }
+        },
+        "x1000c1s1b1n1": {
+            "Parent": "x1000c1s1b1",
+            "Xname": "x1000c1s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1039,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001039"
+                ]
+            }
+        },
+        "x1000c1s2b0n0": {
+            "Parent": "x1000c1s2b0",
+            "Xname": "x1000c1s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1040,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001040"
+                ]
+            }
+        },
+        "x1000c1s2b0n1": {
+            "Parent": "x1000c1s2b0",
+            "Xname": "x1000c1s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1041,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001041"
+                ]
+            }
+        },
+        "x1000c1s2b1n0": {
+            "Parent": "x1000c1s2b1",
+            "Xname": "x1000c1s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1042,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001042"
+                ]
+            }
+        },
+        "x1000c1s2b1n1": {
+            "Parent": "x1000c1s2b1",
+            "Xname": "x1000c1s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1043,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001043"
+                ]
+            }
+        },
+        "x1000c1s3b0n0": {
+            "Parent": "x1000c1s3b0",
+            "Xname": "x1000c1s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1044,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001044"
+                ]
+            }
+        },
+        "x1000c1s3b0n1": {
+            "Parent": "x1000c1s3b0",
+            "Xname": "x1000c1s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1045,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001045"
+                ]
+            }
+        },
+        "x1000c1s3b1n0": {
+            "Parent": "x1000c1s3b1",
+            "Xname": "x1000c1s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1046,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001046"
+                ]
+            }
+        },
+        "x1000c1s3b1n1": {
+            "Parent": "x1000c1s3b1",
+            "Xname": "x1000c1s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1047,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001047"
+                ]
+            }
+        },
+        "x1000c1s4b0n0": {
+            "Parent": "x1000c1s4b0",
+            "Xname": "x1000c1s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1048,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001048"
+                ]
+            }
+        },
+        "x1000c1s4b0n1": {
+            "Parent": "x1000c1s4b0",
+            "Xname": "x1000c1s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1049,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001049"
+                ]
+            }
+        },
+        "x1000c1s4b1n0": {
+            "Parent": "x1000c1s4b1",
+            "Xname": "x1000c1s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1050,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001050"
+                ]
+            }
+        },
+        "x1000c1s4b1n1": {
+            "Parent": "x1000c1s4b1",
+            "Xname": "x1000c1s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1051,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001051"
+                ]
+            }
+        },
+        "x1000c1s5b0n0": {
+            "Parent": "x1000c1s5b0",
+            "Xname": "x1000c1s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1052,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001052"
+                ]
+            }
+        },
+        "x1000c1s5b0n1": {
+            "Parent": "x1000c1s5b0",
+            "Xname": "x1000c1s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1053,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001053"
+                ]
+            }
+        },
+        "x1000c1s5b1n0": {
+            "Parent": "x1000c1s5b1",
+            "Xname": "x1000c1s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1054,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001054"
+                ]
+            }
+        },
+        "x1000c1s5b1n1": {
+            "Parent": "x1000c1s5b1",
+            "Xname": "x1000c1s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1055,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001055"
+                ]
+            }
+        },
+        "x1000c1s6b0n0": {
+            "Parent": "x1000c1s6b0",
+            "Xname": "x1000c1s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1056,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001056"
+                ]
+            }
+        },
+        "x1000c1s6b0n1": {
+            "Parent": "x1000c1s6b0",
+            "Xname": "x1000c1s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1057,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001057"
+                ]
+            }
+        },
+        "x1000c1s6b1n0": {
+            "Parent": "x1000c1s6b1",
+            "Xname": "x1000c1s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1058,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001058"
+                ]
+            }
+        },
+        "x1000c1s6b1n1": {
+            "Parent": "x1000c1s6b1",
+            "Xname": "x1000c1s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1059,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001059"
+                ]
+            }
+        },
+        "x1000c1s7b0n0": {
+            "Parent": "x1000c1s7b0",
+            "Xname": "x1000c1s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1060,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001060"
+                ]
+            }
+        },
+        "x1000c1s7b0n1": {
+            "Parent": "x1000c1s7b0",
+            "Xname": "x1000c1s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1061,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001061"
+                ]
+            }
+        },
+        "x1000c1s7b1n0": {
+            "Parent": "x1000c1s7b1",
+            "Xname": "x1000c1s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1062,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001062"
+                ]
+            }
+        },
+        "x1000c1s7b1n1": {
+            "Parent": "x1000c1s7b1",
+            "Xname": "x1000c1s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1063,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001063"
+                ]
+            }
+        },
+        "x1000c2": {
+            "Parent": "x1000",
+            "Xname": "x1000c2",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c2b0": {
+            "Parent": "x1000c2",
+            "Xname": "x1000c2b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c2s0b0n0": {
+            "Parent": "x1000c2s0b0",
+            "Xname": "x1000c2s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1064,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001064"
+                ]
+            }
+        },
+        "x1000c2s0b0n1": {
+            "Parent": "x1000c2s0b0",
+            "Xname": "x1000c2s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1065,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001065"
+                ]
+            }
+        },
+        "x1000c2s0b1n0": {
+            "Parent": "x1000c2s0b1",
+            "Xname": "x1000c2s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1066,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001066"
+                ]
+            }
+        },
+        "x1000c2s0b1n1": {
+            "Parent": "x1000c2s0b1",
+            "Xname": "x1000c2s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1067,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001067"
+                ]
+            }
+        },
+        "x1000c2s1b0n0": {
+            "Parent": "x1000c2s1b0",
+            "Xname": "x1000c2s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1068,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001068"
+                ]
+            }
+        },
+        "x1000c2s1b0n1": {
+            "Parent": "x1000c2s1b0",
+            "Xname": "x1000c2s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1069,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001069"
+                ]
+            }
+        },
+        "x1000c2s1b1n0": {
+            "Parent": "x1000c2s1b1",
+            "Xname": "x1000c2s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1070,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001070"
+                ]
+            }
+        },
+        "x1000c2s1b1n1": {
+            "Parent": "x1000c2s1b1",
+            "Xname": "x1000c2s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1071,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001071"
+                ]
+            }
+        },
+        "x1000c2s2b0n0": {
+            "Parent": "x1000c2s2b0",
+            "Xname": "x1000c2s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1072,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001072"
+                ]
+            }
+        },
+        "x1000c2s2b0n1": {
+            "Parent": "x1000c2s2b0",
+            "Xname": "x1000c2s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1073,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001073"
+                ]
+            }
+        },
+        "x1000c2s2b1n0": {
+            "Parent": "x1000c2s2b1",
+            "Xname": "x1000c2s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1074,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001074"
+                ]
+            }
+        },
+        "x1000c2s2b1n1": {
+            "Parent": "x1000c2s2b1",
+            "Xname": "x1000c2s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1075,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001075"
+                ]
+            }
+        },
+        "x1000c2s3b0n0": {
+            "Parent": "x1000c2s3b0",
+            "Xname": "x1000c2s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1076,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001076"
+                ]
+            }
+        },
+        "x1000c2s3b0n1": {
+            "Parent": "x1000c2s3b0",
+            "Xname": "x1000c2s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1077,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001077"
+                ]
+            }
+        },
+        "x1000c2s3b1n0": {
+            "Parent": "x1000c2s3b1",
+            "Xname": "x1000c2s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1078,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001078"
+                ]
+            }
+        },
+        "x1000c2s3b1n1": {
+            "Parent": "x1000c2s3b1",
+            "Xname": "x1000c2s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1079,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001079"
+                ]
+            }
+        },
+        "x1000c2s4b0n0": {
+            "Parent": "x1000c2s4b0",
+            "Xname": "x1000c2s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1080,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001080"
+                ]
+            }
+        },
+        "x1000c2s4b0n1": {
+            "Parent": "x1000c2s4b0",
+            "Xname": "x1000c2s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1081,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001081"
+                ]
+            }
+        },
+        "x1000c2s4b1n0": {
+            "Parent": "x1000c2s4b1",
+            "Xname": "x1000c2s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1082,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001082"
+                ]
+            }
+        },
+        "x1000c2s4b1n1": {
+            "Parent": "x1000c2s4b1",
+            "Xname": "x1000c2s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1083,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001083"
+                ]
+            }
+        },
+        "x1000c2s5b0n0": {
+            "Parent": "x1000c2s5b0",
+            "Xname": "x1000c2s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1084,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001084"
+                ]
+            }
+        },
+        "x1000c2s5b0n1": {
+            "Parent": "x1000c2s5b0",
+            "Xname": "x1000c2s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1085,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001085"
+                ]
+            }
+        },
+        "x1000c2s5b1n0": {
+            "Parent": "x1000c2s5b1",
+            "Xname": "x1000c2s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1086,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001086"
+                ]
+            }
+        },
+        "x1000c2s5b1n1": {
+            "Parent": "x1000c2s5b1",
+            "Xname": "x1000c2s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1087,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001087"
+                ]
+            }
+        },
+        "x1000c2s6b0n0": {
+            "Parent": "x1000c2s6b0",
+            "Xname": "x1000c2s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1088,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001088"
+                ]
+            }
+        },
+        "x1000c2s6b0n1": {
+            "Parent": "x1000c2s6b0",
+            "Xname": "x1000c2s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1089,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001089"
+                ]
+            }
+        },
+        "x1000c2s6b1n0": {
+            "Parent": "x1000c2s6b1",
+            "Xname": "x1000c2s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1090,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001090"
+                ]
+            }
+        },
+        "x1000c2s6b1n1": {
+            "Parent": "x1000c2s6b1",
+            "Xname": "x1000c2s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1091,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001091"
+                ]
+            }
+        },
+        "x1000c2s7b0n0": {
+            "Parent": "x1000c2s7b0",
+            "Xname": "x1000c2s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1092,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001092"
+                ]
+            }
+        },
+        "x1000c2s7b0n1": {
+            "Parent": "x1000c2s7b0",
+            "Xname": "x1000c2s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1093,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001093"
+                ]
+            }
+        },
+        "x1000c2s7b1n0": {
+            "Parent": "x1000c2s7b1",
+            "Xname": "x1000c2s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1094,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001094"
+                ]
+            }
+        },
+        "x1000c2s7b1n1": {
+            "Parent": "x1000c2s7b1",
+            "Xname": "x1000c2s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1095,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001095"
+                ]
+            }
+        },
+        "x1000c3": {
+            "Parent": "x1000",
+            "Xname": "x1000c3",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c3b0": {
+            "Parent": "x1000c3",
+            "Xname": "x1000c3b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c3s0b0n0": {
+            "Parent": "x1000c3s0b0",
+            "Xname": "x1000c3s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1096,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001096"
+                ]
+            }
+        },
+        "x1000c3s0b0n1": {
+            "Parent": "x1000c3s0b0",
+            "Xname": "x1000c3s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1097,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001097"
+                ]
+            }
+        },
+        "x1000c3s0b1n0": {
+            "Parent": "x1000c3s0b1",
+            "Xname": "x1000c3s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1098,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001098"
+                ]
+            }
+        },
+        "x1000c3s0b1n1": {
+            "Parent": "x1000c3s0b1",
+            "Xname": "x1000c3s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1099,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001099"
+                ]
+            }
+        },
+        "x1000c3s1b0n0": {
+            "Parent": "x1000c3s1b0",
+            "Xname": "x1000c3s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1100,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001100"
+                ]
+            }
+        },
+        "x1000c3s1b0n1": {
+            "Parent": "x1000c3s1b0",
+            "Xname": "x1000c3s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1101,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001101"
+                ]
+            }
+        },
+        "x1000c3s1b1n0": {
+            "Parent": "x1000c3s1b1",
+            "Xname": "x1000c3s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1102,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001102"
+                ]
+            }
+        },
+        "x1000c3s1b1n1": {
+            "Parent": "x1000c3s1b1",
+            "Xname": "x1000c3s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1103,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001103"
+                ]
+            }
+        },
+        "x1000c3s2b0n0": {
+            "Parent": "x1000c3s2b0",
+            "Xname": "x1000c3s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1104,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001104"
+                ]
+            }
+        },
+        "x1000c3s2b0n1": {
+            "Parent": "x1000c3s2b0",
+            "Xname": "x1000c3s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1105,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001105"
+                ]
+            }
+        },
+        "x1000c3s2b1n0": {
+            "Parent": "x1000c3s2b1",
+            "Xname": "x1000c3s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1106,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001106"
+                ]
+            }
+        },
+        "x1000c3s2b1n1": {
+            "Parent": "x1000c3s2b1",
+            "Xname": "x1000c3s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1107,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001107"
+                ]
+            }
+        },
+        "x1000c3s3b0n0": {
+            "Parent": "x1000c3s3b0",
+            "Xname": "x1000c3s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1108,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001108"
+                ]
+            }
+        },
+        "x1000c3s3b0n1": {
+            "Parent": "x1000c3s3b0",
+            "Xname": "x1000c3s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1109,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001109"
+                ]
+            }
+        },
+        "x1000c3s3b1n0": {
+            "Parent": "x1000c3s3b1",
+            "Xname": "x1000c3s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1110,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001110"
+                ]
+            }
+        },
+        "x1000c3s3b1n1": {
+            "Parent": "x1000c3s3b1",
+            "Xname": "x1000c3s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1111,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001111"
+                ]
+            }
+        },
+        "x1000c3s4b0n0": {
+            "Parent": "x1000c3s4b0",
+            "Xname": "x1000c3s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1112,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001112"
+                ]
+            }
+        },
+        "x1000c3s4b0n1": {
+            "Parent": "x1000c3s4b0",
+            "Xname": "x1000c3s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1113,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001113"
+                ]
+            }
+        },
+        "x1000c3s4b1n0": {
+            "Parent": "x1000c3s4b1",
+            "Xname": "x1000c3s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1114,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001114"
+                ]
+            }
+        },
+        "x1000c3s4b1n1": {
+            "Parent": "x1000c3s4b1",
+            "Xname": "x1000c3s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1115,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001115"
+                ]
+            }
+        },
+        "x1000c3s5b0n0": {
+            "Parent": "x1000c3s5b0",
+            "Xname": "x1000c3s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1116,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001116"
+                ]
+            }
+        },
+        "x1000c3s5b0n1": {
+            "Parent": "x1000c3s5b0",
+            "Xname": "x1000c3s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1117,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001117"
+                ]
+            }
+        },
+        "x1000c3s5b1n0": {
+            "Parent": "x1000c3s5b1",
+            "Xname": "x1000c3s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1118,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001118"
+                ]
+            }
+        },
+        "x1000c3s5b1n1": {
+            "Parent": "x1000c3s5b1",
+            "Xname": "x1000c3s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1119,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001119"
+                ]
+            }
+        },
+        "x1000c3s6b0n0": {
+            "Parent": "x1000c3s6b0",
+            "Xname": "x1000c3s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1120,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001120"
+                ]
+            }
+        },
+        "x1000c3s6b0n1": {
+            "Parent": "x1000c3s6b0",
+            "Xname": "x1000c3s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1121,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001121"
+                ]
+            }
+        },
+        "x1000c3s6b1n0": {
+            "Parent": "x1000c3s6b1",
+            "Xname": "x1000c3s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1122,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001122"
+                ]
+            }
+        },
+        "x1000c3s6b1n1": {
+            "Parent": "x1000c3s6b1",
+            "Xname": "x1000c3s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1123,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001123"
+                ]
+            }
+        },
+        "x1000c3s7b0n0": {
+            "Parent": "x1000c3s7b0",
+            "Xname": "x1000c3s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1124,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001124"
+                ]
+            }
+        },
+        "x1000c3s7b0n1": {
+            "Parent": "x1000c3s7b0",
+            "Xname": "x1000c3s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1125,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001125"
+                ]
+            }
+        },
+        "x1000c3s7b1n0": {
+            "Parent": "x1000c3s7b1",
+            "Xname": "x1000c3s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1126,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001126"
+                ]
+            }
+        },
+        "x1000c3s7b1n1": {
+            "Parent": "x1000c3s7b1",
+            "Xname": "x1000c3s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1127,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001127"
+                ]
+            }
+        },
+        "x1000c4": {
+            "Parent": "x1000",
+            "Xname": "x1000c4",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c4b0": {
+            "Parent": "x1000c4",
+            "Xname": "x1000c4b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c4s0b0n0": {
+            "Parent": "x1000c4s0b0",
+            "Xname": "x1000c4s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1128,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001128"
+                ]
+            }
+        },
+        "x1000c4s0b0n1": {
+            "Parent": "x1000c4s0b0",
+            "Xname": "x1000c4s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1129,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001129"
+                ]
+            }
+        },
+        "x1000c4s0b1n0": {
+            "Parent": "x1000c4s0b1",
+            "Xname": "x1000c4s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1130,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001130"
+                ]
+            }
+        },
+        "x1000c4s0b1n1": {
+            "Parent": "x1000c4s0b1",
+            "Xname": "x1000c4s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1131,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001131"
+                ]
+            }
+        },
+        "x1000c4s1b0n0": {
+            "Parent": "x1000c4s1b0",
+            "Xname": "x1000c4s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1132,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001132"
+                ]
+            }
+        },
+        "x1000c4s1b0n1": {
+            "Parent": "x1000c4s1b0",
+            "Xname": "x1000c4s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1133,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001133"
+                ]
+            }
+        },
+        "x1000c4s1b1n0": {
+            "Parent": "x1000c4s1b1",
+            "Xname": "x1000c4s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1134,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001134"
+                ]
+            }
+        },
+        "x1000c4s1b1n1": {
+            "Parent": "x1000c4s1b1",
+            "Xname": "x1000c4s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1135,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001135"
+                ]
+            }
+        },
+        "x1000c4s2b0n0": {
+            "Parent": "x1000c4s2b0",
+            "Xname": "x1000c4s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1136,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001136"
+                ]
+            }
+        },
+        "x1000c4s2b0n1": {
+            "Parent": "x1000c4s2b0",
+            "Xname": "x1000c4s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1137,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001137"
+                ]
+            }
+        },
+        "x1000c4s2b1n0": {
+            "Parent": "x1000c4s2b1",
+            "Xname": "x1000c4s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1138,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001138"
+                ]
+            }
+        },
+        "x1000c4s2b1n1": {
+            "Parent": "x1000c4s2b1",
+            "Xname": "x1000c4s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1139,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001139"
+                ]
+            }
+        },
+        "x1000c4s3b0n0": {
+            "Parent": "x1000c4s3b0",
+            "Xname": "x1000c4s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1140,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001140"
+                ]
+            }
+        },
+        "x1000c4s3b0n1": {
+            "Parent": "x1000c4s3b0",
+            "Xname": "x1000c4s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1141,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001141"
+                ]
+            }
+        },
+        "x1000c4s3b1n0": {
+            "Parent": "x1000c4s3b1",
+            "Xname": "x1000c4s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1142,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001142"
+                ]
+            }
+        },
+        "x1000c4s3b1n1": {
+            "Parent": "x1000c4s3b1",
+            "Xname": "x1000c4s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1143,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001143"
+                ]
+            }
+        },
+        "x1000c4s4b0n0": {
+            "Parent": "x1000c4s4b0",
+            "Xname": "x1000c4s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1144,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001144"
+                ]
+            }
+        },
+        "x1000c4s4b0n1": {
+            "Parent": "x1000c4s4b0",
+            "Xname": "x1000c4s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1145,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001145"
+                ]
+            }
+        },
+        "x1000c4s4b1n0": {
+            "Parent": "x1000c4s4b1",
+            "Xname": "x1000c4s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1146,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001146"
+                ]
+            }
+        },
+        "x1000c4s4b1n1": {
+            "Parent": "x1000c4s4b1",
+            "Xname": "x1000c4s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1147,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001147"
+                ]
+            }
+        },
+        "x1000c4s5b0n0": {
+            "Parent": "x1000c4s5b0",
+            "Xname": "x1000c4s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1148,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001148"
+                ]
+            }
+        },
+        "x1000c4s5b0n1": {
+            "Parent": "x1000c4s5b0",
+            "Xname": "x1000c4s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1149,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001149"
+                ]
+            }
+        },
+        "x1000c4s5b1n0": {
+            "Parent": "x1000c4s5b1",
+            "Xname": "x1000c4s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1150,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001150"
+                ]
+            }
+        },
+        "x1000c4s5b1n1": {
+            "Parent": "x1000c4s5b1",
+            "Xname": "x1000c4s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1151,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001151"
+                ]
+            }
+        },
+        "x1000c4s6b0n0": {
+            "Parent": "x1000c4s6b0",
+            "Xname": "x1000c4s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1152,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001152"
+                ]
+            }
+        },
+        "x1000c4s6b0n1": {
+            "Parent": "x1000c4s6b0",
+            "Xname": "x1000c4s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1153,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001153"
+                ]
+            }
+        },
+        "x1000c4s6b1n0": {
+            "Parent": "x1000c4s6b1",
+            "Xname": "x1000c4s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1154,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001154"
+                ]
+            }
+        },
+        "x1000c4s6b1n1": {
+            "Parent": "x1000c4s6b1",
+            "Xname": "x1000c4s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1155,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001155"
+                ]
+            }
+        },
+        "x1000c4s7b0n0": {
+            "Parent": "x1000c4s7b0",
+            "Xname": "x1000c4s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1156,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001156"
+                ]
+            }
+        },
+        "x1000c4s7b0n1": {
+            "Parent": "x1000c4s7b0",
+            "Xname": "x1000c4s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1157,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001157"
+                ]
+            }
+        },
+        "x1000c4s7b1n0": {
+            "Parent": "x1000c4s7b1",
+            "Xname": "x1000c4s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1158,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001158"
+                ]
+            }
+        },
+        "x1000c4s7b1n1": {
+            "Parent": "x1000c4s7b1",
+            "Xname": "x1000c4s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1159,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001159"
+                ]
+            }
+        },
+        "x1000c5": {
+            "Parent": "x1000",
+            "Xname": "x1000c5",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c5b0": {
+            "Parent": "x1000c5",
+            "Xname": "x1000c5b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c5s0b0n0": {
+            "Parent": "x1000c5s0b0",
+            "Xname": "x1000c5s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1160,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001160"
+                ]
+            }
+        },
+        "x1000c5s0b0n1": {
+            "Parent": "x1000c5s0b0",
+            "Xname": "x1000c5s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1161,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001161"
+                ]
+            }
+        },
+        "x1000c5s0b1n0": {
+            "Parent": "x1000c5s0b1",
+            "Xname": "x1000c5s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1162,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001162"
+                ]
+            }
+        },
+        "x1000c5s0b1n1": {
+            "Parent": "x1000c5s0b1",
+            "Xname": "x1000c5s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1163,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001163"
+                ]
+            }
+        },
+        "x1000c5s1b0n0": {
+            "Parent": "x1000c5s1b0",
+            "Xname": "x1000c5s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1164,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001164"
+                ]
+            }
+        },
+        "x1000c5s1b0n1": {
+            "Parent": "x1000c5s1b0",
+            "Xname": "x1000c5s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1165,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001165"
+                ]
+            }
+        },
+        "x1000c5s1b1n0": {
+            "Parent": "x1000c5s1b1",
+            "Xname": "x1000c5s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1166,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001166"
+                ]
+            }
+        },
+        "x1000c5s1b1n1": {
+            "Parent": "x1000c5s1b1",
+            "Xname": "x1000c5s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1167,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001167"
+                ]
+            }
+        },
+        "x1000c5s2b0n0": {
+            "Parent": "x1000c5s2b0",
+            "Xname": "x1000c5s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1168,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001168"
+                ]
+            }
+        },
+        "x1000c5s2b0n1": {
+            "Parent": "x1000c5s2b0",
+            "Xname": "x1000c5s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1169,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001169"
+                ]
+            }
+        },
+        "x1000c5s2b1n0": {
+            "Parent": "x1000c5s2b1",
+            "Xname": "x1000c5s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1170,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001170"
+                ]
+            }
+        },
+        "x1000c5s2b1n1": {
+            "Parent": "x1000c5s2b1",
+            "Xname": "x1000c5s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1171,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001171"
+                ]
+            }
+        },
+        "x1000c5s3b0n0": {
+            "Parent": "x1000c5s3b0",
+            "Xname": "x1000c5s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1172,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001172"
+                ]
+            }
+        },
+        "x1000c5s3b0n1": {
+            "Parent": "x1000c5s3b0",
+            "Xname": "x1000c5s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1173,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001173"
+                ]
+            }
+        },
+        "x1000c5s3b1n0": {
+            "Parent": "x1000c5s3b1",
+            "Xname": "x1000c5s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1174,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001174"
+                ]
+            }
+        },
+        "x1000c5s3b1n1": {
+            "Parent": "x1000c5s3b1",
+            "Xname": "x1000c5s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1175,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001175"
+                ]
+            }
+        },
+        "x1000c5s4b0n0": {
+            "Parent": "x1000c5s4b0",
+            "Xname": "x1000c5s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1176,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001176"
+                ]
+            }
+        },
+        "x1000c5s4b0n1": {
+            "Parent": "x1000c5s4b0",
+            "Xname": "x1000c5s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1177,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001177"
+                ]
+            }
+        },
+        "x1000c5s4b1n0": {
+            "Parent": "x1000c5s4b1",
+            "Xname": "x1000c5s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1178,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001178"
+                ]
+            }
+        },
+        "x1000c5s4b1n1": {
+            "Parent": "x1000c5s4b1",
+            "Xname": "x1000c5s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1179,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001179"
+                ]
+            }
+        },
+        "x1000c5s5b0n0": {
+            "Parent": "x1000c5s5b0",
+            "Xname": "x1000c5s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1180,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001180"
+                ]
+            }
+        },
+        "x1000c5s5b0n1": {
+            "Parent": "x1000c5s5b0",
+            "Xname": "x1000c5s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1181,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001181"
+                ]
+            }
+        },
+        "x1000c5s5b1n0": {
+            "Parent": "x1000c5s5b1",
+            "Xname": "x1000c5s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1182,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001182"
+                ]
+            }
+        },
+        "x1000c5s5b1n1": {
+            "Parent": "x1000c5s5b1",
+            "Xname": "x1000c5s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1183,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001183"
+                ]
+            }
+        },
+        "x1000c5s6b0n0": {
+            "Parent": "x1000c5s6b0",
+            "Xname": "x1000c5s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1184,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001184"
+                ]
+            }
+        },
+        "x1000c5s6b0n1": {
+            "Parent": "x1000c5s6b0",
+            "Xname": "x1000c5s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1185,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001185"
+                ]
+            }
+        },
+        "x1000c5s6b1n0": {
+            "Parent": "x1000c5s6b1",
+            "Xname": "x1000c5s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1186,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001186"
+                ]
+            }
+        },
+        "x1000c5s6b1n1": {
+            "Parent": "x1000c5s6b1",
+            "Xname": "x1000c5s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1187,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001187"
+                ]
+            }
+        },
+        "x1000c5s7b0n0": {
+            "Parent": "x1000c5s7b0",
+            "Xname": "x1000c5s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1188,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001188"
+                ]
+            }
+        },
+        "x1000c5s7b0n1": {
+            "Parent": "x1000c5s7b0",
+            "Xname": "x1000c5s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1189,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001189"
+                ]
+            }
+        },
+        "x1000c5s7b1n0": {
+            "Parent": "x1000c5s7b1",
+            "Xname": "x1000c5s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1190,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001190"
+                ]
+            }
+        },
+        "x1000c5s7b1n1": {
+            "Parent": "x1000c5s7b1",
+            "Xname": "x1000c5s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1191,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001191"
+                ]
+            }
+        },
+        "x1000c6": {
+            "Parent": "x1000",
+            "Xname": "x1000c6",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c6b0": {
+            "Parent": "x1000c6",
+            "Xname": "x1000c6b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c6s0b0n0": {
+            "Parent": "x1000c6s0b0",
+            "Xname": "x1000c6s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1192,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001192"
+                ]
+            }
+        },
+        "x1000c6s0b0n1": {
+            "Parent": "x1000c6s0b0",
+            "Xname": "x1000c6s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1193,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001193"
+                ]
+            }
+        },
+        "x1000c6s0b1n0": {
+            "Parent": "x1000c6s0b1",
+            "Xname": "x1000c6s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1194,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001194"
+                ]
+            }
+        },
+        "x1000c6s0b1n1": {
+            "Parent": "x1000c6s0b1",
+            "Xname": "x1000c6s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1195,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001195"
+                ]
+            }
+        },
+        "x1000c6s1b0n0": {
+            "Parent": "x1000c6s1b0",
+            "Xname": "x1000c6s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1196,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001196"
+                ]
+            }
+        },
+        "x1000c6s1b0n1": {
+            "Parent": "x1000c6s1b0",
+            "Xname": "x1000c6s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1197,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001197"
+                ]
+            }
+        },
+        "x1000c6s1b1n0": {
+            "Parent": "x1000c6s1b1",
+            "Xname": "x1000c6s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1198,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001198"
+                ]
+            }
+        },
+        "x1000c6s1b1n1": {
+            "Parent": "x1000c6s1b1",
+            "Xname": "x1000c6s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1199,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001199"
+                ]
+            }
+        },
+        "x1000c6s2b0n0": {
+            "Parent": "x1000c6s2b0",
+            "Xname": "x1000c6s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1200,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001200"
+                ]
+            }
+        },
+        "x1000c6s2b0n1": {
+            "Parent": "x1000c6s2b0",
+            "Xname": "x1000c6s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1201,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001201"
+                ]
+            }
+        },
+        "x1000c6s2b1n0": {
+            "Parent": "x1000c6s2b1",
+            "Xname": "x1000c6s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1202,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001202"
+                ]
+            }
+        },
+        "x1000c6s2b1n1": {
+            "Parent": "x1000c6s2b1",
+            "Xname": "x1000c6s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1203,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001203"
+                ]
+            }
+        },
+        "x1000c6s3b0n0": {
+            "Parent": "x1000c6s3b0",
+            "Xname": "x1000c6s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1204,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001204"
+                ]
+            }
+        },
+        "x1000c6s3b0n1": {
+            "Parent": "x1000c6s3b0",
+            "Xname": "x1000c6s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1205,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001205"
+                ]
+            }
+        },
+        "x1000c6s3b1n0": {
+            "Parent": "x1000c6s3b1",
+            "Xname": "x1000c6s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1206,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001206"
+                ]
+            }
+        },
+        "x1000c6s3b1n1": {
+            "Parent": "x1000c6s3b1",
+            "Xname": "x1000c6s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1207,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001207"
+                ]
+            }
+        },
+        "x1000c6s4b0n0": {
+            "Parent": "x1000c6s4b0",
+            "Xname": "x1000c6s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1208,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001208"
+                ]
+            }
+        },
+        "x1000c6s4b0n1": {
+            "Parent": "x1000c6s4b0",
+            "Xname": "x1000c6s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1209,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001209"
+                ]
+            }
+        },
+        "x1000c6s4b1n0": {
+            "Parent": "x1000c6s4b1",
+            "Xname": "x1000c6s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1210,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001210"
+                ]
+            }
+        },
+        "x1000c6s4b1n1": {
+            "Parent": "x1000c6s4b1",
+            "Xname": "x1000c6s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1211,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001211"
+                ]
+            }
+        },
+        "x1000c6s5b0n0": {
+            "Parent": "x1000c6s5b0",
+            "Xname": "x1000c6s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1212,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001212"
+                ]
+            }
+        },
+        "x1000c6s5b0n1": {
+            "Parent": "x1000c6s5b0",
+            "Xname": "x1000c6s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1213,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001213"
+                ]
+            }
+        },
+        "x1000c6s5b1n0": {
+            "Parent": "x1000c6s5b1",
+            "Xname": "x1000c6s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1214,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001214"
+                ]
+            }
+        },
+        "x1000c6s5b1n1": {
+            "Parent": "x1000c6s5b1",
+            "Xname": "x1000c6s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1215,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001215"
+                ]
+            }
+        },
+        "x1000c6s6b0n0": {
+            "Parent": "x1000c6s6b0",
+            "Xname": "x1000c6s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1216,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001216"
+                ]
+            }
+        },
+        "x1000c6s6b0n1": {
+            "Parent": "x1000c6s6b0",
+            "Xname": "x1000c6s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1217,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001217"
+                ]
+            }
+        },
+        "x1000c6s6b1n0": {
+            "Parent": "x1000c6s6b1",
+            "Xname": "x1000c6s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1218,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001218"
+                ]
+            }
+        },
+        "x1000c6s6b1n1": {
+            "Parent": "x1000c6s6b1",
+            "Xname": "x1000c6s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1219,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001219"
+                ]
+            }
+        },
+        "x1000c6s7b0n0": {
+            "Parent": "x1000c6s7b0",
+            "Xname": "x1000c6s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1220,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001220"
+                ]
+            }
+        },
+        "x1000c6s7b0n1": {
+            "Parent": "x1000c6s7b0",
+            "Xname": "x1000c6s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1221,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001221"
+                ]
+            }
+        },
+        "x1000c6s7b1n0": {
+            "Parent": "x1000c6s7b1",
+            "Xname": "x1000c6s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1222,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001222"
+                ]
+            }
+        },
+        "x1000c6s7b1n1": {
+            "Parent": "x1000c6s7b1",
+            "Xname": "x1000c6s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1223,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001223"
+                ]
+            }
+        },
+        "x1000c7": {
+            "Parent": "x1000",
+            "Xname": "x1000c7",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c7b0": {
+            "Parent": "x1000c7",
+            "Xname": "x1000c7b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c7s0b0n0": {
+            "Parent": "x1000c7s0b0",
+            "Xname": "x1000c7s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1224,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001224"
+                ]
+            }
+        },
+        "x1000c7s0b0n1": {
+            "Parent": "x1000c7s0b0",
+            "Xname": "x1000c7s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1225,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001225"
+                ]
+            }
+        },
+        "x1000c7s0b1n0": {
+            "Parent": "x1000c7s0b1",
+            "Xname": "x1000c7s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1226,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001226"
+                ]
+            }
+        },
+        "x1000c7s0b1n1": {
+            "Parent": "x1000c7s0b1",
+            "Xname": "x1000c7s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1227,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001227"
+                ]
+            }
+        },
+        "x1000c7s1b0n0": {
+            "Parent": "x1000c7s1b0",
+            "Xname": "x1000c7s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1228,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001228"
+                ]
+            }
+        },
+        "x1000c7s1b0n1": {
+            "Parent": "x1000c7s1b0",
+            "Xname": "x1000c7s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1229,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001229"
+                ]
+            }
+        },
+        "x1000c7s1b1n0": {
+            "Parent": "x1000c7s1b1",
+            "Xname": "x1000c7s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1230,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001230"
+                ]
+            }
+        },
+        "x1000c7s1b1n1": {
+            "Parent": "x1000c7s1b1",
+            "Xname": "x1000c7s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1231,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001231"
+                ]
+            }
+        },
+        "x1000c7s2b0n0": {
+            "Parent": "x1000c7s2b0",
+            "Xname": "x1000c7s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1232,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001232"
+                ]
+            }
+        },
+        "x1000c7s2b0n1": {
+            "Parent": "x1000c7s2b0",
+            "Xname": "x1000c7s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1233,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001233"
+                ]
+            }
+        },
+        "x1000c7s2b1n0": {
+            "Parent": "x1000c7s2b1",
+            "Xname": "x1000c7s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1234,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001234"
+                ]
+            }
+        },
+        "x1000c7s2b1n1": {
+            "Parent": "x1000c7s2b1",
+            "Xname": "x1000c7s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1235,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001235"
+                ]
+            }
+        },
+        "x1000c7s3b0n0": {
+            "Parent": "x1000c7s3b0",
+            "Xname": "x1000c7s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1236,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001236"
+                ]
+            }
+        },
+        "x1000c7s3b0n1": {
+            "Parent": "x1000c7s3b0",
+            "Xname": "x1000c7s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1237,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001237"
+                ]
+            }
+        },
+        "x1000c7s3b1n0": {
+            "Parent": "x1000c7s3b1",
+            "Xname": "x1000c7s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1238,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001238"
+                ]
+            }
+        },
+        "x1000c7s3b1n1": {
+            "Parent": "x1000c7s3b1",
+            "Xname": "x1000c7s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1239,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001239"
+                ]
+            }
+        },
+        "x1000c7s4b0n0": {
+            "Parent": "x1000c7s4b0",
+            "Xname": "x1000c7s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1240,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001240"
+                ]
+            }
+        },
+        "x1000c7s4b0n1": {
+            "Parent": "x1000c7s4b0",
+            "Xname": "x1000c7s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1241,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001241"
+                ]
+            }
+        },
+        "x1000c7s4b1n0": {
+            "Parent": "x1000c7s4b1",
+            "Xname": "x1000c7s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1242,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001242"
+                ]
+            }
+        },
+        "x1000c7s4b1n1": {
+            "Parent": "x1000c7s4b1",
+            "Xname": "x1000c7s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1243,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001243"
+                ]
+            }
+        },
+        "x1000c7s5b0n0": {
+            "Parent": "x1000c7s5b0",
+            "Xname": "x1000c7s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1244,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001244"
+                ]
+            }
+        },
+        "x1000c7s5b0n1": {
+            "Parent": "x1000c7s5b0",
+            "Xname": "x1000c7s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1245,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001245"
+                ]
+            }
+        },
+        "x1000c7s5b1n0": {
+            "Parent": "x1000c7s5b1",
+            "Xname": "x1000c7s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1246,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001246"
+                ]
+            }
+        },
+        "x1000c7s5b1n1": {
+            "Parent": "x1000c7s5b1",
+            "Xname": "x1000c7s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1247,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001247"
+                ]
+            }
+        },
+        "x1000c7s6b0n0": {
+            "Parent": "x1000c7s6b0",
+            "Xname": "x1000c7s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1248,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001248"
+                ]
+            }
+        },
+        "x1000c7s6b0n1": {
+            "Parent": "x1000c7s6b0",
+            "Xname": "x1000c7s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1249,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001249"
+                ]
+            }
+        },
+        "x1000c7s6b1n0": {
+            "Parent": "x1000c7s6b1",
+            "Xname": "x1000c7s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1250,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001250"
+                ]
+            }
+        },
+        "x1000c7s6b1n1": {
+            "Parent": "x1000c7s6b1",
+            "Xname": "x1000c7s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1251,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001251"
+                ]
+            }
+        },
+        "x1000c7s7b0n0": {
+            "Parent": "x1000c7s7b0",
+            "Xname": "x1000c7s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1252,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001252"
+                ]
+            }
+        },
+        "x1000c7s7b0n1": {
+            "Parent": "x1000c7s7b0",
+            "Xname": "x1000c7s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1253,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001253"
+                ]
+            }
+        },
+        "x1000c7s7b1n0": {
+            "Parent": "x1000c7s7b1",
+            "Xname": "x1000c7s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1254,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001254"
+                ]
+            }
+        },
+        "x1000c7s7b1n1": {
+            "Parent": "x1000c7s7b1",
+            "Xname": "x1000c7s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1255,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001255"
+                ]
+            }
+        },
+        "x3000": {
+            "Parent": "s0",
+            "Xname": "x3000",
+            "Type": "comptype_cabinet",
+            "Class": "River",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    },
+                    "ncn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    }
+                }
+            }
+        },
+        "x3000c0h33s1": {
+            "Parent": "x3000c0h33",
+            "Xname": "x3000c0h33s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.4",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-001"
+                ]
+            }
+        },
+        "x3000c0h34s1": {
+            "Parent": "x3000c0h34",
+            "Xname": "x3000c0h34s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.5",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-002"
+                ]
+            }
+        },
+        "x3000c0h35s1": {
+            "Parent": "x3000c0h35",
+            "Xname": "x3000c0h35s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.6",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-003"
+                ]
+            }
+        },
+        "x3000c0h36s1": {
+            "Parent": "x3000c0h36",
+            "Xname": "x3000c0h36s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.7",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-004"
+                ]
+            }
+        },
+        "x3000c0h37s1": {
+            "Parent": "x3000c0h37",
+            "Xname": "x3000c0h37s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.2",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-001"
+                ]
+            }
+        },
+        "x3000c0h38s1": {
+            "Parent": "x3000c0h38",
+            "Xname": "x3000c0h38s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.3",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-002"
+                ]
+            }
+        },
+        "x3000c0r39b0": {
+            "Parent": "x3000c0r39",
+            "Xname": "x3000c0r39b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x3000c0r39b0",
+                "Password": "vault://hms-creds/x3000c0r39b0"
+            }
+        },
+        "x3000c0r40b0": {
+            "Parent": "x3000c0r40",
+            "Xname": "x3000c0r40b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x3000c0r40b0",
+                "Password": "vault://hms-creds/x3000c0r40b0"
+            }
+        },
+        "x3000c0s10b0n0": {
+            "Parent": "x3000c0s10b0",
+            "Xname": "x3000c0s10b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100001,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s003"
+                ]
+            }
+        },
+        "x3000c0s15b0n0": {
+            "Parent": "x3000c0s15b0",
+            "Xname": "x3000c0s15b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan01"
+                ]
+            }
+        },
+        "x3000c0s16b0n0": {
+            "Parent": "x3000c0s16b0",
+            "Xname": "x3000c0s16b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan02"
+                ]
+            }
+        },
+        "x3000c0s1b0n0": {
+            "Parent": "x3000c0s1b0",
+            "Xname": "x3000c0s1b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100010,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m001"
+                ]
+            }
+        },
+        "x3000c0s24b0n0": {
+            "Parent": "x3000c0s24b0",
+            "Xname": "x3000c0s24b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "@rie.mockup": "XL675d_A40",
+                "NID": 1,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid000001"
+                ]
+            }
+        },
+        "x3000c0s2b0n0": {
+            "Parent": "x3000c0s2b0",
+            "Xname": "x3000c0s2b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100009,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m002"
+                ]
+            }
+        },
+        "x3000c0s3b0n0": {
+            "Parent": "x3000c0s3b0",
+            "Xname": "x3000c0s3b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100008,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m003"
+                ]
+            }
+        },
+        "x3000c0s4b0n0": {
+            "Parent": "x3000c0s4b0",
+            "Xname": "x3000c0s4b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100007,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w001"
+                ]
+            }
+        },
+        "x3000c0s5b0n0": {
+            "Parent": "x3000c0s5b0",
+            "Xname": "x3000c0s5b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100006,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w002"
+                ]
+            }
+        },
+        "x3000c0s6b0n0": {
+            "Parent": "x3000c0s6b0",
+            "Xname": "x3000c0s6b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100005,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w003"
+                ]
+            }
+        },
+        "x3000c0s7b0n0": {
+            "Parent": "x3000c0s7b0",
+            "Xname": "x3000c0s7b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100004,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w004"
+                ]
+            }
+        },
+        "x3000c0s8b0n0": {
+            "Parent": "x3000c0s8b0",
+            "Xname": "x3000c0s8b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100003,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s001"
+                ]
+            }
+        },
+        "x3000c0s9b0n0": {
+            "Parent": "x3000c0s9b0",
+            "Xname": "x3000c0s9b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100002,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s002"
+                ]
+            }
+        },
+        "x3000c0w31": {
+            "Parent": "x3000c0",
+            "Xname": "x3000c0w31",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.8",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-001"
+                ]
+            }
+        },
+        "x3000c0w31j29": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j29",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s24b0"
+                ],
+                "VendorName": "1/1/29"
+            }
+        },
+        "x3000c0w31j34": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j34",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s2b0"
+                ],
+                "VendorName": "1/1/34"
+            }
+        },
+        "x3000c0w31j35": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j35",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s4b0"
+                ],
+                "VendorName": "1/1/35"
+            }
+        },
+        "x3000c0w31j36": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s5b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x3000c0w31j37": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s6b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x3000c0w31j38": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s8b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x3000c0w31j39": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j39",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s9b0"
+                ],
+                "VendorName": "1/1/39"
+            }
+        },
+        "x3000c0w31j40": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j40",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s15b0"
+                ],
+                "VendorName": "1/1/40"
+            }
+        },
+        "x3000c0w31j41": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j41",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s16b0"
+                ],
+                "VendorName": "1/1/41"
+            }
+        },
+        "x3000c0w31j47": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0r39b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x3000c0w31j48": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000m0"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x3000c0w32": {
+            "Parent": "x3000c0",
+            "Xname": "x3000c0w32",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.9",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x3000c0w32",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x3000c0w32",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-002"
+                ]
+            }
+        },
+        "x3000c0w32j36": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s3b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x3000c0w32j37": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s7b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x3000c0w32j38": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s10b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x3000c0w32j47": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0r40b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x3000c0w32j48": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000m1"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x3000m0": {
+            "Parent": "x3000",
+            "Xname": "x3000m0",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        },
+        "x3000m1": {
+            "Parent": "x3000",
+            "Xname": "x3000m1",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        }
+    },
+    "Networks": {}
+}

--- a/testdata/fixtures/sls/River.json
+++ b/testdata/fixtures/sls/River.json
@@ -1,0 +1,599 @@
+{
+    "Hardware": {
+        "x3000": {
+            "Parent": "s0",
+            "Xname": "x3000",
+            "Type": "comptype_cabinet",
+            "Class": "River",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    },
+                    "ncn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    }
+                }
+            }
+        },
+        "x3000c0h33s1": {
+            "Parent": "x3000c0h33",
+            "Xname": "x3000c0h33s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.4",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-001"
+                ]
+            }
+        },
+        "x3000c0h34s1": {
+            "Parent": "x3000c0h34",
+            "Xname": "x3000c0h34s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.5",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-002"
+                ]
+            }
+        },
+        "x3000c0h35s1": {
+            "Parent": "x3000c0h35",
+            "Xname": "x3000c0h35s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.6",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-003"
+                ]
+            }
+        },
+        "x3000c0h36s1": {
+            "Parent": "x3000c0h36",
+            "Xname": "x3000c0h36s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.7",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-004"
+                ]
+            }
+        },
+        "x3000c0h37s1": {
+            "Parent": "x3000c0h37",
+            "Xname": "x3000c0h37s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.2",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-001"
+                ]
+            }
+        },
+        "x3000c0h38s1": {
+            "Parent": "x3000c0h38",
+            "Xname": "x3000c0h38s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.3",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-002"
+                ]
+            }
+        },
+        "x3000c0r39b0": {
+            "Parent": "x3000c0r39",
+            "Xname": "x3000c0r39b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x3000c0r39b0",
+                "Password": "vault://hms-creds/x3000c0r39b0"
+            }
+        },
+        "x3000c0r40b0": {
+            "Parent": "x3000c0r40",
+            "Xname": "x3000c0r40b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x3000c0r40b0",
+                "Password": "vault://hms-creds/x3000c0r40b0"
+            }
+        },
+        "x3000c0s10b0n0": {
+            "Parent": "x3000c0s10b0",
+            "Xname": "x3000c0s10b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100001,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s003"
+                ]
+            }
+        },
+        "x3000c0s15b0n0": {
+            "Parent": "x3000c0s15b0",
+            "Xname": "x3000c0s15b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan01"
+                ]
+            }
+        },
+        "x3000c0s16b0n0": {
+            "Parent": "x3000c0s16b0",
+            "Xname": "x3000c0s16b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan02"
+                ]
+            }
+        },
+        "x3000c0s1b0n0": {
+            "Parent": "x3000c0s1b0",
+            "Xname": "x3000c0s1b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100010,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m001"
+                ]
+            }
+        },
+        "x3000c0s24b0n0": {
+            "Parent": "x3000c0s24b0",
+            "Xname": "x3000c0s24b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "@rie.mockup": "XL675d_A40",
+                "NID": 1,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid000001"
+                ]
+            }
+        },
+        "x3000c0s2b0n0": {
+            "Parent": "x3000c0s2b0",
+            "Xname": "x3000c0s2b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100009,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m002"
+                ]
+            }
+        },
+        "x3000c0s3b0n0": {
+            "Parent": "x3000c0s3b0",
+            "Xname": "x3000c0s3b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100008,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m003"
+                ]
+            }
+        },
+        "x3000c0s4b0n0": {
+            "Parent": "x3000c0s4b0",
+            "Xname": "x3000c0s4b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100007,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w001"
+                ]
+            }
+        },
+        "x3000c0s5b0n0": {
+            "Parent": "x3000c0s5b0",
+            "Xname": "x3000c0s5b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100006,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w002"
+                ]
+            }
+        },
+        "x3000c0s6b0n0": {
+            "Parent": "x3000c0s6b0",
+            "Xname": "x3000c0s6b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100005,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w003"
+                ]
+            }
+        },
+        "x3000c0s7b0n0": {
+            "Parent": "x3000c0s7b0",
+            "Xname": "x3000c0s7b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100004,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w004"
+                ]
+            }
+        },
+        "x3000c0s8b0n0": {
+            "Parent": "x3000c0s8b0",
+            "Xname": "x3000c0s8b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100003,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s001"
+                ]
+            }
+        },
+        "x3000c0s9b0n0": {
+            "Parent": "x3000c0s9b0",
+            "Xname": "x3000c0s9b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100002,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s002"
+                ]
+            }
+        },
+        "x3000c0w31": {
+            "Parent": "x3000c0",
+            "Xname": "x3000c0w31",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.8",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-001"
+                ]
+            }
+        },
+        "x3000c0w31j29": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j29",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s24b0"
+                ],
+                "VendorName": "1/1/29"
+            }
+        },
+        "x3000c0w31j34": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j34",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s2b0"
+                ],
+                "VendorName": "1/1/34"
+            }
+        },
+        "x3000c0w31j35": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j35",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s4b0"
+                ],
+                "VendorName": "1/1/35"
+            }
+        },
+        "x3000c0w31j36": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s5b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x3000c0w31j37": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s6b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x3000c0w31j38": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s8b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x3000c0w31j39": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j39",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s9b0"
+                ],
+                "VendorName": "1/1/39"
+            }
+        },
+        "x3000c0w31j40": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j40",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s15b0"
+                ],
+                "VendorName": "1/1/40"
+            }
+        },
+        "x3000c0w31j41": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j41",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s16b0"
+                ],
+                "VendorName": "1/1/41"
+            }
+        },
+        "x3000c0w31j47": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0r39b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x3000c0w31j48": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000m0"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x3000c0w32": {
+            "Parent": "x3000c0",
+            "Xname": "x3000c0w32",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.9",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x3000c0w32",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x3000c0w32",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-002"
+                ]
+            }
+        },
+        "x3000c0w32j36": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s3b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x3000c0w32j37": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s7b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x3000c0w32j38": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s10b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x3000c0w32j47": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0r40b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x3000c0w32j48": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000m1"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x3000m0": {
+            "Parent": "x3000",
+            "Xname": "x3000m0",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        },
+        "x3000m1": {
+            "Parent": "x3000",
+            "Xname": "x3000m1",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        }
+    },
+    "Networks": {}
+}

--- a/testdata/fixtures/sls/no_hardware.json
+++ b/testdata/fixtures/sls/no_hardware.json
@@ -1,0 +1,4 @@
+{
+    "Hardware": {},
+    "Networks": {}
+}

--- a/testdata/fixtures/sls/one_of_each_blade.json
+++ b/testdata/fixtures/sls/one_of_each_blade.json
@@ -1,0 +1,135 @@
+{
+    "Hardware": {
+
+        "x1000": {
+            "Parent": "s0",
+            "Xname": "x1000",
+            "Type": "comptype_cabinet",
+            "Class": "Mountain",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.104.0.0/22",
+                            "Gateway": "10.104.0.1",
+                            "VLan": 3001
+                        },
+                        "NMN": {
+                            "CIDR": "10.100.0.0/22",
+                            "Gateway": "10.100.0.1",
+                            "VLan": 2001
+                        }
+                    }
+                }
+            }
+        },
+        "x1000c0": {       "Parent": "x1000",       "Xname": "x1000c0",       "Type": "comptype_chassis",     "TypeString": "Chassis",       "Class": "Mountain" },
+        "x1000c0b0": {     "Parent": "x1000c0",     "Xname": "x1000c0b0",     "Type": "comptype_chassis_bmc", "TypeString": "ChassisBMC",    "Class": "Mountain" },
+        
+        "x1000c0r0": {     "Parent": "x1000c0",     "Xname": "x1000c0r3",     "Type": "comptype_rtrmod",     "TypeString": "RouterModule",   "Class": "Mountain", "ExtraProperties": {"@rie.mockup": "Slingshot_Switch_Blade"}},
+
+        "x1000c0s0": {     "Parent": "x1000c0",     "Xname": "x1000c0s0",     "Type": "comptype_compmod",     "TypeString": "ComputeModule", "Class": "Mountain", "ExtraProperties": {"@rie.mockup": "EX425"}},
+        "x1000c0s0b0n0": { "Parent": "x1000c0s0b0", "Xname": "x1000c0s0b0n0", "Type": "comptype_node",        "TypeString": "Node",          "Class": "Mountain", "ExtraProperties": {"NID": 1000, "Role": "Compute", "Aliases": ["nid001000"]}},
+        "x1000c0s0b0n1": { "Parent": "x1000c0s0b0", "Xname": "x1000c0s0b0n1", "Type": "comptype_node",        "TypeString": "Node",          "Class": "Mountain", "ExtraProperties": {"NID": 1001, "Role": "Compute", "Aliases": ["nid001001"]}},
+        "x1000c0s0b1n0": { "Parent": "x1000c0s0b1", "Xname": "x1000c0s0b1n0", "Type": "comptype_node",        "TypeString": "Node",          "Class": "Mountain", "ExtraProperties": {"NID": 1002, "Role": "Compute", "Aliases": ["nid001002"]}},
+        "x1000c0s0b1n1": { "Parent": "x1000c0s0b1", "Xname": "x1000c0s0b1n1", "Type": "comptype_node",        "TypeString": "Node",          "Class": "Mountain", "ExtraProperties": {"NID": 1003, "Role": "Compute", "Aliases": ["nid001003"]}},
+
+        "x1000c0s1": {     "Parent": "x1000c0",     "Xname": "x1000c0s1",     "Type": "comptype_compmod",     "TypeString": "ComputeModule", "Class": "Mountain", "ExtraProperties": {"@rie.mockup": "EX420"}},
+        "x1000c0s1b0n0": { "Parent": "x1000c0s1b0", "Xname": "x1000c0s1b0n0", "Type": "comptype_node",        "TypeString": "Node",          "Class": "Mountain", "ExtraProperties": {"NID": 1100, "Role": "Compute", "Aliases": ["nid001100"]}},
+        "x1000c0s1b0n1": { "Parent": "x1000c0s1b0", "Xname": "x1000c0s1b0n1", "Type": "comptype_node",        "TypeString": "Node",          "Class": "Mountain", "ExtraProperties": {"NID": 1101, "Role": "Compute", "Aliases": ["nid001101"]}},
+        "x1000c0s1b1n0": { "Parent": "x1000c0s1b1", "Xname": "x1000c0s1b1n0", "Type": "comptype_node",        "TypeString": "Node",          "Class": "Mountain", "ExtraProperties": {"NID": 1102, "Role": "Compute", "Aliases": ["nid001102"]}},
+        "x1000c0s1b1n1": { "Parent": "x1000c0s1b1", "Xname": "x1000c0s1b1n1", "Type": "comptype_node",        "TypeString": "Node",          "Class": "Mountain", "ExtraProperties": {"NID": 1103, "Role": "Compute", "Aliases": ["nid001103"]}},
+
+        "x1000c0s2": {     "Parent": "x1000c0",     "Xname": "x1000c0s2",     "Type": "comptype_compmod",     "TypeString": "ComputeModule", "Class": "Mountain", "ExtraProperties": {"@rie.mockup": "EX235a"}},
+        "x1000c0s2b0n0": { "Parent": "x1000c0s2b0", "Xname": "x1000c0s2b0n0", "Type": "comptype_node",        "TypeString": "Node",          "Class": "Mountain", "ExtraProperties": {"NID": 1200, "Role": "Compute", "Aliases": ["nid001200"]}},
+        "x1000c0s2b1n0": { "Parent": "x1000c0s2b1", "Xname": "x1000c0s2b1n0", "Type": "comptype_node",        "TypeString": "Node",          "Class": "Mountain", "ExtraProperties": {"NID": 1201, "Role": "Compute", "Aliases": ["nid001201"]}},
+
+        "x1000c0s3": {     "Parent": "x1000c0",     "Xname": "x1000c0s3",     "Type": "comptype_compmod",     "TypeString": "ComputeModule", "Class": "Mountain", "ExtraProperties": {"@rie.mockup": "EX235n"}},
+        "x1000c0s3b0n0": { "Parent": "x1000c0s3b0", "Xname": "x1000c0s3b0n0", "Type": "comptype_node",        "TypeString": "Node",          "Class": "Mountain", "ExtraProperties": {"NID": 1300, "Role": "Compute", "Aliases": ["nid001300"]}},
+        "x1000c0s3b1n0": { "Parent": "x1000c0s3b0", "Xname": "x1000c0s3b0n1", "Type": "comptype_node",        "TypeString": "Node",          "Class": "Mountain", "ExtraProperties": {"NID": 1301, "Role": "Compute", "Aliases": ["nid001301"]}},
+
+        "x3000": {
+            "Parent": "s0",
+            "Xname": "x3000",
+            "Type": "comptype_cabinet",
+            "Class": "River",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    },
+                    "ncn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    }
+                }
+            }
+        },
+
+        "x3000c0s1b1n0": { "Parent": "x3000c0s1b1", "Xname": "x3000c0s1b1n0", "Type": "comptype_node", "TypeString": "Node", "Class": "River", "ExtraProperties": {"@rie.mockup": "Intel", "NID": 1, "Role": "Compute", "Aliases": ["nid000001"]}},
+        "x3000c0s1b2n0": { "Parent": "x3000c0s1b2", "Xname": "x3000c0s1b2n0", "Type": "comptype_node", "TypeString": "Node", "Class": "River", "ExtraProperties": {"@rie.mockup": "Intel", "NID": 2, "Role": "Compute", "Aliases": ["nid000002"]}},
+        "x3000c0s1b3n0": { "Parent": "x3000c0s1b3", "Xname": "x3000c0s1b3n0", "Type": "comptype_node", "TypeString": "Node", "Class": "River", "ExtraProperties": {"@rie.mockup": "Intel", "NID": 3, "Role": "Compute", "Aliases": ["nid000003"]}},
+        "x3000c0s1b4n0": { "Parent": "x3000c0s1b4", "Xname": "x3000c0s1b4n0", "Type": "comptype_node", "TypeString": "Node", "Class": "River", "ExtraProperties": {"@rie.mockup": "Intel", "NID": 4, "Role": "Compute", "Aliases": ["nid000004"]}},
+
+        "x3000c0s3b1n0": { "Parent": "x3000c0s3b1", "Xname": "x3000c0s3b1n0", "Type": "comptype_node", "TypeString": "Node", "Class": "River", "ExtraProperties": {"@rie.mockup": "Gigabyte", "NID": 11, "Role": "Compute", "Aliases": ["nid000011"]}},
+        "x3000c0s3b2n0": { "Parent": "x3000c0s3b2", "Xname": "x3000c0s3b2n0", "Type": "comptype_node", "TypeString": "Node", "Class": "River", "ExtraProperties": {"@rie.mockup": "Gigabyte", "NID": 12, "Role": "Compute", "Aliases": ["nid000012"]}},
+        "x3000c0s3b3n0": { "Parent": "x3000c0s3b3", "Xname": "x3000c0s3b3n0", "Type": "comptype_node", "TypeString": "Node", "Class": "River", "ExtraProperties": {"@rie.mockup": "Gigabyte", "NID": 13, "Role": "Compute", "Aliases": ["nid000013"]}},
+        "x3000c0s3b4n0": { "Parent": "x3000c0s3b4", "Xname": "x3000c0s3b4n0", "Type": "comptype_node", "TypeString": "Node", "Class": "River", "ExtraProperties": {"@rie.mockup": "Gigabyte", "NID": 14, "Role": "Compute", "Aliases": ["nid000014"]}},
+
+        "x3000c0s5b0n0": { "Parent": "x3000c0s5b0", "Xname": "x3000c0s5b0n0", "Type": "comptype_node", "TypeString": "Node", "Class": "River", "ExtraProperties": {"@rie.mockup": "DL325",      "Role": "Application", "SubRole": "UAN", "Aliases": ["uan01"]}},
+
+        "x3000c0s6b0n0": { "Parent": "x3000c0s6b0", "Xname": "x3000c0s6b0n0", "Type": "comptype_node", "TypeString": "Node", "Class": "River", "ExtraProperties": {"@rie.mockup": "XL675d_A40", "NID": 20, "Role": "Compute",   "Aliases": ["nid000020"]}},
+
+        "x3000c0w31": {"Parent": "x3000c0",
+            "Xname": "x3000c0w31",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.8",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-001"
+                ]
+            }
+        },
+
+        "x3000c0w31j10": { "Parent": "x3000c0w31", "Xname": "x3000c0w31j10", "Type": "comptype_mgmt_switch_connector", "TypeString": "MgmtSwitchConnector", "Class": "River", "ExtraProperties": {"NodeNics": ["x3000c0s1b1"], "VendorName": "1/1/10"}},
+        "x3000c0w31j11": { "Parent": "x3000c0w31", "Xname": "x3000c0w31j11", "Type": "comptype_mgmt_switch_connector", "TypeString": "MgmtSwitchConnector", "Class": "River", "ExtraProperties": {"NodeNics": ["x3000c0s1b2"], "VendorName": "1/1/11"}},
+        "x3000c0w31j12": { "Parent": "x3000c0w31", "Xname": "x3000c0w31j12", "Type": "comptype_mgmt_switch_connector", "TypeString": "MgmtSwitchConnector", "Class": "River", "ExtraProperties": {"NodeNics": ["x3000c0s1b3"], "VendorName": "1/1/12"}},
+        "x3000c0w31j13": { "Parent": "x3000c0w31", "Xname": "x3000c0w31j13", "Type": "comptype_mgmt_switch_connector", "TypeString": "MgmtSwitchConnector", "Class": "River", "ExtraProperties": {"NodeNics": ["x3000c0s1b4"], "VendorName": "1/1/13"}},
+        
+        "x3000c0w31j14": { "Parent": "x3000c0w31", "Xname": "x3000c0w31j14", "Type": "comptype_mgmt_switch_connector", "TypeString": "MgmtSwitchConnector", "Class": "River", "ExtraProperties": {"NodeNics": ["x3000c0s3b1"], "VendorName": "1/1/14"}},
+        "x3000c0w31j15": { "Parent": "x3000c0w31", "Xname": "x3000c0w31j15", "Type": "comptype_mgmt_switch_connector", "TypeString": "MgmtSwitchConnector", "Class": "River", "ExtraProperties": {"NodeNics": ["x3000c0s3b2"], "VendorName": "1/1/15"}},
+        "x3000c0w31j16": { "Parent": "x3000c0w31", "Xname": "x3000c0w31j16", "Type": "comptype_mgmt_switch_connector", "TypeString": "MgmtSwitchConnector", "Class": "River", "ExtraProperties": {"NodeNics": ["x3000c0s3b3"], "VendorName": "1/1/16"}},
+        "x3000c0w31j17": { "Parent": "x3000c0w31", "Xname": "x3000c0w31j17", "Type": "comptype_mgmt_switch_connector", "TypeString": "MgmtSwitchConnector", "Class": "River", "ExtraProperties": {"NodeNics": ["x3000c0s3b4"], "VendorName": "1/1/17"}},
+        
+        "x3000c0w31j18": { "Parent": "x3000c0w31", "Xname": "x3000c0w31j18", "Type": "comptype_mgmt_switch_connector", "TypeString": "MgmtSwitchConnector", "Class": "River", "ExtraProperties": {"NodeNics": ["x3000c0s5b0"], "VendorName": "1/1/18"}},
+        "x3000c0w31j19": { "Parent": "x3000c0w31", "Xname": "x3000c0w31j19", "Type": "comptype_mgmt_switch_connector", "TypeString": "MgmtSwitchConnector", "Class": "River", "ExtraProperties": {"NodeNics": ["x3000c0s6b0"], "VendorName": "1/1/19"}}
+    },
+    "Networks": {}
+}

--- a/testdata/fixtures/sls/small_mountain.json
+++ b/testdata/fixtures/sls/small_mountain.json
@@ -1,0 +1,167 @@
+{
+    "Hardware": {
+        "x1000": {
+            "Parent": "s0",
+            "Xname": "x1000",
+            "Type": "comptype_cabinet",
+            "Class": "Mountain",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Networks": {
+                    "cn": {
+                        "HMN_MTN": {
+                            "CIDR": "10.104.0.0/17",
+                            "Gateway": "10.104.0.1",
+                            "VLan": 3001
+                        },
+                        "NMN_MTN": {
+                            "CIDR": "10.100.0.0/17",
+                            "Gateway": "10.100.0.1",
+                            "VLan": 2001
+                        }
+                    }
+                }
+            }
+        },
+        "x1000c0": {
+            "Parent": "x1000",
+            "Xname": "x1000c0",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c0b0": {
+            "Parent": "x1000c0",
+            "Xname": "x1000c0b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c0s0": {
+            "Parent": "x1000c0",
+            "Xname": "x1000c0s0",
+            "Type": "comptype_compmod",
+            "TypeString": "ComputeModule",
+            "Class": "Mountain",
+            "ExtraProperties": {
+                "@rie.mockup": "EX425"
+            }
+        },
+        "x1000c0s0b0n0": {
+            "Parent": "x1000c0s0b0",
+            "Xname": "x1000c0s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1000,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001000"
+                ]
+            }
+        },
+        "x1000c0s0b0n1": {
+            "Parent": "x1000c0s0b0",
+            "Xname": "x1000c0s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1001,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001001"
+                ]
+            }
+        },
+        "x1000c0s0b1n0": {
+            "Parent": "x1000c0s0b1",
+            "Xname": "x1000c0s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1002,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001002"
+                ]
+            }
+        },
+        "x1000c0s0b1n1": {
+            "Parent": "x1000c0s0b1",
+            "Xname": "x1000c0s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1003,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001003"
+                ]
+            }
+        }
+    },
+    "Networks": {
+      "NMN_MTN": {
+        "Name": "NMN_MTN",
+        "FullName": "Mountain Compute Node Management Network",
+        "IPRanges": [
+          "10.100.0.0/17"
+        ],
+        "Type": "ethernet",
+        "LastUpdated": 1686885977,
+        "LastUpdatedTime": "2023-06-16 03:26:17.008229 +0000 +0000",
+        "ExtraProperties": {
+          "CIDR": "10.100.0.0/17",
+          "MTU": 9000,
+          "Subnets": [
+            {
+              "CIDR": "10.100.0.0/17",
+              "DHCPEnd": "10.100.3.254",
+              "DHCPStart": "10.100.0.10",
+              "FullName": "",
+              "Gateway": "10.100.0.1",
+              "Name": "cabinet_1000",
+              "VlanID": 3000
+            }
+          ],
+          "VlanRange": [
+            3000,
+            3999
+          ]
+        }
+      },
+      "HMN_MTN": {
+        "Name": "HMN_MTN",
+        "FullName": "Mountain Compute Hardware Management Network",
+        "IPRanges": [
+          "10.104.0.0/17"
+        ],
+        "Type": "ethernet",
+        "LastUpdated": 1686885971,
+        "LastUpdatedTime": "2023-06-16 03:26:11.054111 +0000 +0000",
+        "ExtraProperties": {
+          "CIDR": "10.104.0.0/17",
+          "MTU": 9000,
+          "Subnets": [
+            {
+              "CIDR": "10.104.0.0/17",
+              "DHCPEnd": "10.104.3.254",
+              "DHCPStart": "10.104.0.10",
+              "FullName": "",
+              "Gateway": "10.104.0.1",
+              "Name": "cabinet_1000",
+              "VlanID": 3000
+            }
+          ],
+          "VlanRange": [
+            2000,
+            2999
+          ]
+        }
+      }
+    }
+}

--- a/testdata/fixtures/sls/valid_hardware_networks.json
+++ b/testdata/fixtures/sls/valid_hardware_networks.json
@@ -1,0 +1,2819 @@
+{
+  "Hardware": {
+      "x3000": {
+          "Parent": "s0",
+          "Xname": "x3000",
+          "Type": "comptype_cabinet",
+          "Class": "River",
+          "TypeString": "Cabinet",
+          "ExtraProperties": {
+              "Networks": {
+                  "cn": {
+                      "HMN": {
+                          "CIDR": "10.107.0.0/22",
+                          "Gateway": "10.107.0.1",
+                          "VLan": 1513
+                      },
+                      "NMN": {
+                          "CIDR": "10.106.0.0/22",
+                          "Gateway": "10.106.0.1",
+                          "VLan": 1770
+                      }
+                  },
+                  "ncn": {
+                      "HMN": {
+                          "CIDR": "10.107.0.0/22",
+                          "Gateway": "10.107.0.1",
+                          "VLan": 1513
+                      },
+                      "NMN": {
+                          "CIDR": "10.106.0.0/22",
+                          "Gateway": "10.106.0.1",
+                          "VLan": 1770
+                      }
+                  }
+              }
+          }
+      },
+      "x3000c0h12s1": {
+          "Parent": "x3000c0h12",
+          "Xname": "x3000c0h12s1",
+          "Type": "comptype_hl_switch",
+          "Class": "River",
+          "TypeString": "MgmtHLSwitch",
+          "ExtraProperties": {
+              "IP4addr": "10.254.0.2",
+              "Brand": "Aruba",
+              "Aliases": [
+                  "sw-spine-001"
+              ]
+          }
+      },
+      "x3000c0h13s1": {
+          "Parent": "x3000c0h13",
+          "Xname": "x3000c0h13s1",
+          "Type": "comptype_hl_switch",
+          "Class": "River",
+          "TypeString": "MgmtHLSwitch",
+          "ExtraProperties": {
+              "IP4addr": "10.254.0.3",
+              "Brand": "Aruba",
+              "Aliases": [
+                  "sw-spine-002"
+              ]
+          }
+      },
+      "x3000c0r15b0": {
+          "Parent": "x3000c0r15",
+          "Xname": "x3000c0r15b0",
+          "Type": "comptype_rtr_bmc",
+          "Class": "River",
+          "TypeString": "RouterBMC",
+          "ExtraProperties": {
+              "Username": "vault://hms-creds/x3000c0r15b0",
+              "Password": "vault://hms-creds/x3000c0r15b0"
+          }
+      },
+      "x3000c0s16b0n0": {
+          "Parent": "x3000c0s16b0",
+          "Xname": "x3000c0s16b0n0",
+          "Type": "comptype_node",
+          "Class": "River",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "Role": "Application",
+              "SubRole": "Gateway",
+              "Aliases": [
+                  "gateway01"
+              ]
+          }
+      },
+      "x3000c0s19b0n0": {
+          "Parent": "x3000c0s19b0",
+          "Xname": "x3000c0s19b0n0",
+          "Type": "comptype_node",
+          "Class": "River",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "Role": "Application",
+              "SubRole": "UAN",
+              "Aliases": [
+                  "uan01"
+              ]
+          }
+      },
+      "x3000c0s1b0n0": {
+          "Parent": "x3000c0s1b0",
+          "Xname": "x3000c0s1b0n0",
+          "Type": "comptype_node",
+          "Class": "River",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 100009,
+              "Role": "Management",
+              "SubRole": "Master",
+              "Aliases": [
+                  "ncn-m001"
+              ]
+          }
+      },
+      "x3000c0s24b0n0": {
+          "Parent": "x3000c0s24b0",
+          "Xname": "x3000c0s24b0n0",
+          "Type": "comptype_node",
+          "Class": "River",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "Role": "Application",
+              "SubRole": "UAN",
+              "Aliases": [
+                  "uan04"
+              ]
+          }
+      },
+      "x3000c0s2b0n0": {
+          "Parent": "x3000c0s2b0",
+          "Xname": "x3000c0s2b0n0",
+          "Type": "comptype_node",
+          "Class": "River",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 100008,
+              "Role": "Management",
+              "SubRole": "Master",
+              "Aliases": [
+                  "ncn-m002"
+              ]
+          }
+      },
+      "x3000c0s30b0n0": {
+          "Parent": "x3000c0s30b0",
+          "Xname": "x3000c0s30b0n0",
+          "Type": "comptype_node",
+          "Class": "River",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "Role": "Application",
+              "SubRole": "UAN",
+              "Aliases": [
+                  "uan05"
+              ]
+          }
+      },
+      "x3000c0s32b0n0": {
+          "Parent": "x3000c0s32b0",
+          "Xname": "x3000c0s32b0n0",
+          "Type": "comptype_node",
+          "Class": "River",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "Role": "Application",
+              "SubRole": "UAN",
+              "Aliases": [
+                  "uan06"
+              ]
+          }
+      },
+      "x3000c0s3b0n0": {
+          "Parent": "x3000c0s3b0",
+          "Xname": "x3000c0s3b0n0",
+          "Type": "comptype_node",
+          "Class": "River",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 100007,
+              "Role": "Management",
+              "SubRole": "Master",
+              "Aliases": [
+                  "ncn-m003"
+              ]
+          }
+      },
+      "x3000c0s4b0n0": {
+          "Parent": "x3000c0s4b0",
+          "Xname": "x3000c0s4b0n0",
+          "Type": "comptype_node",
+          "Class": "River",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 100006,
+              "Role": "Management",
+              "SubRole": "Worker",
+              "Aliases": [
+                  "ncn-w001"
+              ]
+          }
+      },
+      "x3000c0s5b0n0": {
+          "Parent": "x3000c0s5b0",
+          "Xname": "x3000c0s5b0n0",
+          "Type": "comptype_node",
+          "Class": "River",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 100005,
+              "Role": "Management",
+              "SubRole": "Worker",
+              "Aliases": [
+                  "ncn-w002"
+              ]
+          }
+      },
+      "x3000c0s6b0n0": {
+          "Parent": "x3000c0s6b0",
+          "Xname": "x3000c0s6b0n0",
+          "Type": "comptype_node",
+          "Class": "River",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 100004,
+              "Role": "Management",
+              "SubRole": "Worker",
+              "Aliases": [
+                  "ncn-w003"
+              ]
+          }
+      },
+      "x3000c0s7b0n0": {
+          "Parent": "x3000c0s7b0",
+          "Xname": "x3000c0s7b0n0",
+          "Type": "comptype_node",
+          "Class": "River",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 100003,
+              "Role": "Management",
+              "SubRole": "Storage",
+              "Aliases": [
+                  "ncn-s001"
+              ]
+          }
+      },
+      "x3000c0s8b0n0": {
+          "Parent": "x3000c0s8b0",
+          "Xname": "x3000c0s8b0n0",
+          "Type": "comptype_node",
+          "Class": "River",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 100002,
+              "Role": "Management",
+              "SubRole": "Storage",
+              "Aliases": [
+                  "ncn-s002"
+              ]
+          }
+      },
+      "x3000c0s9b0n0": {
+          "Parent": "x3000c0s9b0",
+          "Xname": "x3000c0s9b0n0",
+          "Type": "comptype_node",
+          "Class": "River",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 100001,
+              "Role": "Management",
+              "SubRole": "Storage",
+              "Aliases": [
+                  "ncn-s003"
+              ]
+          }
+      },
+      "x3000c0w14": {
+          "Parent": "x3000c0",
+          "Xname": "x3000c0w14",
+          "Type": "comptype_mgmt_switch",
+          "Class": "River",
+          "TypeString": "MgmtSwitch",
+          "ExtraProperties": {
+              "IP4addr": "10.254.0.4",
+              "Brand": "Aruba",
+              "SNMPAuthPassword": "vault://hms-creds/x3000c0w14",
+              "SNMPAuthProtocol": "MD5",
+              "SNMPPrivPassword": "vault://hms-creds/x3000c0w14",
+              "SNMPPrivProtocol": "DES",
+              "SNMPUsername": "testuser",
+              "Aliases": [
+                  "sw-leaf-bmc-001"
+              ]
+          }
+      },
+      "x3000c0w14j11": {
+          "Parent": "x3000c0w14",
+          "Xname": "x3000c0w14j11",
+          "Type": "comptype_mgmt_switch_connector",
+          "Class": "River",
+          "TypeString": "MgmtSwitchConnector",
+          "ExtraProperties": {
+              "NodeNics": [
+                  "x3000c0s30b0"
+              ],
+              "VendorName": "1/1/11"
+          }
+      },
+      "x3000c0w14j12": {
+          "Parent": "x3000c0w14",
+          "Xname": "x3000c0w14j12",
+          "Type": "comptype_mgmt_switch_connector",
+          "Class": "River",
+          "TypeString": "MgmtSwitchConnector",
+          "ExtraProperties": {
+              "NodeNics": [
+                  "x3000c0s32b0"
+              ],
+              "VendorName": "1/1/12"
+          }
+      },
+      "x3000c0w14j25": {
+          "Parent": "x3000c0w14",
+          "Xname": "x3000c0w14j25",
+          "Type": "comptype_mgmt_switch_connector",
+          "Class": "River",
+          "TypeString": "MgmtSwitchConnector",
+          "ExtraProperties": {
+              "NodeNics": [
+                  "x3000c0s4b0"
+              ],
+              "VendorName": "1/1/25"
+          }
+      },
+      "x3000c0w14j26": {
+          "Parent": "x3000c0w14",
+          "Xname": "x3000c0w14j26",
+          "Type": "comptype_mgmt_switch_connector",
+          "Class": "River",
+          "TypeString": "MgmtSwitchConnector",
+          "ExtraProperties": {
+              "NodeNics": [
+                  "x3000c0s2b0"
+              ],
+              "VendorName": "1/1/26"
+          }
+      },
+      "x3000c0w14j27": {
+          "Parent": "x3000c0w14",
+          "Xname": "x3000c0w14j27",
+          "Type": "comptype_mgmt_switch_connector",
+          "Class": "River",
+          "TypeString": "MgmtSwitchConnector",
+          "ExtraProperties": {
+              "NodeNics": [
+                  "x3000c0s3b0"
+              ],
+              "VendorName": "1/1/27"
+          }
+      },
+      "x3000c0w14j28": {
+          "Parent": "x3000c0w14",
+          "Xname": "x3000c0w14j28",
+          "Type": "comptype_mgmt_switch_connector",
+          "Class": "River",
+          "TypeString": "MgmtSwitchConnector",
+          "ExtraProperties": {
+              "NodeNics": [
+                  "x3000c0s5b0"
+              ],
+              "VendorName": "1/1/28"
+          }
+      },
+      "x3000c0w14j29": {
+          "Parent": "x3000c0w14",
+          "Xname": "x3000c0w14j29",
+          "Type": "comptype_mgmt_switch_connector",
+          "Class": "River",
+          "TypeString": "MgmtSwitchConnector",
+          "ExtraProperties": {
+              "NodeNics": [
+                  "x3000c0s6b0"
+              ],
+              "VendorName": "1/1/29"
+          }
+      },
+      "x3000c0w14j30": {
+          "Parent": "x3000c0w14",
+          "Xname": "x3000c0w14j30",
+          "Type": "comptype_mgmt_switch_connector",
+          "Class": "River",
+          "TypeString": "MgmtSwitchConnector",
+          "ExtraProperties": {
+              "NodeNics": [
+                  "x3000c0s7b0"
+              ],
+              "VendorName": "1/1/30"
+          }
+      },
+      "x3000c0w14j31": {
+          "Parent": "x3000c0w14",
+          "Xname": "x3000c0w14j31",
+          "Type": "comptype_mgmt_switch_connector",
+          "Class": "River",
+          "TypeString": "MgmtSwitchConnector",
+          "ExtraProperties": {
+              "NodeNics": [
+                  "x3000c0s8b0"
+              ],
+              "VendorName": "1/1/31"
+          }
+      },
+      "x3000c0w14j32": {
+          "Parent": "x3000c0w14",
+          "Xname": "x3000c0w14j32",
+          "Type": "comptype_mgmt_switch_connector",
+          "Class": "River",
+          "TypeString": "MgmtSwitchConnector",
+          "ExtraProperties": {
+              "NodeNics": [
+                  "x3000c0s9b0"
+              ],
+              "VendorName": "1/1/32"
+          }
+      },
+      "x3000c0w14j37": {
+          "Parent": "x3000c0w14",
+          "Xname": "x3000c0w14j37",
+          "Type": "comptype_mgmt_switch_connector",
+          "Class": "River",
+          "TypeString": "MgmtSwitchConnector",
+          "ExtraProperties": {
+              "NodeNics": [
+                  "x3000m1"
+              ],
+              "VendorName": "1/1/37"
+          }
+      },
+      "x3000c0w14j38": {
+          "Parent": "x3000c0w14",
+          "Xname": "x3000c0w14j38",
+          "Type": "comptype_mgmt_switch_connector",
+          "Class": "River",
+          "TypeString": "MgmtSwitchConnector",
+          "ExtraProperties": {
+              "NodeNics": [
+                  "x3000m0"
+              ],
+              "VendorName": "1/1/38"
+          }
+      },
+      "x3000c0w14j39": {
+          "Parent": "x3000c0w14",
+          "Xname": "x3000c0w14j39",
+          "Type": "comptype_mgmt_switch_connector",
+          "Class": "River",
+          "TypeString": "MgmtSwitchConnector",
+          "ExtraProperties": {
+              "NodeNics": [
+                  "x3000c0s19b0"
+              ],
+              "VendorName": "1/1/39"
+          }
+      },
+      "x3000c0w14j40": {
+          "Parent": "x3000c0w14",
+          "Xname": "x3000c0w14j40",
+          "Type": "comptype_mgmt_switch_connector",
+          "Class": "River",
+          "TypeString": "MgmtSwitchConnector",
+          "ExtraProperties": {
+              "NodeNics": [
+                  "x3000c0s16b0"
+              ],
+              "VendorName": "1/1/40"
+          }
+      },
+      "x3000c0w14j44": {
+          "Parent": "x3000c0w14",
+          "Xname": "x3000c0w14j44",
+          "Type": "comptype_mgmt_switch_connector",
+          "Class": "River",
+          "TypeString": "MgmtSwitchConnector",
+          "ExtraProperties": {
+              "NodeNics": [
+                  "x3000c0s24b0"
+              ],
+              "VendorName": "1/1/44"
+          }
+      },
+      "x3000c0w14j47": {
+          "Parent": "x3000c0w14",
+          "Xname": "x3000c0w14j47",
+          "Type": "comptype_mgmt_switch_connector",
+          "Class": "River",
+          "TypeString": "MgmtSwitchConnector",
+          "ExtraProperties": {
+              "NodeNics": [
+                  "x3000c0r15b0"
+              ],
+              "VendorName": "1/1/47"
+          }
+      },
+      "x3000m0": {
+          "Parent": "x3000",
+          "Xname": "x3000m0",
+          "Type": "comptype_cab_pdu_controller",
+          "Class": "River",
+          "TypeString": "CabinetPDUController"
+      },
+      "x3000m1": {
+          "Parent": "x3000",
+          "Xname": "x3000m1",
+          "Type": "comptype_cab_pdu_controller",
+          "Class": "River",
+          "TypeString": "CabinetPDUController"
+      },
+      "x3001": {
+          "Parent": "s0",
+          "Xname": "x3001",
+          "Type": "comptype_cabinet",
+          "Class": "River",
+          "TypeString": "Cabinet",
+          "ExtraProperties": {
+              "Networks": {
+                  "cn": {
+                      "HMN": {
+                          "CIDR": "10.107.4.0/22",
+                          "Gateway": "10.107.4.1",
+                          "VLan": 1514
+                      },
+                      "NMN": {
+                          "CIDR": "10.106.4.0/22",
+                          "Gateway": "10.106.4.1",
+                          "VLan": 1771
+                      }
+                  },
+                  "ncn": {
+                      "HMN": {
+                          "CIDR": "10.107.4.0/22",
+                          "Gateway": "10.107.4.1",
+                          "VLan": 1514
+                      },
+                      "NMN": {
+                          "CIDR": "10.106.4.0/22",
+                          "Gateway": "10.106.4.1",
+                          "VLan": 1771
+                      }
+                  }
+              }
+          }
+      },
+      "x3001c0s7b0n0": {
+          "Parent": "x3001c0s7b0",
+          "Xname": "x3001c0s7b0n0",
+          "Type": "comptype_node",
+          "Class": "River",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid000001"
+              ]
+          }
+      },
+      "x3001c0w40": {
+          "Parent": "x3001c0",
+          "Xname": "x3001c0w40",
+          "Type": "comptype_mgmt_switch",
+          "Class": "River",
+          "TypeString": "MgmtSwitch",
+          "ExtraProperties": {
+              "IP4addr": "10.254.0.5",
+              "Brand": "Aruba",
+              "SNMPAuthPassword": "vault://hms-creds/x3001c0w40",
+              "SNMPAuthProtocol": "MD5",
+              "SNMPPrivPassword": "vault://hms-creds/x3001c0w40",
+              "SNMPPrivProtocol": "DES",
+              "SNMPUsername": "testuser",
+              "Aliases": [
+                  "sw-leaf-bmc-002"
+              ]
+          }
+      },
+      "x3001c0w40j1": {
+          "Parent": "x3001c0w40",
+          "Xname": "x3001c0w40j1",
+          "Type": "comptype_mgmt_switch_connector",
+          "Class": "River",
+          "TypeString": "MgmtSwitchConnector",
+          "ExtraProperties": {
+              "NodeNics": [
+                  "x3001c0s7b0"
+              ],
+              "VendorName": "1/1/1"
+          }
+      },
+      "x9000": {
+          "Parent": "s0",
+          "Xname": "x9000",
+          "Type": "comptype_cabinet",
+          "Class": "Hill",
+          "TypeString": "Cabinet",
+          "ExtraProperties": {
+              "Networks": {
+                  "cn": {
+                      "HMN": {
+                          "CIDR": "10.104.0.0/22",
+                          "Gateway": "10.104.0.1",
+                          "VLan": 3000
+                      },
+                      "NMN": {
+                          "CIDR": "10.100.0.0/22",
+                          "Gateway": "10.100.0.1",
+                          "VLan": 2000
+                      }
+                  }
+              }
+          }
+      },
+      "x9000c1": {
+          "Parent": "x9000",
+          "Xname": "x9000c1",
+          "Type": "comptype_chassis",
+          "Class": "Hill",
+          "TypeString": "Chassis"
+      },
+      "x9000c1b0": {
+          "Parent": "x9000c1",
+          "Xname": "x9000c1b0",
+          "Type": "comptype_chassis_bmc",
+          "Class": "Hill",
+          "TypeString": "ChassisBMC"
+      },
+      "x9000c1s0b0n0": {
+          "Parent": "x9000c1s0b0",
+          "Xname": "x9000c1s0b0n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1000,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001000"
+              ]
+          }
+      },
+      "x9000c1s0b0n1": {
+          "Parent": "x9000c1s0b0",
+          "Xname": "x9000c1s0b0n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1001,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001001"
+              ]
+          }
+      },
+      "x9000c1s0b1n0": {
+          "Parent": "x9000c1s0b1",
+          "Xname": "x9000c1s0b1n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1002,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001002"
+              ]
+          }
+      },
+      "x9000c1s0b1n1": {
+          "Parent": "x9000c1s0b1",
+          "Xname": "x9000c1s0b1n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1003,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001003"
+              ]
+          }
+      },
+      "x9000c1s1b0n0": {
+          "Parent": "x9000c1s1b0",
+          "Xname": "x9000c1s1b0n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1004,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001004"
+              ]
+          }
+      },
+      "x9000c1s1b0n1": {
+          "Parent": "x9000c1s1b0",
+          "Xname": "x9000c1s1b0n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1005,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001005"
+              ]
+          }
+      },
+      "x9000c1s1b1n0": {
+          "Parent": "x9000c1s1b1",
+          "Xname": "x9000c1s1b1n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1006,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001006"
+              ]
+          }
+      },
+      "x9000c1s1b1n1": {
+          "Parent": "x9000c1s1b1",
+          "Xname": "x9000c1s1b1n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1007,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001007"
+              ]
+          }
+      },
+      "x9000c1s2b0n0": {
+          "Parent": "x9000c1s2b0",
+          "Xname": "x9000c1s2b0n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1008,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001008"
+              ]
+          }
+      },
+      "x9000c1s2b0n1": {
+          "Parent": "x9000c1s2b0",
+          "Xname": "x9000c1s2b0n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1009,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001009"
+              ]
+          }
+      },
+      "x9000c1s2b1n0": {
+          "Parent": "x9000c1s2b1",
+          "Xname": "x9000c1s2b1n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1010,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001010"
+              ]
+          }
+      },
+      "x9000c1s2b1n1": {
+          "Parent": "x9000c1s2b1",
+          "Xname": "x9000c1s2b1n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1011,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001011"
+              ]
+          }
+      },
+      "x9000c1s3b0n0": {
+          "Parent": "x9000c1s3b0",
+          "Xname": "x9000c1s3b0n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1012,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001012"
+              ]
+          }
+      },
+      "x9000c1s3b0n1": {
+          "Parent": "x9000c1s3b0",
+          "Xname": "x9000c1s3b0n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1013,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001013"
+              ]
+          }
+      },
+      "x9000c1s3b1n0": {
+          "Parent": "x9000c1s3b1",
+          "Xname": "x9000c1s3b1n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1014,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001014"
+              ]
+          }
+      },
+      "x9000c1s3b1n1": {
+          "Parent": "x9000c1s3b1",
+          "Xname": "x9000c1s3b1n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1015,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001015"
+              ]
+          }
+      },
+      "x9000c1s4b0n0": {
+          "Parent": "x9000c1s4b0",
+          "Xname": "x9000c1s4b0n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1016,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001016"
+              ]
+          }
+      },
+      "x9000c1s4b0n1": {
+          "Parent": "x9000c1s4b0",
+          "Xname": "x9000c1s4b0n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1017,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001017"
+              ]
+          }
+      },
+      "x9000c1s4b1n0": {
+          "Parent": "x9000c1s4b1",
+          "Xname": "x9000c1s4b1n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1018,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001018"
+              ]
+          }
+      },
+      "x9000c1s4b1n1": {
+          "Parent": "x9000c1s4b1",
+          "Xname": "x9000c1s4b1n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1019,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001019"
+              ]
+          }
+      },
+      "x9000c1s5b0n0": {
+          "Parent": "x9000c1s5b0",
+          "Xname": "x9000c1s5b0n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1020,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001020"
+              ]
+          }
+      },
+      "x9000c1s5b0n1": {
+          "Parent": "x9000c1s5b0",
+          "Xname": "x9000c1s5b0n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1021,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001021"
+              ]
+          }
+      },
+      "x9000c1s5b1n0": {
+          "Parent": "x9000c1s5b1",
+          "Xname": "x9000c1s5b1n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1022,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001022"
+              ]
+          }
+      },
+      "x9000c1s5b1n1": {
+          "Parent": "x9000c1s5b1",
+          "Xname": "x9000c1s5b1n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1023,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001023"
+              ]
+          }
+      },
+      "x9000c1s6b0n0": {
+          "Parent": "x9000c1s6b0",
+          "Xname": "x9000c1s6b0n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1024,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001024"
+              ]
+          }
+      },
+      "x9000c1s6b0n1": {
+          "Parent": "x9000c1s6b0",
+          "Xname": "x9000c1s6b0n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1025,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001025"
+              ]
+          }
+      },
+      "x9000c1s6b1n0": {
+          "Parent": "x9000c1s6b1",
+          "Xname": "x9000c1s6b1n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1026,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001026"
+              ]
+          }
+      },
+      "x9000c1s6b1n1": {
+          "Parent": "x9000c1s6b1",
+          "Xname": "x9000c1s6b1n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1027,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001027"
+              ]
+          }
+      },
+      "x9000c1s7b0n0": {
+          "Parent": "x9000c1s7b0",
+          "Xname": "x9000c1s7b0n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1028,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001028"
+              ]
+          }
+      },
+      "x9000c1s7b0n1": {
+          "Parent": "x9000c1s7b0",
+          "Xname": "x9000c1s7b0n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1029,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001029"
+              ]
+          }
+      },
+      "x9000c1s7b1n0": {
+          "Parent": "x9000c1s7b1",
+          "Xname": "x9000c1s7b1n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1030,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001030"
+              ]
+          }
+      },
+      "x9000c1s7b1n1": {
+          "Parent": "x9000c1s7b1",
+          "Xname": "x9000c1s7b1n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1031,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001031"
+              ]
+          }
+      },
+      "x9000c3": {
+          "Parent": "x9000",
+          "Xname": "x9000c3",
+          "Type": "comptype_chassis",
+          "Class": "Hill",
+          "TypeString": "Chassis"
+      },
+      "x9000c3b0": {
+          "Parent": "x9000c3",
+          "Xname": "x9000c3b0",
+          "Type": "comptype_chassis_bmc",
+          "Class": "Hill",
+          "TypeString": "ChassisBMC"
+      },
+      "x9000c3s0b0n0": {
+          "Parent": "x9000c3s0b0",
+          "Xname": "x9000c3s0b0n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1032,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001032"
+              ]
+          }
+      },
+      "x9000c3s0b0n1": {
+          "Parent": "x9000c3s0b0",
+          "Xname": "x9000c3s0b0n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1033,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001033"
+              ]
+          }
+      },
+      "x9000c3s0b1n0": {
+          "Parent": "x9000c3s0b1",
+          "Xname": "x9000c3s0b1n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1034,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001034"
+              ]
+          }
+      },
+      "x9000c3s0b1n1": {
+          "Parent": "x9000c3s0b1",
+          "Xname": "x9000c3s0b1n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1035,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001035"
+              ]
+          }
+      },
+      "x9000c3s1b0n0": {
+          "Parent": "x9000c3s1b0",
+          "Xname": "x9000c3s1b0n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1036,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001036"
+              ]
+          }
+      },
+      "x9000c3s1b0n1": {
+          "Parent": "x9000c3s1b0",
+          "Xname": "x9000c3s1b0n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1037,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001037"
+              ]
+          }
+      },
+      "x9000c3s1b1n0": {
+          "Parent": "x9000c3s1b1",
+          "Xname": "x9000c3s1b1n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1038,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001038"
+              ]
+          }
+      },
+      "x9000c3s1b1n1": {
+          "Parent": "x9000c3s1b1",
+          "Xname": "x9000c3s1b1n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1039,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001039"
+              ]
+          }
+      },
+      "x9000c3s2b0n0": {
+          "Parent": "x9000c3s2b0",
+          "Xname": "x9000c3s2b0n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1040,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001040"
+              ]
+          }
+      },
+      "x9000c3s2b0n1": {
+          "Parent": "x9000c3s2b0",
+          "Xname": "x9000c3s2b0n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1041,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001041"
+              ]
+          }
+      },
+      "x9000c3s2b1n0": {
+          "Parent": "x9000c3s2b1",
+          "Xname": "x9000c3s2b1n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1042,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001042"
+              ]
+          }
+      },
+      "x9000c3s2b1n1": {
+          "Parent": "x9000c3s2b1",
+          "Xname": "x9000c3s2b1n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1043,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001043"
+              ]
+          }
+      },
+      "x9000c3s3b0n0": {
+          "Parent": "x9000c3s3b0",
+          "Xname": "x9000c3s3b0n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1044,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001044"
+              ]
+          }
+      },
+      "x9000c3s3b0n1": {
+          "Parent": "x9000c3s3b0",
+          "Xname": "x9000c3s3b0n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1045,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001045"
+              ]
+          }
+      },
+      "x9000c3s3b1n0": {
+          "Parent": "x9000c3s3b1",
+          "Xname": "x9000c3s3b1n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1046,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001046"
+              ]
+          }
+      },
+      "x9000c3s3b1n1": {
+          "Parent": "x9000c3s3b1",
+          "Xname": "x9000c3s3b1n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1047,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001047"
+              ]
+          }
+      },
+      "x9000c3s4b0n0": {
+          "Parent": "x9000c3s4b0",
+          "Xname": "x9000c3s4b0n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1048,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001048"
+              ]
+          }
+      },
+      "x9000c3s4b0n1": {
+          "Parent": "x9000c3s4b0",
+          "Xname": "x9000c3s4b0n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1049,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001049"
+              ]
+          }
+      },
+      "x9000c3s4b1n0": {
+          "Parent": "x9000c3s4b1",
+          "Xname": "x9000c3s4b1n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1050,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001050"
+              ]
+          }
+      },
+      "x9000c3s4b1n1": {
+          "Parent": "x9000c3s4b1",
+          "Xname": "x9000c3s4b1n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1051,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001051"
+              ]
+          }
+      },
+      "x9000c3s5b0n0": {
+          "Parent": "x9000c3s5b0",
+          "Xname": "x9000c3s5b0n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1052,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001052"
+              ]
+          }
+      },
+      "x9000c3s5b0n1": {
+          "Parent": "x9000c3s5b0",
+          "Xname": "x9000c3s5b0n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1053,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001053"
+              ]
+          }
+      },
+      "x9000c3s5b1n0": {
+          "Parent": "x9000c3s5b1",
+          "Xname": "x9000c3s5b1n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1054,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001054"
+              ]
+          }
+      },
+      "x9000c3s5b1n1": {
+          "Parent": "x9000c3s5b1",
+          "Xname": "x9000c3s5b1n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1055,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001055"
+              ]
+          }
+      },
+      "x9000c3s6b0n0": {
+          "Parent": "x9000c3s6b0",
+          "Xname": "x9000c3s6b0n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1056,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001056"
+              ]
+          }
+      },
+      "x9000c3s6b0n1": {
+          "Parent": "x9000c3s6b0",
+          "Xname": "x9000c3s6b0n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1057,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001057"
+              ]
+          }
+      },
+      "x9000c3s6b1n0": {
+          "Parent": "x9000c3s6b1",
+          "Xname": "x9000c3s6b1n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1058,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001058"
+              ]
+          }
+      },
+      "x9000c3s6b1n1": {
+          "Parent": "x9000c3s6b1",
+          "Xname": "x9000c3s6b1n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1059,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001059"
+              ]
+          }
+      },
+      "x9000c3s7b0n0": {
+          "Parent": "x9000c3s7b0",
+          "Xname": "x9000c3s7b0n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1060,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001060"
+              ]
+          }
+      },
+      "x9000c3s7b0n1": {
+          "Parent": "x9000c3s7b0",
+          "Xname": "x9000c3s7b0n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1061,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001061"
+              ]
+          }
+      },
+      "x9000c3s7b1n0": {
+          "Parent": "x9000c3s7b1",
+          "Xname": "x9000c3s7b1n0",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1062,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001062"
+              ]
+          }
+      },
+      "x9000c3s7b1n1": {
+          "Parent": "x9000c3s7b1",
+          "Xname": "x9000c3s7b1n1",
+          "Type": "comptype_node",
+          "Class": "Hill",
+          "TypeString": "Node",
+          "ExtraProperties": {
+              "NID": 1063,
+              "Role": "Compute",
+              "Aliases": [
+                  "nid001063"
+              ]
+          }
+      }
+  },
+  "Networks": {
+      "BICAN": {
+          "Name": "BICAN",
+          "FullName": "SystemDefaultRoute points the network name of the default route",
+          "IPRanges": [
+              "0.0.0.0/0"
+          ],
+          "Type": "ethernet",
+          "ExtraProperties": {
+              "CIDR": "0.0.0.0/0",
+              "VlanRange": [
+                  0
+              ],
+              "MTU": 9000,
+              "Subnets": [],
+              "SystemDefaultRoute": "CAN"
+          }
+      },
+      "CAN": {
+          "Name": "CAN",
+          "FullName": "Customer Access Network",
+          "IPRanges": [
+              "10.102.65.128/25"
+          ],
+          "Type": "ethernet",
+          "ExtraProperties": {
+              "CIDR": "10.102.65.128/25",
+              "VlanRange": [
+                  6
+              ],
+              "MTU": 9000,
+              "Subnets": [
+                  {
+                      "FullName": "CAN Dynamic MetalLB",
+                      "CIDR": "10.102.65.192/26",
+                      "Name": "can_metallb_address_pool",
+                      "VlanID": 6,
+                      "Gateway": "10.102.65.193",
+                      "MetalLBPoolName": "customer-access"
+                  },
+                  {
+                      "FullName": "CAN Bootstrap DHCP Subnet",
+                      "CIDR": "10.102.65.128/25",
+                      "IPReservations": [
+                          {
+                              "Name": "can-switch-1",
+                              "IPAddress": "10.102.65.130"
+                          },
+                          {
+                              "Name": "can-switch-2",
+                              "IPAddress": "10.102.65.131"
+                          },
+                          {
+                              "Name": "kubeapi-vip",
+                              "IPAddress": "10.102.65.132",
+                              "Comment": "k8s-virtual-ip"
+                          },
+                          {
+                              "Name": "ncn-s003",
+                              "IPAddress": "10.102.65.133",
+                              "Aliases": [
+                                  "ncn-s003-can",
+                                  "time-can",
+                                  "time-can.local"
+                              ],
+                              "Comment": "x3000c0s9b0n0"
+                          },
+                          {
+                              "Name": "ncn-s002",
+                              "IPAddress": "10.102.65.134",
+                              "Aliases": [
+                                  "ncn-s002-can",
+                                  "time-can",
+                                  "time-can.local"
+                              ],
+                              "Comment": "x3000c0s8b0n0"
+                          },
+                          {
+                              "Name": "ncn-s001",
+                              "IPAddress": "10.102.65.135",
+                              "Aliases": [
+                                  "ncn-s001-can",
+                                  "time-can",
+                                  "time-can.local"
+                              ],
+                              "Comment": "x3000c0s7b0n0"
+                          },
+                          {
+                              "Name": "ncn-w003",
+                              "IPAddress": "10.102.65.136",
+                              "Aliases": [
+                                  "ncn-w003-can",
+                                  "time-can",
+                                  "time-can.local"
+                              ],
+                              "Comment": "x3000c0s6b0n0"
+                          },
+                          {
+                              "Name": "ncn-w002",
+                              "IPAddress": "10.102.65.137",
+                              "Aliases": [
+                                  "ncn-w002-can",
+                                  "time-can",
+                                  "time-can.local"
+                              ],
+                              "Comment": "x3000c0s5b0n0"
+                          },
+                          {
+                              "Name": "ncn-w001",
+                              "IPAddress": "10.102.65.138",
+                              "Aliases": [
+                                  "ncn-w001-can",
+                                  "time-can",
+                                  "time-can.local"
+                              ],
+                              "Comment": "x3000c0s4b0n0"
+                          },
+                          {
+                              "Name": "ncn-m003",
+                              "IPAddress": "10.102.65.139",
+                              "Aliases": [
+                                  "ncn-m003-can",
+                                  "time-can",
+                                  "time-can.local"
+                              ],
+                              "Comment": "x3000c0s3b0n0"
+                          },
+                          {
+                              "Name": "ncn-m002",
+                              "IPAddress": "10.102.65.140",
+                              "Aliases": [
+                                  "ncn-m002-can",
+                                  "time-can",
+                                  "time-can.local"
+                              ],
+                              "Comment": "x3000c0s2b0n0"
+                          },
+                          {
+                              "Name": "ncn-m001",
+                              "IPAddress": "10.102.65.141",
+                              "Aliases": [
+                                  "ncn-m001-can",
+                                  "time-can",
+                                  "time-can.local"
+                              ],
+                              "Comment": "x3000c0s1b0n0"
+                          },
+                          {
+                              "Name": "uan05",
+                              "IPAddress": "10.102.65.142",
+                              "Comment": "x3000c0s30b0n0"
+                          },
+                          {
+                              "Name": "uan01",
+                              "IPAddress": "10.102.65.143",
+                              "Comment": "x3000c0s19b0n0"
+                          },
+                          {
+                              "Name": "uan06",
+                              "IPAddress": "10.102.65.144",
+                              "Comment": "x3000c0s32b0n0"
+                          },
+                          {
+                              "Name": "uan04",
+                              "IPAddress": "10.102.65.145",
+                              "Comment": "x3000c0s24b0n0"
+                          }
+                      ],
+                      "Name": "bootstrap_dhcp",
+                      "VlanID": 6,
+                      "Gateway": "10.102.65.129",
+                      "DHCPStart": "10.102.65.146",
+                      "DHCPEnd": "10.102.65.191"
+                  }
+              ]
+          }
+      },
+      "CMN": {
+          "Name": "CMN",
+          "FullName": "Customer Management Network",
+          "IPRanges": [
+              "10.102.65.0/25"
+          ],
+          "Type": "ethernet",
+          "ExtraProperties": {
+              "CIDR": "10.102.65.0/25",
+              "VlanRange": [
+                  7
+              ],
+              "MTU": 9000,
+              "PeerASN": 65533,
+              "MyASN": 65532,
+              "Subnets": [
+                  {
+                      "FullName": "CMN Static Pool MetalLB",
+                      "CIDR": "10.102.65.60/30",
+                      "IPReservations": [
+                          {
+                              "Name": "external-dns",
+                              "IPAddress": "10.102.65.61",
+                              "Comment": "site to system lookups"
+                          }
+                      ],
+                      "Name": "cmn_metallb_static_pool",
+                      "VlanID": 7,
+                      "Gateway": "10.102.65.61",
+                      "MetalLBPoolName": "customer-management-static"
+                  },
+                  {
+                      "FullName": "CMN Dynamic MetalLB",
+                      "CIDR": "10.102.65.64/26",
+                      "Name": "cmn_metallb_address_pool",
+                      "VlanID": 7,
+                      "Gateway": "10.102.65.65",
+                      "MetalLBPoolName": "customer-management"
+                  },
+                  {
+                      "FullName": "CMN Management Network Infrastructure",
+                      "CIDR": "10.102.65.0/25",
+                      "IPReservations": [
+                          {
+                              "Name": "sw-spine-001",
+                              "IPAddress": "10.102.65.2",
+                              "Comment": "x3000c0h12s1"
+                          },
+                          {
+                              "Name": "sw-spine-002",
+                              "IPAddress": "10.102.65.3",
+                              "Comment": "x3000c0h13s1"
+                          },
+                          {
+                              "Name": "sw-leaf-bmc-001",
+                              "IPAddress": "10.102.65.4",
+                              "Comment": "x3000c0w14"
+                          },
+                          {
+                              "Name": "sw-leaf-bmc-002",
+                              "IPAddress": "10.102.65.5",
+                              "Comment": "x3001c0w40"
+                          }
+                      ],
+                      "Name": "network_hardware",
+                      "VlanID": 7,
+                      "Gateway": "10.102.65.1"
+                  },
+                  {
+                      "FullName": "CMN Bootstrap DHCP Subnet",
+                      "CIDR": "10.102.65.16/25",
+                      "IPReservations": [
+                          {
+                              "Name": "kubeapi-vip",
+                              "IPAddress": "10.102.65.18",
+                              "Comment": "k8s-virtual-ip"
+                          },
+                          {
+                              "Name": "ncn-s003",
+                              "IPAddress": "10.102.65.19",
+                              "Aliases": [
+                                  "ncn-s003-cmn",
+                                  "time-cmn",
+                                  "time-cmn.local"
+                              ],
+                              "Comment": "x3000c0s9b0n0"
+                          },
+                          {
+                              "Name": "ncn-s002",
+                              "IPAddress": "10.102.65.20",
+                              "Aliases": [
+                                  "ncn-s002-cmn",
+                                  "time-cmn",
+                                  "time-cmn.local"
+                              ],
+                              "Comment": "x3000c0s8b0n0"
+                          },
+                          {
+                              "Name": "ncn-s001",
+                              "IPAddress": "10.102.65.21",
+                              "Aliases": [
+                                  "ncn-s001-cmn",
+                                  "time-cmn",
+                                  "time-cmn.local"
+                              ],
+                              "Comment": "x3000c0s7b0n0"
+                          },
+                          {
+                              "Name": "ncn-w003",
+                              "IPAddress": "10.102.65.22",
+                              "Aliases": [
+                                  "ncn-w003-cmn",
+                                  "time-cmn",
+                                  "time-cmn.local"
+                              ],
+                              "Comment": "x3000c0s6b0n0"
+                          },
+                          {
+                              "Name": "ncn-w002",
+                              "IPAddress": "10.102.65.23",
+                              "Aliases": [
+                                  "ncn-w002-cmn",
+                                  "time-cmn",
+                                  "time-cmn.local"
+                              ],
+                              "Comment": "x3000c0s5b0n0"
+                          },
+                          {
+                              "Name": "ncn-w001",
+                              "IPAddress": "10.102.65.24",
+                              "Aliases": [
+                                  "ncn-w001-cmn",
+                                  "time-cmn",
+                                  "time-cmn.local"
+                              ],
+                              "Comment": "x3000c0s4b0n0"
+                          },
+                          {
+                              "Name": "ncn-m003",
+                              "IPAddress": "10.102.65.25",
+                              "Aliases": [
+                                  "ncn-m003-cmn",
+                                  "time-cmn",
+                                  "time-cmn.local"
+                              ],
+                              "Comment": "x3000c0s3b0n0"
+                          },
+                          {
+                              "Name": "ncn-m002",
+                              "IPAddress": "10.102.65.26",
+                              "Aliases": [
+                                  "ncn-m002-cmn",
+                                  "time-cmn",
+                                  "time-cmn.local"
+                              ],
+                              "Comment": "x3000c0s2b0n0"
+                          },
+                          {
+                              "Name": "ncn-m001",
+                              "IPAddress": "10.102.65.27",
+                              "Aliases": [
+                                  "ncn-m001-cmn",
+                                  "time-cmn",
+                                  "time-cmn.local"
+                              ],
+                              "Comment": "x3000c0s1b0n0"
+                          }
+                      ],
+                      "Name": "bootstrap_dhcp",
+                      "VlanID": 7,
+                      "Gateway": "10.102.65.1",
+                      "DHCPStart": "10.102.65.28",
+                      "DHCPEnd": "10.102.65.59"
+                  }
+              ]
+          }
+      },
+      "HMN": {
+          "Name": "HMN",
+          "FullName": "Hardware Management Network",
+          "IPRanges": [
+              "10.254.0.0/17"
+          ],
+          "Type": "ethernet",
+          "ExtraProperties": {
+              "CIDR": "10.254.0.0/17",
+              "VlanRange": [
+                  4
+              ],
+              "MTU": 9000,
+              "Subnets": [
+                  {
+                      "FullName": "HMN Management Network Infrastructure",
+                      "CIDR": "10.254.0.0/17",
+                      "IPReservations": [
+                          {
+                              "Name": "sw-spine-001",
+                              "IPAddress": "10.254.0.2",
+                              "Comment": "x3000c0h12s1"
+                          },
+                          {
+                              "Name": "sw-spine-002",
+                              "IPAddress": "10.254.0.3",
+                              "Comment": "x3000c0h13s1"
+                          },
+                          {
+                              "Name": "sw-leaf-bmc-001",
+                              "IPAddress": "10.254.0.4",
+                              "Comment": "x3000c0w14"
+                          },
+                          {
+                              "Name": "sw-leaf-bmc-002",
+                              "IPAddress": "10.254.0.5",
+                              "Comment": "x3001c0w40"
+                          }
+                      ],
+                      "Name": "network_hardware",
+                      "VlanID": 4,
+                      "Gateway": "10.254.0.1"
+                  },
+                  {
+                      "FullName": "HMN Bootstrap DHCP Subnet",
+                      "CIDR": "10.254.1.0/17",
+                      "IPReservations": [
+                          {
+                              "Name": "kubeapi-vip",
+                              "IPAddress": "10.254.1.2",
+                              "Comment": "k8s-virtual-ip"
+                          },
+                          {
+                              "Name": "x3000c0s9b0",
+                              "IPAddress": "10.254.1.3",
+                              "Aliases": [
+                                  "ncn-s003-mgmt"
+                              ],
+                              "Comment": "x3000c0s9b0"
+                          },
+                          {
+                              "Name": "ncn-s003",
+                              "IPAddress": "10.254.1.4",
+                              "Aliases": [
+                                  "ncn-s003-hmn",
+                                  "time-hmn",
+                                  "time-hmn.local",
+                                  "rgw-vip.hmn"
+                              ],
+                              "Comment": "x3000c0s9b0n0"
+                          },
+                          {
+                              "Name": "x3000c0s8b0",
+                              "IPAddress": "10.254.1.5",
+                              "Aliases": [
+                                  "ncn-s002-mgmt"
+                              ],
+                              "Comment": "x3000c0s8b0"
+                          },
+                          {
+                              "Name": "ncn-s002",
+                              "IPAddress": "10.254.1.6",
+                              "Aliases": [
+                                  "ncn-s002-hmn",
+                                  "time-hmn",
+                                  "time-hmn.local",
+                                  "rgw-vip.hmn"
+                              ],
+                              "Comment": "x3000c0s8b0n0"
+                          },
+                          {
+                              "Name": "x3000c0s7b0",
+                              "IPAddress": "10.254.1.7",
+                              "Aliases": [
+                                  "ncn-s001-mgmt"
+                              ],
+                              "Comment": "x3000c0s7b0"
+                          },
+                          {
+                              "Name": "ncn-s001",
+                              "IPAddress": "10.254.1.8",
+                              "Aliases": [
+                                  "ncn-s001-hmn",
+                                  "time-hmn",
+                                  "time-hmn.local",
+                                  "rgw-vip.hmn"
+                              ],
+                              "Comment": "x3000c0s7b0n0"
+                          },
+                          {
+                              "Name": "x3000c0s6b0",
+                              "IPAddress": "10.254.1.9",
+                              "Aliases": [
+                                  "ncn-w003-mgmt"
+                              ],
+                              "Comment": "x3000c0s6b0"
+                          },
+                          {
+                              "Name": "ncn-w003",
+                              "IPAddress": "10.254.1.10",
+                              "Aliases": [
+                                  "ncn-w003-hmn",
+                                  "time-hmn",
+                                  "time-hmn.local"
+                              ],
+                              "Comment": "x3000c0s6b0n0"
+                          },
+                          {
+                              "Name": "x3000c0s5b0",
+                              "IPAddress": "10.254.1.11",
+                              "Aliases": [
+                                  "ncn-w002-mgmt"
+                              ],
+                              "Comment": "x3000c0s5b0"
+                          },
+                          {
+                              "Name": "ncn-w002",
+                              "IPAddress": "10.254.1.12",
+                              "Aliases": [
+                                  "ncn-w002-hmn",
+                                  "time-hmn",
+                                  "time-hmn.local"
+                              ],
+                              "Comment": "x3000c0s5b0n0"
+                          },
+                          {
+                              "Name": "x3000c0s4b0",
+                              "IPAddress": "10.254.1.13",
+                              "Aliases": [
+                                  "ncn-w001-mgmt"
+                              ],
+                              "Comment": "x3000c0s4b0"
+                          },
+                          {
+                              "Name": "ncn-w001",
+                              "IPAddress": "10.254.1.14",
+                              "Aliases": [
+                                  "ncn-w001-hmn",
+                                  "time-hmn",
+                                  "time-hmn.local"
+                              ],
+                              "Comment": "x3000c0s4b0n0"
+                          },
+                          {
+                              "Name": "x3000c0s3b0",
+                              "IPAddress": "10.254.1.15",
+                              "Aliases": [
+                                  "ncn-m003-mgmt"
+                              ],
+                              "Comment": "x3000c0s3b0"
+                          },
+                          {
+                              "Name": "ncn-m003",
+                              "IPAddress": "10.254.1.16",
+                              "Aliases": [
+                                  "ncn-m003-hmn",
+                                  "time-hmn",
+                                  "time-hmn.local"
+                              ],
+                              "Comment": "x3000c0s3b0n0"
+                          },
+                          {
+                              "Name": "x3000c0s2b0",
+                              "IPAddress": "10.254.1.17",
+                              "Aliases": [
+                                  "ncn-m002-mgmt"
+                              ],
+                              "Comment": "x3000c0s2b0"
+                          },
+                          {
+                              "Name": "ncn-m002",
+                              "IPAddress": "10.254.1.18",
+                              "Aliases": [
+                                  "ncn-m002-hmn",
+                                  "time-hmn",
+                                  "time-hmn.local"
+                              ],
+                              "Comment": "x3000c0s2b0n0"
+                          },
+                          {
+                              "Name": "x3000c0s1b0",
+                              "IPAddress": "10.254.1.19",
+                              "Aliases": [
+                                  "ncn-m001-mgmt"
+                              ],
+                              "Comment": "x3000c0s1b0"
+                          },
+                          {
+                              "Name": "ncn-m001",
+                              "IPAddress": "10.254.1.20",
+                              "Aliases": [
+                                  "ncn-m001-hmn",
+                                  "time-hmn",
+                                  "time-hmn.local"
+                              ],
+                              "Comment": "x3000c0s1b0n0"
+                          }
+                      ],
+                      "Name": "bootstrap_dhcp",
+                      "VlanID": 4,
+                      "Gateway": "10.254.0.1",
+                      "DHCPStart": "10.254.1.21",
+                      "DHCPEnd": "10.254.1.221"
+                  }
+              ]
+          }
+      },
+      "HMNLB": {
+          "Name": "HMNLB",
+          "FullName": "Hardware Management Network LoadBalancers",
+          "IPRanges": [
+              "10.94.100.0/24"
+          ],
+          "Type": "ethernet",
+          "ExtraProperties": {
+              "CIDR": "10.94.100.0/24",
+              "VlanRange": null,
+              "MTU": 9000,
+              "Subnets": [
+                  {
+                      "FullName": "HMN MetalLB",
+                      "CIDR": "10.94.100.0/24",
+                      "IPReservations": [
+                          {
+                              "Name": "istio-ingressgateway",
+                              "IPAddress": "10.94.100.71"
+                          },
+                          {
+                              "Name": "rsyslog-aggregator",
+                              "IPAddress": "10.94.100.72",
+                              "Aliases": [
+                                  "rsyslog-agg-service"
+                              ],
+                              "Comment": "rsyslog-agg-service"
+                          },
+                          {
+                              "Name": "cray-tftp",
+                              "IPAddress": "10.94.100.60",
+                              "Aliases": [
+                                  "tftp-service"
+                              ],
+                              "Comment": "tftp-service"
+                          },
+                          {
+                              "Name": "unbound",
+                              "IPAddress": "10.94.100.225",
+                              "Aliases": [
+                                  "unbound"
+                              ],
+                              "Comment": "unbound"
+                          },
+                          {
+                              "Name": "docker-registry",
+                              "IPAddress": "10.94.100.73",
+                              "Aliases": [
+                                  "docker_registry_service"
+                              ],
+                              "Comment": "docker_registry_service"
+                          }
+                      ],
+                      "Name": "hmn_metallb_address_pool",
+                      "VlanID": 4,
+                      "Gateway": "10.94.100.1",
+                      "MetalLBPoolName": "hardware-management"
+                  }
+              ]
+          }
+      },
+      "HMN_MTN": {
+          "Name": "HMN_MTN",
+          "FullName": "Mountain Compute Hardware Management Network",
+          "IPRanges": [
+              "10.104.0.0/17"
+          ],
+          "Type": "ethernet",
+          "ExtraProperties": {
+              "CIDR": "10.104.0.0/17",
+              "VlanRange": [
+                  3000,
+                  3000
+              ],
+              "MTU": 9000,
+              "Subnets": [
+                  {
+                      "FullName": "",
+                      "CIDR": "10.104.0.0/22",
+                      "Name": "cabinet_9000",
+                      "VlanID": 3000,
+                      "Gateway": "10.104.0.1",
+                      "DHCPStart": "10.104.0.10",
+                      "DHCPEnd": "10.104.3.254"
+                  }
+              ]
+          }
+      },
+      "HMN_RVR": {
+          "Name": "HMN_RVR",
+          "FullName": "River Compute Hardware Management Network",
+          "IPRanges": [
+              "10.107.0.0/17"
+          ],
+          "Type": "ethernet",
+          "ExtraProperties": {
+              "CIDR": "10.107.0.0/17",
+              "VlanRange": [
+                  1513,
+                  1514
+              ],
+              "MTU": 9000,
+              "Subnets": [
+                  {
+                      "FullName": "",
+                      "CIDR": "10.107.0.0/22",
+                      "Name": "cabinet_3000",
+                      "VlanID": 1513,
+                      "Gateway": "10.107.0.1",
+                      "DHCPStart": "10.107.0.10",
+                      "DHCPEnd": "10.107.3.254"
+                  },
+                  {
+                      "FullName": "",
+                      "CIDR": "10.107.4.0/22",
+                      "Name": "cabinet_3001",
+                      "VlanID": 1514,
+                      "Gateway": "10.107.4.1",
+                      "DHCPStart": "10.107.4.10",
+                      "DHCPEnd": "10.107.7.254"
+                  }
+              ]
+          }
+      },
+      "HSN": {
+          "Name": "HSN",
+          "FullName": "High Speed Network",
+          "IPRanges": [
+              "10.253.0.0/16"
+          ],
+          "Type": "slingshot10",
+          "ExtraProperties": {
+              "CIDR": "10.253.0.0/16",
+              "VlanRange": [
+                  613,
+                  868
+              ],
+              "MTU": 9000,
+              "Subnets": [
+                  {
+                      "FullName": "HSN Base Subnet",
+                      "CIDR": "10.253.0.0/16",
+                      "Name": "hsn_base_subnet",
+                      "VlanID": 613,
+                      "Gateway": "10.253.0.1"
+                  }
+              ]
+          }
+      },
+      "MTL": {
+          "Name": "MTL",
+          "FullName": "Provisioning Network (untagged)",
+          "IPRanges": [
+              "10.1.1.0/16"
+          ],
+          "Type": "ethernet",
+          "ExtraProperties": {
+              "CIDR": "10.1.1.0/16",
+              "VlanRange": [
+                  0
+              ],
+              "MTU": 9000,
+              "Comment": "This network is only valid for the NCNs",
+              "Subnets": [
+                  {
+                      "FullName": "MTL Management Network Infrastructure",
+                      "CIDR": "10.1.0.0/16",
+                      "IPReservations": [
+                          {
+                              "Name": "sw-spine-001",
+                              "IPAddress": "10.1.0.2",
+                              "Comment": "x3000c0h12s1"
+                          },
+                          {
+                              "Name": "sw-spine-002",
+                              "IPAddress": "10.1.0.3",
+                              "Comment": "x3000c0h13s1"
+                          },
+                          {
+                              "Name": "sw-leaf-bmc-001",
+                              "IPAddress": "10.1.0.4",
+                              "Comment": "x3000c0w14"
+                          },
+                          {
+                              "Name": "sw-leaf-bmc-002",
+                              "IPAddress": "10.1.0.5",
+                              "Comment": "x3001c0w40"
+                          }
+                      ],
+                      "Name": "network_hardware",
+                      "VlanID": 0,
+                      "Gateway": "10.1.0.1"
+                  },
+                  {
+                      "FullName": "MTL Bootstrap DHCP Subnet",
+                      "CIDR": "10.1.1.0/16",
+                      "IPReservations": [
+                          {
+                              "Name": "ncn-s003",
+                              "IPAddress": "10.1.1.2",
+                              "Aliases": [
+                                  "ncn-s003-mtl",
+                                  "time-mtl",
+                                  "time-mtl.local"
+                              ],
+                              "Comment": "x3000c0s9b0n0"
+                          },
+                          {
+                              "Name": "ncn-s002",
+                              "IPAddress": "10.1.1.3",
+                              "Aliases": [
+                                  "ncn-s002-mtl",
+                                  "time-mtl",
+                                  "time-mtl.local"
+                              ],
+                              "Comment": "x3000c0s8b0n0"
+                          },
+                          {
+                              "Name": "ncn-s001",
+                              "IPAddress": "10.1.1.4",
+                              "Aliases": [
+                                  "ncn-s001-mtl",
+                                  "time-mtl",
+                                  "time-mtl.local"
+                              ],
+                              "Comment": "x3000c0s7b0n0"
+                          },
+                          {
+                              "Name": "ncn-w003",
+                              "IPAddress": "10.1.1.5",
+                              "Aliases": [
+                                  "ncn-w003-mtl",
+                                  "time-mtl",
+                                  "time-mtl.local"
+                              ],
+                              "Comment": "x3000c0s6b0n0"
+                          },
+                          {
+                              "Name": "ncn-w002",
+                              "IPAddress": "10.1.1.6",
+                              "Aliases": [
+                                  "ncn-w002-mtl",
+                                  "time-mtl",
+                                  "time-mtl.local"
+                              ],
+                              "Comment": "x3000c0s5b0n0"
+                          },
+                          {
+                              "Name": "ncn-w001",
+                              "IPAddress": "10.1.1.7",
+                              "Aliases": [
+                                  "ncn-w001-mtl",
+                                  "time-mtl",
+                                  "time-mtl.local"
+                              ],
+                              "Comment": "x3000c0s4b0n0"
+                          },
+                          {
+                              "Name": "ncn-m003",
+                              "IPAddress": "10.1.1.8",
+                              "Aliases": [
+                                  "ncn-m003-mtl",
+                                  "time-mtl",
+                                  "time-mtl.local"
+                              ],
+                              "Comment": "x3000c0s3b0n0"
+                          },
+                          {
+                              "Name": "ncn-m002",
+                              "IPAddress": "10.1.1.9",
+                              "Aliases": [
+                                  "ncn-m002-mtl",
+                                  "time-mtl",
+                                  "time-mtl.local"
+                              ],
+                              "Comment": "x3000c0s2b0n0"
+                          },
+                          {
+                              "Name": "ncn-m001",
+                              "IPAddress": "10.1.1.10",
+                              "Aliases": [
+                                  "ncn-m001-mtl",
+                                  "time-mtl",
+                                  "time-mtl.local"
+                              ],
+                              "Comment": "x3000c0s1b0n0"
+                          }
+                      ],
+                      "Name": "bootstrap_dhcp",
+                      "VlanID": 0,
+                      "Gateway": "10.1.0.1",
+                      "DHCPStart": "10.1.1.11",
+                      "DHCPEnd": "10.1.1.211"
+                  }
+              ]
+          }
+      },
+      "NMN": {
+          "Name": "NMN",
+          "FullName": "Node Management Network",
+          "IPRanges": [
+              "10.252.0.0/17"
+          ],
+          "Type": "ethernet",
+          "ExtraProperties": {
+              "CIDR": "10.252.0.0/17",
+              "VlanRange": [
+                  2
+              ],
+              "MTU": 9000,
+              "PeerASN": 65533,
+              "MyASN": 65531,
+              "Subnets": [
+                  {
+                      "FullName": "NMN Management Network Infrastructure",
+                      "CIDR": "10.252.0.0/17",
+                      "IPReservations": [
+                          {
+                              "Name": "sw-spine-001",
+                              "IPAddress": "10.252.0.2",
+                              "Comment": "x3000c0h12s1"
+                          },
+                          {
+                              "Name": "sw-spine-002",
+                              "IPAddress": "10.252.0.3",
+                              "Comment": "x3000c0h13s1"
+                          },
+                          {
+                              "Name": "sw-leaf-bmc-001",
+                              "IPAddress": "10.252.0.4",
+                              "Comment": "x3000c0w14"
+                          },
+                          {
+                              "Name": "sw-leaf-bmc-002",
+                              "IPAddress": "10.252.0.5",
+                              "Comment": "x3001c0w40"
+                          }
+                      ],
+                      "Name": "network_hardware",
+                      "VlanID": 2,
+                      "Gateway": "10.252.0.1"
+                  },
+                  {
+                      "FullName": "NMN Bootstrap DHCP Subnet",
+                      "CIDR": "10.252.1.0/17",
+                      "IPReservations": [
+                          {
+                              "Name": "kubeapi-vip",
+                              "IPAddress": "10.252.1.2",
+                              "Aliases": [
+                                  "kubeapi-vip.local"
+                              ],
+                              "Comment": "k8s-virtual-ip"
+                          },
+                          {
+                              "Name": "rgw-vip",
+                              "IPAddress": "10.252.1.3",
+                              "Aliases": [
+                                  "rgw-vip.local"
+                              ],
+                              "Comment": "rgw-virtual-ip"
+                          },
+                          {
+                              "Name": "ncn-s003",
+                              "IPAddress": "10.252.1.4",
+                              "Aliases": [
+                                  "ncn-s003-nmn",
+                                  "time-nmn",
+                                  "time-nmn.local",
+                                  "x3000c0s9b0n0",
+                                  "ncn-s003.local"
+                              ],
+                              "Comment": "x3000c0s9b0n0"
+                          },
+                          {
+                              "Name": "ncn-s002",
+                              "IPAddress": "10.252.1.5",
+                              "Aliases": [
+                                  "ncn-s002-nmn",
+                                  "time-nmn",
+                                  "time-nmn.local",
+                                  "x3000c0s8b0n0",
+                                  "ncn-s002.local"
+                              ],
+                              "Comment": "x3000c0s8b0n0"
+                          },
+                          {
+                              "Name": "ncn-s001",
+                              "IPAddress": "10.252.1.6",
+                              "Aliases": [
+                                  "ncn-s001-nmn",
+                                  "time-nmn",
+                                  "time-nmn.local",
+                                  "x3000c0s7b0n0",
+                                  "ncn-s001.local"
+                              ],
+                              "Comment": "x3000c0s7b0n0"
+                          },
+                          {
+                              "Name": "ncn-w003",
+                              "IPAddress": "10.252.1.7",
+                              "Aliases": [
+                                  "ncn-w003-nmn",
+                                  "time-nmn",
+                                  "time-nmn.local",
+                                  "x3000c0s6b0n0",
+                                  "ncn-w003.local"
+                              ],
+                              "Comment": "x3000c0s6b0n0"
+                          },
+                          {
+                              "Name": "ncn-w002",
+                              "IPAddress": "10.252.1.8",
+                              "Aliases": [
+                                  "ncn-w002-nmn",
+                                  "time-nmn",
+                                  "time-nmn.local",
+                                  "x3000c0s5b0n0",
+                                  "ncn-w002.local"
+                              ],
+                              "Comment": "x3000c0s5b0n0"
+                          },
+                          {
+                              "Name": "ncn-w001",
+                              "IPAddress": "10.252.1.9",
+                              "Aliases": [
+                                  "ncn-w001-nmn",
+                                  "time-nmn",
+                                  "time-nmn.local",
+                                  "x3000c0s4b0n0",
+                                  "ncn-w001.local"
+                              ],
+                              "Comment": "x3000c0s4b0n0"
+                          },
+                          {
+                              "Name": "ncn-m003",
+                              "IPAddress": "10.252.1.10",
+                              "Aliases": [
+                                  "ncn-m003-nmn",
+                                  "time-nmn",
+                                  "time-nmn.local",
+                                  "x3000c0s3b0n0",
+                                  "ncn-m003.local"
+                              ],
+                              "Comment": "x3000c0s3b0n0"
+                          },
+                          {
+                              "Name": "ncn-m002",
+                              "IPAddress": "10.252.1.11",
+                              "Aliases": [
+                                  "ncn-m002-nmn",
+                                  "time-nmn",
+                                  "time-nmn.local",
+                                  "x3000c0s2b0n0",
+                                  "ncn-m002.local"
+                              ],
+                              "Comment": "x3000c0s2b0n0"
+                          },
+                          {
+                              "Name": "ncn-m001",
+                              "IPAddress": "10.252.1.12",
+                              "Aliases": [
+                                  "ncn-m001-nmn",
+                                  "time-nmn",
+                                  "time-nmn.local",
+                                  "x3000c0s1b0n0",
+                                  "ncn-m001.local"
+                              ],
+                              "Comment": "x3000c0s1b0n0"
+                          }
+                      ],
+                      "Name": "bootstrap_dhcp",
+                      "VlanID": 2,
+                      "Gateway": "10.252.0.1",
+                      "DHCPStart": "10.252.1.13",
+                      "DHCPEnd": "10.252.1.213"
+                  },
+                  {
+                      "FullName": "NMN UAIs",
+                      "CIDR": "10.252.2.0/23",
+                      "IPReservations": [
+                          {
+                              "Name": "pbs_comm_service",
+                              "IPAddress": "10.252.2.2",
+                              "Aliases": [
+                                  "pbs-comm-service",
+                                  "pbs-comm-service-nmn",
+                                  "pbs_comm_service.local"
+                              ],
+                              "Comment": "pbs-comm-service,pbs-comm-service-nmn"
+                          },
+                          {
+                              "Name": "pbs_service",
+                              "IPAddress": "10.252.2.3",
+                              "Aliases": [
+                                  "pbs-service",
+                                  "pbs-service-nmn",
+                                  "pbs_service.local"
+                              ],
+                              "Comment": "pbs-service,pbs-service-nmn"
+                          },
+                          {
+                              "Name": "slurmctld_service",
+                              "IPAddress": "10.252.2.4",
+                              "Aliases": [
+                                  "slurmctld-service",
+                                  "slurmctld-service-nmn",
+                                  "slurmctld_service.local"
+                              ],
+                              "Comment": "slurmctld-service,slurmctld-service-nmn"
+                          },
+                          {
+                              "Name": "slurmdbd_service",
+                              "IPAddress": "10.252.2.5",
+                              "Aliases": [
+                                  "slurmdbd-service",
+                                  "slurmdbd-service-nmn",
+                                  "slurmdbd_service.local"
+                              ],
+                              "Comment": "slurmdbd-service,slurmdbd-service-nmn"
+                          },
+                          {
+                              "Name": "uai_nmn_blackhole",
+                              "IPAddress": "10.252.2.6",
+                              "Aliases": [
+                                  "uai-nmn-blackhole",
+                                  "uai_nmn_blackhole.local"
+                              ],
+                              "Comment": "uai-nmn-blackhole"
+                          }
+                      ],
+                      "Name": "uai_macvlan",
+                      "VlanID": 2,
+                      "Gateway": "10.252.0.1",
+                      "ReservationStart": "10.252.2.10",
+                      "ReservationEnd": "10.252.3.254"
+                  }
+              ]
+          }
+      },
+      "NMNLB": {
+          "Name": "NMNLB",
+          "FullName": "Node Management Network LoadBalancers",
+          "IPRanges": [
+              "10.92.100.0/24"
+          ],
+          "Type": "ethernet",
+          "ExtraProperties": {
+              "CIDR": "10.92.100.0/24",
+              "VlanRange": null,
+              "MTU": 9000,
+              "Subnets": [
+                  {
+                      "FullName": "NMN MetalLB",
+                      "CIDR": "10.92.100.0/24",
+                      "IPReservations": [
+                          {
+                              "Name": "docker-registry",
+                              "IPAddress": "10.92.100.73",
+                              "Aliases": [
+                                  "docker_registry_service"
+                              ],
+                              "Comment": "docker_registry_service"
+                          },
+                          {
+                              "Name": "istio-ingressgateway",
+                              "IPAddress": "10.92.100.71",
+                              "Aliases": [
+                                  "api-gw-service",
+                                  "api-gw-service-nmn.local",
+                                  "packages",
+                                  "registry",
+                                  "spire.local",
+                                  "api_gw_service",
+                                  "registry.local",
+                                  "packages",
+                                  "packages.local",
+                                  "spire"
+                              ],
+                              "Comment": "api-gw-service,api-gw-service-nmn.local,packages,registry,spire.local,api_gw_service,registry.local,packages,packages.local,spire"
+                          },
+                          {
+                              "Name": "istio-ingressgateway-local",
+                              "IPAddress": "10.92.100.81",
+                              "Aliases": [
+                                  "api-gw-service.local"
+                              ],
+                              "Comment": "api-gw-service.local"
+                          },
+                          {
+                              "Name": "rsyslog-aggregator",
+                              "IPAddress": "10.92.100.72",
+                              "Aliases": [
+                                  "rsyslog-agg-service"
+                              ],
+                              "Comment": "rsyslog-agg-service"
+                          },
+                          {
+                              "Name": "cray-tftp",
+                              "IPAddress": "10.92.100.60",
+                              "Aliases": [
+                                  "tftp-service"
+                              ],
+                              "Comment": "tftp-service"
+                          },
+                          {
+                              "Name": "unbound",
+                              "IPAddress": "10.92.100.225",
+                              "Aliases": [
+                                  "unbound"
+                              ],
+                              "Comment": "unbound"
+                          }
+                      ],
+                      "Name": "nmn_metallb_address_pool",
+                      "VlanID": 2,
+                      "Gateway": "10.92.100.1",
+                      "MetalLBPoolName": "node-management"
+                  }
+              ]
+          }
+      },
+      "NMN_MTN": {
+          "Name": "NMN_MTN",
+          "FullName": "Mountain Compute Node Management Network",
+          "IPRanges": [
+              "10.100.0.0/17"
+          ],
+          "Type": "ethernet",
+          "ExtraProperties": {
+              "CIDR": "10.100.0.0/17",
+              "VlanRange": [
+                  2000,
+                  2000
+              ],
+              "MTU": 9000,
+              "Subnets": [
+                  {
+                      "FullName": "",
+                      "CIDR": "10.100.0.0/22",
+                      "Name": "cabinet_9000",
+                      "VlanID": 2000,
+                      "Gateway": "10.100.0.1",
+                      "DHCPStart": "10.100.0.10",
+                      "DHCPEnd": "10.100.3.254"
+                  }
+              ]
+          }
+      },
+      "NMN_RVR": {
+          "Name": "NMN_RVR",
+          "FullName": "River Compute Node Management Network",
+          "IPRanges": [
+              "10.106.0.0/17"
+          ],
+          "Type": "ethernet",
+          "ExtraProperties": {
+              "CIDR": "10.106.0.0/17",
+              "VlanRange": [
+                  1770,
+                  1771
+              ],
+              "MTU": 9000,
+              "Subnets": [
+                  {
+                      "FullName": "",
+                      "CIDR": "10.106.0.0/22",
+                      "Name": "cabinet_3000",
+                      "VlanID": 1770,
+                      "Gateway": "10.106.0.1",
+                      "DHCPStart": "10.106.0.10",
+                      "DHCPEnd": "10.106.3.254"
+                  },
+                  {
+                      "FullName": "",
+                      "CIDR": "10.106.4.0/22",
+                      "Name": "cabinet_3001",
+                      "VlanID": 1771,
+                      "Gateway": "10.106.4.1",
+                      "DHCPStart": "10.106.4.10",
+                      "DHCPEnd": "10.106.7.254"
+                  }
+              ]
+          }
+      }
+  }
+}


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- runs the hms-simulator in github actions, runs cani use cases via shellspec, and inspects csm services with tavern
- drops cachix/install-nix-action in favor of just cloning shellspec and symlinking it
- removes macos github runners due to new dependency of docker
- adds a shell script that is part of `make test`, which loops through a dir and runs `shellspec` and then `tavern-ci`, this is the main loop used for integration tests and validation of the APIS
- adds a shell script that is part of `make test`, which sets up the simulator (assuming it is already cloned)
- adds a function to `spec_helper.sh` to load a config to SLS
- adds many SLS fixtures (some still need network info)

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->


Low.  Adds tests and fixtures