### PR TITLE
improve formating of cabinet vlan report. add sort options

### DIFF
--- a/cmd/cabinet/init.go
+++ b/cmd/cabinet/init.go
@@ -35,6 +35,7 @@ var (
 	auto          bool
 	accept        bool
 	format        string
+	sortBy        string
 )
 
 func init() {
@@ -55,5 +56,7 @@ func init() {
 	AddCabinetCmd.Flags().BoolVar(&auto, "auto", false, "Automatically recommend and assign required flags.")
 	AddCabinetCmd.MarkFlagsMutuallyExclusive("auto")
 	AddCabinetCmd.Flags().BoolVarP(&accept, "accept", "y", false, "Automatically accept recommended values.")
+
 	ListCabinetCmd.Flags().StringVarP(&format, "format", "f", "pretty", "Format out output")
+	ListCabinetCmd.Flags().StringVarP(&sortBy, "sort", "s", "location", "Sort by a specific key")
 }


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- Improves inconsistent indents in the cabinet list view
- adds sort by options

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

