### PR TITLE
Some refactoring on how provider metadata is handled

### DIFF
--- a/cmd/cabinet/add_cabinet.go
+++ b/cmd/cabinet/add_cabinet.go
@@ -67,7 +67,7 @@ func addCabinet(cmd *cobra.Command, args []string) error {
 		log.Info().Msgf("Querying inventory to suggest cabinet number and VLAN ID")
 		// set the vars to the recommendations
 		cabinetNumber = recommendations.LocationOrdinal
-		vlanId = recommendations.ProviderMetadata[csm.ProviderPropertyVlanId].(int)
+		vlanId = recommendations.ProviderMetadata[csm.ProviderMetadataVlanId].(int)
 		log.Debug().Msgf("Provider recommendations: %+v", recommendations)
 		log.Info().Msgf("Suggested cabinet number: %d", cabinetNumber)
 		log.Info().Msgf("Suggested VLAN ID: %d", vlanId)
@@ -97,7 +97,7 @@ func addCabinet(cmd *cobra.Command, args []string) error {
 	// Right now the build metadata function in the CSM provider will
 	// unset options if nil is passed in.
 	cabinetMetadata := map[string]interface{}{
-		csm.ProviderPropertyVlanId: vlanId,
+		csm.ProviderMetadataVlanId: vlanId,
 	}
 
 	// Add the cabinet to the inventory using domain methods

--- a/cmd/cabinet/list_cabinet.go
+++ b/cmd/cabinet/list_cabinet.go
@@ -39,7 +39,6 @@ import (
 	"github.com/Cray-HPE/cani/internal/provider/csm"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/google/uuid"
-	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 )
 
@@ -126,17 +125,26 @@ func listCabinet(cmd *cobra.Command, args []string) error {
 			return filtered[keys[i]].LocationPath.String() < filtered[keys[j]].LocationPath.String()
 		})
 
-		properties := csm.CabinetMetadata{}
 		for _, hw := range keys {
-			if _, exists := filtered[hw].ProviderProperties[string(inventory.CSMProvider)]; exists {
-				if err := mapstructure.Decode(filtered[hw].ProviderProperties["csm"], &properties); err != nil {
+			// Start with an empty cabinet metadata struct, just in case if this cabinet doesn't have any
+			// metadata set
+			cabinetMetadata := csm.CabinetMetadata{}
+
+			if _, exists := filtered[hw].ProviderMetadata[inventory.CSMProvider]; exists {
+				csmMetadata, err := csm.DecodeProviderMetadata(filtered[hw])
+				if err != nil {
 					return err
 				}
+
+				if csmMetadata.Cabinet != nil {
+					cabinetMetadata = *csmMetadata.Cabinet
+				}
 			}
+
 			fmt.Fprintf(w, "%s\t%s\t%v\t%s\n",
 				filtered[hw].ID.String(),
 				filtered[hw].DeviceTypeSlug,
-				*properties.HMNVlan,
+				*cabinetMetadata.HMNVlan,
 				filtered[hw].LocationPath.String())
 		}
 

--- a/cmd/cabinet/list_cabinet.go
+++ b/cmd/cabinet/list_cabinet.go
@@ -38,6 +38,7 @@ import (
 	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/internal/provider/csm"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
+	"github.com/Cray-HPE/cani/pkg/pointers"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
@@ -144,7 +145,7 @@ func listCabinet(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(w, "%s\t%s\t%v\t%s\n",
 				filtered[hw].ID.String(),
 				filtered[hw].DeviceTypeSlug,
-				*cabinetMetadata.HMNVlan,
+				pointers.IntPtrToStr(cabinetMetadata.HMNVlan),
 				filtered[hw].LocationPath.String())
 		}
 

--- a/cmd/node/update_node.go
+++ b/cmd/node/update_node.go
@@ -61,16 +61,16 @@ func updateNode(cmd *cobra.Command, args []string) error {
 	// unset options if nil is passed in.
 	nodeMeta := map[string]interface{}{}
 	if cmd.Flags().Changed("role") {
-		nodeMeta[csm.ProviderPropertyRole] = role
+		nodeMeta[csm.ProviderMetadataRole] = role
 	}
 	if cmd.Flags().Changed("subrole") {
-		nodeMeta[csm.ProviderPropertySubRole] = subrole
+		nodeMeta[csm.ProviderMetadataSubRole] = subrole
 	}
 	if cmd.Flags().Changed("alias") {
-		nodeMeta[csm.ProviderPropertyAlias] = alias
+		nodeMeta[csm.ProviderMetadataAlias] = alias
 	}
 	if cmd.Flags().Changed("alias") {
-		nodeMeta[csm.ProviderPropertyNID] = nid
+		nodeMeta[csm.ProviderMetadataNID] = nid
 	}
 
 	// Remove the node from the inventory using domain methods

--- a/cmd/node/update_node.go
+++ b/cmd/node/update_node.go
@@ -32,6 +32,7 @@ import (
 	root "github.com/Cray-HPE/cani/cmd"
 	"github.com/Cray-HPE/cani/internal/domain"
 	"github.com/Cray-HPE/cani/internal/provider"
+	"github.com/Cray-HPE/cani/internal/provider/csm"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -60,16 +61,16 @@ func updateNode(cmd *cobra.Command, args []string) error {
 	// unset options if nil is passed in.
 	nodeMeta := map[string]interface{}{}
 	if cmd.Flags().Changed("role") {
-		nodeMeta["role"] = role
+		nodeMeta[csm.ProviderPropertyRole] = role
 	}
 	if cmd.Flags().Changed("subrole") {
-		nodeMeta["subrole"] = subrole
+		nodeMeta[csm.ProviderPropertySubRole] = subrole
 	}
 	if cmd.Flags().Changed("alias") {
-		nodeMeta["alias"] = alias
+		nodeMeta[csm.ProviderPropertyAlias] = alias
 	}
 	if cmd.Flags().Changed("alias") {
-		nodeMeta["nid"] = nid
+		nodeMeta[csm.ProviderPropertyNID] = nid
 	}
 
 	// Remove the node from the inventory using domain methods

--- a/internal/domain/node.go
+++ b/internal/domain/node.go
@@ -58,7 +58,7 @@ func (d *Domain) UpdateNode(ctx context.Context, cabinet, chassis, slot, bmc, no
 		return AddHardwareResult{}, err
 	}
 
-	log.Debug().Any("metadata", hw.ProviderProperties).Msg("Provider Properties")
+	log.Debug().Any("metadata", hw.ProviderMetadata).Msg("Provider Properties")
 
 	// Push it back into the data store
 	if err := d.datastore.Update(&hw); err != nil {

--- a/internal/inventory/model.go
+++ b/internal/inventory/model.go
@@ -88,19 +88,16 @@ func (i *Inventory) FilterHardwareByTypeStatus(status HardwareStatus, types ...h
 // Hardware is the smallest unit of inventory
 // It has all the potential fields that hardware can have
 type Hardware struct {
-	ID                 uuid.UUID
-	Name               string                     `json:"Name,omitempty" yaml:"Name,omitempty" default:"" usage:"Friendly name"`
-	Type               hardwaretypes.HardwareType `json:"Type,omitempty" yaml:"Type,omitempty" default:"" usage:"Type"`
-	DeviceTypeSlug     string                     `json:"DeviceTypeSlug,omitempty" yaml:"DeviceTypeSlug,omitempty" default:"" usage:"Hardware Type Library Device slug"`
-	Vendor             string                     `json:"Vendor,omitempty" yaml:"Vendor,omitempty" default:"" usage:"Vendor"`
-	Architecture       string                     `json:"Architecture,omitempty" yaml:"Architecture,omitempty" default:"" usage:"Architecture"`
-	Model              string                     `json:"Model,omitempty" yaml:"Model,omitempty" default:"" usage:"Model"`
-	Status             HardwareStatus             `json:"Status,omitempty" yaml:"Status,omitempty" default:"Staged" usage:"Hardware can be [staged, provisioned, decomissioned]"`
-	Properties         map[string]interface{}     `json:"Properties,omitempty" yaml:"Properties,omitempty" default:"" usage:"Properties"`
-	Role               string                     `json:"Role,omitempty" yaml:"Role,omitempty" default:"" usage:"Role"`
-	SubRole            string                     `json:"SubRole,omitempty" yaml:"SubRole,omitempty" default:"" usage:"SubRole"`
-	Alias              string                     `json:"Alias,omitempty" yaml:"Alias,omitempty" default:"" usage:"Alias"`
-	ProviderProperties map[string]interface{}     `json:"ProviderProperties,omitempty" yaml:"ProviderProperties,omitempty" default:"" usage:"ProviderProperties"`
+	ID               uuid.UUID
+	Name             string                           `json:"Name,omitempty" yaml:"Name,omitempty" default:"" usage:"Friendly name"`
+	Type             hardwaretypes.HardwareType       `json:"Type,omitempty" yaml:"Type,omitempty" default:"" usage:"Type"`
+	DeviceTypeSlug   string                           `json:"DeviceTypeSlug,omitempty" yaml:"DeviceTypeSlug,omitempty" default:"" usage:"Hardware Type Library Device slug"`
+	Vendor           string                           `json:"Vendor,omitempty" yaml:"Vendor,omitempty" default:"" usage:"Vendor"`
+	Architecture     string                           `json:"Architecture,omitempty" yaml:"Architecture,omitempty" default:"" usage:"Architecture"`
+	Model            string                           `json:"Model,omitempty" yaml:"Model,omitempty" default:"" usage:"Model"`
+	Status           HardwareStatus                   `json:"Status,omitempty" yaml:"Status,omitempty" default:"Staged" usage:"Hardware can be [staged, provisioned, decomissioned]"`
+	Properties       map[string]interface{}           `json:"Properties,omitempty" yaml:"Properties,omitempty" default:"" usage:"Properties"`
+	ProviderMetadata map[Provider]ProviderMetadataRaw `json:"ProviderMetadata,omitempty" yaml:"ProviderMetadata,omitempty" default:"" usage:"ProviderMetadata"`
 
 	Parent uuid.UUID `json:"Parent,omitempty" yaml:"Parent,omitempty" default:"00000000-0000-0000-0000-000000000000" usage:"Parent hardware"`
 	// The following are derived from Parent
@@ -108,6 +105,16 @@ type Hardware struct {
 	LocationPath LocationPath `json:"LocationPath,omitempty" yaml:"LocationPath,omitempty"`
 
 	LocationOrdinal *int
+}
+
+func (hardware *Hardware) SetProviderMetadata(provider Provider, metadata map[string]interface{}) {
+	// Initialize ProviderMetadata map if nil
+	if hardware.ProviderMetadata == nil {
+		hardware.ProviderMetadata = map[Provider]ProviderMetadataRaw{}
+	}
+
+	// Set provider metadata
+	hardware.ProviderMetadata[provider] = metadata
 }
 
 func NewHardwareFromBuildOut(hardwareBuildOut hardwaretypes.HardwareBuildOut, status HardwareStatus) Hardware {
@@ -148,6 +155,9 @@ const (
 	SchemaVersionV1Alpha1 = SchemaVersion("v1alpha1")
 	CSMProvider           = Provider("csm")
 )
+
+// ProviderMetadataRaw stores the metadata from a provider in a generic map.
+type ProviderMetadataRaw map[string]interface{}
 
 type LocationToken struct {
 	HardwareType hardwaretypes.HardwareType

--- a/internal/provider/csm/csv.go
+++ b/internal/provider/csm/csv.go
@@ -38,7 +38,7 @@ import (
 func (csm *CSM) GetFields(hw *inventory.Hardware, fieldNames []string) (values []string, err error) {
 	values = make([]string, len(fieldNames))
 
-	csmProps, ok := hw.ProviderMetadata["csm"]
+	csmProps, ok := hw.ProviderMetadata[inventory.CSMProvider]
 	if !ok {
 		csmProps = make(map[string]interface{})
 	}

--- a/internal/provider/csm/csv.go
+++ b/internal/provider/csm/csv.go
@@ -92,50 +92,55 @@ func (csm *CSM) GetFields(hw *inventory.Hardware, fieldNames []string) (values [
 }
 
 func (csm *CSM) SetFields(hw *inventory.Hardware, values map[string]string) (result provider.SetFieldsResult, err error) {
-	rawCsmProps := hw.ProviderProperties["csm"]
-	csmProps, ok := rawCsmProps.(map[string]interface{})
-	if !ok {
-		// NodeCard's do not have csm props
-		// todo possibly verify that the writable columns are empty in the csv input
+	csmHardware, err := ToCsmHardware(hw)
+	if err != nil {
+		return result, err
+	}
+
+	if csmHardware.CabinetMetadata == nil && csmHardware.NodeMetadata == nil {
 		log.Debug().Msgf("Skipping %v of the type %v. It does not have writable properties", hw.ID, hw.Type)
 		return
 	}
 
-	for key, value := range values {
-		switch key {
-		case "Vlan":
-			modified, err := setVlan(value, csmProps)
-			if err != nil {
-				return result, err
+	if csmHardware.NodeMetadata != nil {
+		for key, value := range values {
+			switch key {
+			case "Role":
+				modified := setRole(value, csmHardware.NodeMetadata)
+				if modified {
+					result.ModifiedFields = append(result.ModifiedFields, "Role")
+				}
+			case "SubRole":
+				modified := setSubRole(value, csmHardware.NodeMetadata)
+				if modified {
+					result.ModifiedFields = append(result.ModifiedFields, "SubRole")
+				}
+			case "Alias":
+				modified := setAlias(value, csmHardware.NodeMetadata)
+				if modified {
+					result.ModifiedFields = append(result.ModifiedFields, "Alias")
+				}
+			case "Nid":
+				modified, err := setNid(value, csmHardware.NodeMetadata)
+				if err != nil {
+					return result, err
+				}
+				if modified {
+					result.ModifiedFields = append(result.ModifiedFields, "Nid")
+				}
 			}
-			if modified {
-				result.ModifiedFields = append(result.ModifiedFields, "Vlan")
-			}
-		case "Role":
-			modified := setRole(value, csmProps)
-			if modified {
-				result.ModifiedFields = append(result.ModifiedFields, "Role")
-			}
-		case "SubRole":
-			modified := setSubRole(value, csmProps)
-			if modified {
-				result.ModifiedFields = append(result.ModifiedFields, "SubRole")
-			}
-		case "Alias":
-			modified, err := setAlias(value, csmProps, hw)
-			if err != nil {
-				return result, err
-			}
-			if modified {
-				result.ModifiedFields = append(result.ModifiedFields, "Alias")
-			}
-		case "Nid":
-			modified, err := setNid(value, csmProps)
-			if err != nil {
-				return result, err
-			}
-			if modified {
-				result.ModifiedFields = append(result.ModifiedFields, "Nid")
+		}
+	} else if csmHardware.CabinetMetadata != nil {
+		for key, value := range values {
+			switch key {
+			case "Vlan":
+				modified, err := setVlan(value, csmHardware.CabinetMetadata)
+				if err != nil {
+					return result, err
+				}
+				if modified {
+					result.ModifiedFields = append(result.ModifiedFields, "Vlan")
+				}
 			}
 		}
 	}
@@ -143,100 +148,97 @@ func (csm *CSM) SetFields(hw *inventory.Hardware, values map[string]string) (res
 	return
 }
 
-func setVlan(vlanStr string, csmProperties map[string]interface{}) (bool, error) {
+func setVlan(vlanStr string, cabinetMetadata *CabinetMetadata) (bool, error) {
 	modified := false
-	if vlanStr != "" {
+	if vlanStr == "" {
+		if cabinetMetadata.HMNVlan != nil {
+			cabinetMetadata.HMNVlan = nil
+			modified = true
+		}
+	} else {
 		// todo should vlanStr == "" cause the "HMNVlan" field to be removed?
 		vlan, err := strconv.ParseInt(vlanStr, 10, 64)
 		if err != nil {
 			return modified, err
 		}
-		current := csmProperties["HMNVlan"]
-		vlanFloat := float64(vlan)
-		if current != vlanFloat {
-			csmProperties["HMNVlan"] = vlanFloat
+		vlanInt := int(vlan)
+		if cabinetMetadata.HMNVlan == nil || *cabinetMetadata.HMNVlan != vlanInt {
+			cabinetMetadata.HMNVlan = &vlanInt
 			modified = true
 		}
 	}
 	return modified, nil
 }
 
-func setRole(role string, csmProperties map[string]interface{}) bool {
+func setRole(role string, nodeMetadata *NodeMetadata) bool {
 	modified := false
-	if role != "" {
-		if role != csmProperties["Role"] {
-			csmProperties["Role"] = role
+	if role == "" {
+		if nodeMetadata.Role != nil {
+			nodeMetadata.Role = nil
 			modified = true
-		}
-	}
-	return modified
-}
-
-func setSubRole(subRole string, csmProperties map[string]interface{}) bool {
-	modified := false
-	currentSubRole, ok := csmProperties["SubRole"]
-	if subRole == "" {
-		if ok {
-			if nil != currentSubRole && subRole != currentSubRole {
-				csmProperties["SubRole"] = nil
-				modified = true
-			}
 		}
 	} else {
-		if subRole != currentSubRole {
-			csmProperties["SubRole"] = subRole
+		if nodeMetadata.Role == nil || role != *nodeMetadata.Role {
+			nodeMetadata.Role = &role
 			modified = true
 		}
 	}
 	return modified
 }
 
-func setNid(nidStr string, csmProperties map[string]interface{}) (bool, error) {
+func setSubRole(subRole string, nodeMetadata *NodeMetadata) bool {
 	modified := false
-	if nidStr != "" {
+	if subRole == "" {
+		if nodeMetadata.SubRole != nil {
+			nodeMetadata.SubRole = nil
+			modified = true
+		}
+	} else {
+		if nodeMetadata.SubRole == nil || subRole != *nodeMetadata.SubRole {
+			nodeMetadata.SubRole = &subRole
+			modified = true
+		}
+	}
+	return modified
+}
+
+func setNid(nidStr string, nodeMetadata *NodeMetadata) (bool, error) {
+	modified := false
+	if nidStr == "" {
+		if nodeMetadata.Nid != nil {
+			nodeMetadata.Nid = nil
+			modified = true
+		}
+	} else {
 		nid, err := strconv.ParseInt(nidStr, 10, 64)
 		if err != nil {
 			return modified, errors.Join(fmt.Errorf("failed to parse nid %v", nidStr), err)
 		}
-		currentNidRaw := csmProperties["Nid"]
-		currentNid, ok := currentNidRaw.(float64)
-		nidFloat := float64(nid)
-		if !ok || nidFloat != currentNid {
-			csmProperties["Nid"] = nidFloat
+		nidInt := int(nid)
+		if nodeMetadata.Nid == nil || nidInt != *nodeMetadata.Nid {
+			nodeMetadata.Nid = &nidInt
 			modified = true
 		}
 	}
 	return modified, nil
 }
 
-func setAlias(alias string, csmProperties map[string]interface{}, hw *inventory.Hardware) (bool, error) {
+func setAlias(alias string, nodeMetadata *NodeMetadata) bool {
 	modified := false
+	// todo what should be done with an empty string
+	//   should it remove all alias, or remove the first element, or do nothing
 	if alias != "" {
-		rawAlias, ok := csmProperties["Alias"]
-		if !ok {
-			a := make([]interface{}, 0)
-			a = append(a, alias)
-			csmProperties["Alias"] = a
-			modified = true
-		} else {
-			v, ok := rawAlias.([]interface{})
-			if !ok {
-				return modified, fmt.Errorf("expected the Alias field to be an array in the hardware %v", hw)
-			}
-			if len(v) > 0 {
-				if v[0] != alias {
-					v[0] = alias
-					csmProperties["Alias"] = v
-					modified = true
-				}
-			} else {
-				v = append(v, alias)
-				csmProperties["Alias"] = v
+		if len(nodeMetadata.Alias) > 0 {
+			if nodeMetadata.Alias[0] != alias {
+				nodeMetadata.Alias[0] = alias
 				modified = true
 			}
+		} else {
+			nodeMetadata.Alias = append(nodeMetadata.Alias, alias)
+			modified = true
 		}
 	}
-	return modified, nil
+	return modified
 }
 
 func getStringFromArray(value interface{}, i int) string {

--- a/internal/provider/csm/csv_test.go
+++ b/internal/provider/csm/csv_test.go
@@ -27,13 +27,12 @@ package csm
 
 import (
 	"testing"
-
-	"github.com/Cray-HPE/cani/internal/inventory"
 )
 
 func TestSetVlan(t *testing.T) {
-	csmProps := make(map[string]interface{})
-	modified, err := setVlan("", csmProps)
+	props := &CabinetMetadata{}
+
+	modified, err := setVlan("", props)
 	if err != nil {
 		t.Errorf("set empty vlan unexpected error: %v", err)
 	}
@@ -41,133 +40,167 @@ func TestSetVlan(t *testing.T) {
 		t.Errorf("set empty vlan, modified should be false")
 	}
 
-	var value = "1000"
-	var expected float64 = 1000
-	csmProps["HMNVlan"] = expected
-	modified, err = setVlan(value, csmProps)
+	value := "1000"
+	expected := 1000
+	props.HMNVlan = new(int)
+	*props.HMNVlan = expected
+	modified, err = setVlan(value, props)
 	if err != nil {
 		t.Errorf("set same vlan unexpected error: %v", err)
 	}
 	if modified {
 		t.Errorf("set same vlan, modified should be false")
 	}
-	if csmProps["HMNVlan"] != expected {
-		t.Errorf("set same vlan, wrong value, expected: %v, actual: %v", expected, csmProps["HMNVlan"])
+	if *props.HMNVlan != expected {
+		t.Errorf("set same vlan, wrong value, expected: %v, actual: %v", expected, *props.HMNVlan)
 	}
 
 	value = "3333"
 	expected = 3333
-	modified, err = setVlan(value, csmProps)
+	modified, err = setVlan(value, props)
 	if err != nil {
 		t.Errorf("set new vlan unexpected error: %v", err)
 	}
 	if !modified {
 		t.Errorf("set new vlan, modified should be true")
 	}
-	if csmProps["HMNVlan"] != expected {
-		t.Errorf("set new vlan, wrong value, expected: %v, actual: %v", expected, csmProps["HMNVlan"])
+	if *props.HMNVlan != expected {
+		t.Errorf("set new vlan, wrong value, expected: %v, actual: %v", expected, *props.HMNVlan)
+	}
+
+	// test set vlan to empty
+	modified, err = setVlan("", props)
+	if err != nil {
+		t.Errorf("set vlan to empty, unexpected error: %v", err)
+	}
+	if !modified {
+		t.Errorf("set vlan to empty, modified should be true")
+	}
+	if props.HMNVlan != nil {
+		t.Errorf("set vlan to empty, wrong value, expected: nil, actual: %v", *props.HMNVlan)
+	}
+
+	// test set vlan to empty again
+	modified, err = setVlan("", props)
+	if err != nil {
+		t.Errorf("set vlan to empty again, unexpected error: %v", err)
+	}
+	if modified {
+		t.Errorf("set vlan to empty again, modified should be false")
+	}
+	if props.HMNVlan != nil {
+		t.Errorf("set vlan to empty again, wrong value, expected: nil, actual: %v", *props.HMNVlan)
 	}
 }
 
 func TestSetRole(t *testing.T) {
-	csmProps := make(map[string]interface{})
+	props := &NodeMetadata{}
 
 	// test empty value
-	modified := setRole("", csmProps)
+	modified := setRole("", props)
 	if modified {
 		t.Errorf("set empty role, modified should be false")
 	}
 
 	// test set to Compute
 	expected := "Compute"
-	modified = setRole(expected, csmProps)
+	modified = setRole(expected, props)
 	if !modified {
 		t.Errorf("set role Compute, modified should be true")
 	}
-	actual := csmProps["Role"]
+	actual := *props.Role
 	if expected != actual {
 		t.Errorf("set role Compute, expected: %s, actual: %v", expected, actual)
 	}
 
 	// test set to same value
-	modified = setRole(expected, csmProps)
+	modified = setRole(expected, props)
 	if modified {
 		t.Errorf("set role to same value, modified should be false")
 	}
-	actual = csmProps["Role"]
+	actual = *props.Role
 	if expected != actual {
 		t.Errorf("set role to same value, expected: %s, actual: %v", expected, actual)
 	}
 
 	// test set to new value
 	expected = "Application"
-	modified = setRole(expected, csmProps)
+	modified = setRole(expected, props)
 	if !modified {
 		t.Errorf("set role Application, modified should be true")
 	}
-	actual = csmProps["Role"]
+	actual = *props.Role
 	if expected != actual {
 		t.Errorf("set role Application, expected: %s, actual: %v", expected, actual)
+	}
+
+	// test set to empty
+	modified = setRole("", props)
+	if !modified {
+		t.Errorf("set role to empty, modified should be true")
+	}
+	if props.Role != nil {
+		t.Errorf("set role to empty, expected: nil, actual: %v", *props.Role)
 	}
 }
 
 func TestSetSubRole(t *testing.T) {
-	csmProps := make(map[string]interface{})
+	props := &NodeMetadata{}
 
 	// test empty value
-	modified := setSubRole("", csmProps)
+	modified := setSubRole("", props)
 	if modified {
 		t.Errorf("set empty subrole, modified should be false")
 	}
 
 	// test set to Compute
 	expected := "Worker"
-	modified = setSubRole(expected, csmProps)
+	modified = setSubRole(expected, props)
 	if !modified {
 		t.Errorf("set subrole Worker, modified should be true")
 	}
-	actual := csmProps["SubRole"]
-	if expected != actual {
+	actual := props.SubRole
+	if actual == nil || expected != *actual {
 		t.Errorf("set subrole worker, expected: %s, actual: %v", expected, actual)
 	}
 
 	// test set to same value
-	modified = setSubRole(expected, csmProps)
+	modified = setSubRole(expected, props)
 	if modified {
 		t.Errorf("set subrole to same value, modified should be false")
 	}
-	actual = csmProps["SubRole"]
-	if expected != actual {
+	actual = props.SubRole
+	if actual == nil || expected != *actual {
 		t.Errorf("set subrole to same value, expected: %s, actual: %v", expected, actual)
 	}
 
 	// test set to new value
 	expected = "Storage"
-	modified = setSubRole(expected, csmProps)
+	modified = setSubRole(expected, props)
 	if !modified {
 		t.Errorf("set subrole Storage, modified should be true")
 	}
-	actual = csmProps["SubRole"]
-	if expected != actual {
+	actual = props.SubRole
+	if actual == nil || expected != *actual {
 		t.Errorf("set subrole Storage, expected: %s, actual: %v", expected, actual)
 	}
 
 	// set back to empty
-	modified = setSubRole("", csmProps)
+	modified = setSubRole("", props)
 	if !modified {
 		t.Errorf("set back to empty subrole, modified should be true")
 	}
-	actual = csmProps["SubRole"]
+	actual = props.SubRole
 	if actual != nil {
 		t.Errorf("set subrole Storage, expected: nil, actual: %v", actual)
 	}
 }
 
 func TestSetNid(t *testing.T) {
-	csmProps := make(map[string]interface{})
+	props := &NodeMetadata{}
 
 	// test empty value
-	modified, err := setNid("", csmProps)
+	modified, err := setNid("", props)
 	if err != nil {
 		t.Errorf("set empty nid, unexpected error: %v", err)
 	}
@@ -176,87 +209,88 @@ func TestSetNid(t *testing.T) {
 	}
 
 	// Test good value
-	var expected float64 = 42
-	modified, err = setNid("42", csmProps)
+	expected := 42
+	modified, err = setNid("42", props)
 	if err != nil {
 		t.Errorf("set nid, unexpected error: %v", err)
 	}
 	if !modified {
 		t.Errorf("set nid, modified should be true")
 	}
-	actual := csmProps["Nid"]
-	if actual != expected {
+	actual := props.Nid
+	if actual == nil || *actual != expected {
 		t.Errorf("set nid, expected: %v, actual: %v", expected, actual)
 	}
 
 	// Test same value
-	modified, err = setNid("42", csmProps)
+	modified, err = setNid("42", props)
 	if err != nil {
 		t.Errorf("set nid to same value, unexpected error: %v", err)
 	}
 	if modified {
 		t.Errorf("set nid to same value, modified should be false")
 	}
-	actual = csmProps["Nid"]
-	if actual != expected {
+	actual = props.Nid
+	if actual == nil || *actual != expected {
 		t.Errorf("set nid to same value, expected: %v, actual: %v", expected, actual)
 	}
 
 	// Test bad value
-	modified, err = setNid("42.42", csmProps)
+	modified, err = setNid("42.42", props)
 	if err == nil {
 		t.Errorf("set nid to bad value, expected to get an error: %v", err)
 	}
 	if modified {
 		t.Errorf("set nid to bad value, modified should be false")
 	}
-	actual = csmProps["Nid"]
-	if actual != expected {
+	actual = props.Nid
+	if actual == nil || *actual != expected {
 		t.Errorf("set nid to bad value, expected: %v, actual: %v", expected, actual)
 	}
 
 	// Test new value
 	expected = 3
-	modified, err = setNid("3", csmProps)
+	modified, err = setNid("3", props)
 	if err != nil {
 		t.Errorf("set nid to new value, unexpected error: %v", err)
 	}
 	if !modified {
 		t.Errorf("set nid to new value, modified should be true")
 	}
-	actual = csmProps["Nid"]
-	if actual != expected {
+	actual = props.Nid
+	if actual == nil || *actual != expected {
 		t.Errorf("set nid to new value, expected: %v, actual: %v", expected, actual)
+	}
+
+	// test empty value
+	modified, err = setNid("", props)
+	if err != nil {
+		t.Errorf("set nid back to empty, unexpected error: %v", err)
+	}
+	if !modified {
+		t.Errorf("set nid back to empty, modified should be true")
+	}
+	if props.Nid != nil {
+		t.Errorf("set nid back to empty, expected: nil, actual: %v", *props.Nid)
 	}
 }
 
 func TestSetAlias(t *testing.T) {
-	csmProps := make(map[string]interface{})
-	var hw inventory.Hardware
+	props := &NodeMetadata{}
 
 	// Test empty alias
-	modified, err := setAlias("", csmProps, &hw)
-	if err != nil {
-		t.Errorf("set empty alias, unexpected error: %v", err)
-	}
+	modified := setAlias("", props)
 	if modified {
 		t.Errorf("set empty alias, modified should be false")
 	}
 
 	// Test alias
 	expected := "rabbit"
-	modified, err = setAlias(expected, csmProps, &hw)
-	if err != nil {
-		t.Errorf("set alias, unexpected error: %v", err)
-	}
+	modified = setAlias(expected, props)
 	if !modified {
 		t.Errorf("set alias, modified should be true")
 	}
-	actualRaw := csmProps["Alias"]
-	actual, ok := actualRaw.([]interface{})
-	if !ok {
-		t.Errorf("set alias, expected alias to be []interface{}, alias: %v, type: %T", actualRaw, actualRaw)
-	}
+	actual := props.Alias
 	if len(actual) != 1 {
 		t.Errorf("set alias, expected length: %d, actual length: %d", 1, len(actual))
 	} else if actual[0] != expected {
@@ -264,18 +298,11 @@ func TestSetAlias(t *testing.T) {
 	}
 
 	// Test same alias
-	modified, err = setAlias(expected, csmProps, &hw)
-	if err != nil {
-		t.Errorf("set same alias, unexpected error: %v", err)
-	}
+	modified = setAlias(expected, props)
 	if modified {
 		t.Errorf("set same alias, modified should be false")
 	}
-	actualRaw = csmProps["Alias"]
-	actual, ok = actualRaw.([]interface{})
-	if !ok {
-		t.Errorf("set same alias, expected alias to be []interface{}, alias: %v, type: %T", actualRaw, actualRaw)
-	}
+	actual = props.Alias
 	if len(actual) != 1 {
 		t.Errorf("set same alias, expected length: %d, actual length: %d", 1, len(actual))
 	} else if actual[0] != expected {
@@ -284,18 +311,11 @@ func TestSetAlias(t *testing.T) {
 
 	// Test new alias
 	expected = "squirrel"
-	modified, err = setAlias(expected, csmProps, &hw)
-	if err != nil {
-		t.Errorf("set new alias, unexpected error: %v", err)
-	}
+	modified = setAlias(expected, props)
 	if !modified {
 		t.Errorf("set new alias, modified should be true")
 	}
-	actualRaw = csmProps["Alias"]
-	actual, ok = actualRaw.([]interface{})
-	if !ok {
-		t.Errorf("set new alias, expected alias to be []interface{}, alias: %v, type: %T", actualRaw, actualRaw)
-	}
+	actual = props.Alias
 	if len(actual) != 1 {
 		t.Errorf("set new alias, expected length: %d, actual length: %d", 1, len(actual))
 	} else if actual[0] != expected {
@@ -303,23 +323,16 @@ func TestSetAlias(t *testing.T) {
 	}
 
 	// Test multiple aliases
-	expectedAliases := make([]interface{}, 0)
+	expectedAliases := make([]string, 0)
 	expectedAliases = append(expectedAliases, "fish")
 	expectedAliases = append(expectedAliases, "bird")
-	csmProps["Alias"] = expectedAliases
+	props.Alias = expectedAliases
 	expected = "pig"
-	modified, err = setAlias(expected, csmProps, &hw)
-	if err != nil {
-		t.Errorf("set alias on multiple aliases, unexpected error: %v", err)
-	}
+	modified = setAlias(expected, props)
 	if !modified {
 		t.Errorf("set alias on multiple aliases, modified should be true")
 	}
-	actualRaw = csmProps["Alias"]
-	actual, ok = actualRaw.([]interface{})
-	if !ok {
-		t.Errorf("set alias on multiple aliases, expected alias to be []interface{}, alias: %v, type: %T", actualRaw, actualRaw)
-	}
+	actual = props.Alias
 	if len(actual) != 2 {
 		t.Errorf("set alias, expected length: %d, actual length: %d, aliases: %v", 1, len(actual), actual)
 	} else if actual[0] != expected || actual[1] != "bird" {

--- a/internal/provider/csm/import.go
+++ b/internal/provider/csm/import.go
@@ -41,6 +41,7 @@ import (
 	"github.com/Cray-HPE/cani/internal/provider/csm/sls"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	hsm_client "github.com/Cray-HPE/cani/pkg/hsm-client"
+	"github.com/Cray-HPE/cani/pkg/pointers"
 	sls_client "github.com/Cray-HPE/cani/pkg/sls-client"
 	"github.com/Cray-HPE/hms-xname/xnames"
 	"github.com/Cray-HPE/hms-xname/xnametypes"
@@ -276,7 +277,7 @@ func (csm *CSM) Import(ctx context.Context, datastore inventory.Datastore) error
 			// Set cabinet metadata
 			cabinetMetadata := CabinetMetadata{}
 			if vlan, exists := cabinetHMNVlans[slsCabinet.Xname]; exists {
-				cabinetMetadata.HMNVlan = IntPtr(vlan)
+				cabinetMetadata.HMNVlan = pointers.IntPtr(vlan)
 			}
 
 			cCabinet, err = tempDatastore.GetAtLocation(locationPath)
@@ -594,15 +595,15 @@ func (csm *CSM) Import(ctx context.Context, datastore inventory.Datastore) error
 
 		nodeMetadata := NodeMetadata{}
 		if slsNodeEP.Role != "" {
-			nodeMetadata.Role = StringPtr(slsNodeEP.Role)
+			nodeMetadata.Role = pointers.StringPtr(slsNodeEP.Role)
 		}
 
 		if slsNodeEP.SubRole != "" {
-			nodeMetadata.Role = StringPtr(slsNodeEP.SubRole)
+			nodeMetadata.Role = pointers.StringPtr(slsNodeEP.SubRole)
 		}
 
 		if slsNodeEP.NID != 0 {
-			nodeMetadata.Nid = IntPtr(int(slsNodeEP.NID))
+			nodeMetadata.Nid = pointers.IntPtr(int(slsNodeEP.NID))
 		}
 
 		if len(slsNodeEP.Aliases) != 0 {

--- a/internal/provider/csm/metadata.go
+++ b/internal/provider/csm/metadata.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
+	"github.com/Cray-HPE/cani/pkg/pointers"
 	"github.com/mitchellh/mapstructure"
 	"github.com/rs/zerolog/log"
 )
@@ -71,14 +72,6 @@ type NodeMetadataStrings struct {
 
 type CabinetMetadata struct {
 	HMNVlan *int `json:"HMNVlan" mapstructure:"HMNVlan"`
-}
-
-// TODO this might need a better home
-func StringPtr(s string) *string {
-	return &s
-}
-func IntPtr(i int) *int {
-	return &i
 }
 
 // DecodeProviderMetadata return a Metadata structure from the given hardwares CSM Provider properties.
@@ -157,7 +150,7 @@ func (csm *CSM) BuildHardwareMetadata(cHardware *inventory.Hardware, rawProperti
 			if vlanIDRaw == nil {
 				metadata.Cabinet.HMNVlan = nil
 			} else {
-				metadata.Cabinet.HMNVlan = IntPtr(vlanIDRaw.(int))
+				metadata.Cabinet.HMNVlan = pointers.IntPtr(vlanIDRaw.(int))
 			}
 		}
 	case hardwaretypes.Node:
@@ -172,21 +165,21 @@ func (csm *CSM) BuildHardwareMetadata(cHardware *inventory.Hardware, rawProperti
 			if roleRaw == nil {
 				metadata.Node.Role = nil
 			} else {
-				metadata.Node.Role = StringPtr(roleRaw.(string))
+				metadata.Node.Role = pointers.StringPtr(roleRaw.(string))
 			}
 		}
 		if subroleRaw, exists := rawProperties[ProviderPropertySubRole]; exists {
 			if subroleRaw == nil {
 				metadata.Node.SubRole = nil
 			} else {
-				metadata.Node.SubRole = StringPtr(subroleRaw.(string))
+				metadata.Node.SubRole = pointers.StringPtr(subroleRaw.(string))
 			}
 		}
 		if nidRaw, exists := rawProperties[ProviderPropertyNID]; exists {
 			if nidRaw == nil {
 				metadata.Node.Nid = nil
 			} else {
-				metadata.Node.Nid = IntPtr(nidRaw.(int))
+				metadata.Node.Nid = pointers.IntPtr(nidRaw.(int))
 			}
 		}
 		if aliasRaw, exists := rawProperties[ProviderPropertyAlias]; exists {
@@ -323,33 +316,15 @@ func nextAvailableInt(s []int, offset int) int {
 }
 
 func (nm *NodeMetadata) Pretty() (prettyNm NodeMetadataStrings) {
-	var role, subrole, nid string
-	var alias []string
-	if nm.Role == nil {
-		role = ""
-	} else {
-		role = *nm.Role
-	}
-	if nm.SubRole == nil {
-		subrole = ""
-	} else {
-		subrole = *nm.SubRole
-	}
-	if nm.Alias == nil {
-		alias = []string{}
-	} else {
+	alias := []string{}
+	if nm.Alias != nil {
 		alias = nm.Alias
 	}
-	if nm.Nid == nil {
-		nid = ""
-	} else {
-		nid = fmt.Sprint(*nm.Nid)
+
+	return NodeMetadataStrings{
+		Role:    pointers.StrPtrToStr(nm.Role),
+		SubRole: pointers.StrPtrToStr(nm.SubRole),
+		Alias:   alias,
+		Nid:     pointers.IntPtrToStr(nm.Nid),
 	}
-
-	prettyNm.Role = role
-	prettyNm.SubRole = subrole
-	prettyNm.Nid = nid
-	prettyNm.Alias = alias
-
-	return prettyNm
 }

--- a/internal/provider/csm/metadata.go
+++ b/internal/provider/csm/metadata.go
@@ -39,11 +39,11 @@ import (
 )
 
 const (
-	ProviderPropertyVlanId  = "VlanID"
-	ProviderPropertyRole    = "Role"
-	ProviderPropertySubRole = "SubRole"
-	ProviderPropertyAlias   = "Alias"
-	ProviderPropertyNID     = "NID"
+	ProviderMetadataVlanId  = "VlanID"
+	ProviderMetadataRole    = "Role"
+	ProviderMetadataSubRole = "SubRole"
+	ProviderMetadataAlias   = "Alias"
+	ProviderMetadataNID     = "NID"
 )
 
 // NOTE: When adding new Metadata structure make sure to add them to the MetadataStructTagSuite test suite
@@ -137,7 +137,7 @@ func (csm *CSM) BuildHardwareMetadata(cHardware *inventory.Hardware, rawProperti
 
 		// Make changes to the node metadata
 		// The keys of rawProperties need to match what is defined in ./cmd/cabinet/add_cabinet.go
-		if vlanIDRaw, exists := rawProperties[ProviderPropertyVlanId]; exists {
+		if vlanIDRaw, exists := rawProperties[ProviderMetadataVlanId]; exists {
 			// Check if the VLAN exceeds the valid range for the hardware
 			max, err := DetermineEndingVlanFromSlug(cHardware.DeviceTypeSlug, *csm.hardwareLibrary)
 			if err != nil {
@@ -161,28 +161,28 @@ func (csm *CSM) BuildHardwareMetadata(cHardware *inventory.Hardware, rawProperti
 
 		// Make changes to the node metadata
 		// The keys of rawProperties need to match what is defined in ./cmd/node/update_node.go
-		if roleRaw, exists := rawProperties[ProviderPropertyRole]; exists {
+		if roleRaw, exists := rawProperties[ProviderMetadataRole]; exists {
 			if roleRaw == nil {
 				metadata.Node.Role = nil
 			} else {
 				metadata.Node.Role = pointers.StringPtr(roleRaw.(string))
 			}
 		}
-		if subroleRaw, exists := rawProperties[ProviderPropertySubRole]; exists {
+		if subroleRaw, exists := rawProperties[ProviderMetadataSubRole]; exists {
 			if subroleRaw == nil {
 				metadata.Node.SubRole = nil
 			} else {
 				metadata.Node.SubRole = pointers.StringPtr(subroleRaw.(string))
 			}
 		}
-		if nidRaw, exists := rawProperties[ProviderPropertyNID]; exists {
+		if nidRaw, exists := rawProperties[ProviderMetadataNID]; exists {
 			if nidRaw == nil {
 				metadata.Node.Nid = nil
 			} else {
 				metadata.Node.Nid = pointers.IntPtr(nidRaw.(int))
 			}
 		}
-		if aliasRaw, exists := rawProperties[ProviderPropertyAlias]; exists {
+		if aliasRaw, exists := rawProperties[ProviderMetadataAlias]; exists {
 			if aliasRaw == nil {
 				metadata.Node.Alias = nil
 			} else {
@@ -286,7 +286,7 @@ func (csm *CSM) RecommendCabinet(inv inventory.Inventory, deviceTypeSlug string)
 	// set the provider metadata
 	recommended.ProviderMetadata = map[string]interface{}{
 		// there are no vlans yet, and presumably no cabinets, so set it to 1
-		ProviderPropertyVlanId: chosenVlan,
+		ProviderMetadataVlanId: chosenVlan,
 	}
 
 	// return the recommendations

--- a/internal/provider/csm/metadata_test.go
+++ b/internal/provider/csm/metadata_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
+	"github.com/Cray-HPE/cani/pkg/pointers"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 )
@@ -171,7 +172,7 @@ func (suite *BuildHardwareMetadataTestSuite) TestCabinet() {
 
 	expectedMetadata := Metadata{
 		Cabinet: &CabinetMetadata{
-			HMNVlan: IntPtr(1234),
+			HMNVlan: pointers.IntPtr(1234),
 		},
 	}
 	suite.EqualValues(expectedMetadata, csmMetadata)
@@ -196,7 +197,7 @@ type EncodeProviderMetadataTestSuite struct {
 func (suite *EncodeProviderMetadataTestSuite) TestCabinet() {
 	metadata := Metadata{
 		Cabinet: &CabinetMetadata{
-			HMNVlan: IntPtr(4321),
+			HMNVlan: pointers.IntPtr(4321),
 		},
 	}
 
@@ -205,7 +206,7 @@ func (suite *EncodeProviderMetadataTestSuite) TestCabinet() {
 
 	expectedMetadata := map[string]interface{}{
 		"Cabinet": map[string]interface{}{
-			"HMNVlan": IntPtr(4321),
+			"HMNVlan": pointers.IntPtr(4321),
 		},
 	}
 	suite.EqualValues(expectedMetadata, metadataRaw)
@@ -214,9 +215,9 @@ func (suite *EncodeProviderMetadataTestSuite) TestCabinet() {
 func (suite *EncodeProviderMetadataTestSuite) TestNode() {
 	metadata := Metadata{
 		Node: &NodeMetadata{
-			Role:    StringPtr("Management"),
-			SubRole: StringPtr("Worker"),
-			Nid:     IntPtr(10000),
+			Role:    pointers.StringPtr("Management"),
+			SubRole: pointers.StringPtr("Worker"),
+			Nid:     pointers.IntPtr(10000),
 			Alias: []string{
 				"ncn-w001",
 			},
@@ -228,9 +229,9 @@ func (suite *EncodeProviderMetadataTestSuite) TestNode() {
 
 	expectedMetadata := map[string]interface{}{
 		"Node": map[string]interface{}{
-			"Role":    StringPtr("Management"),
-			"SubRole": StringPtr("Worker"),
-			"Nid":     IntPtr(10000),
+			"Role":    pointers.StringPtr("Management"),
+			"SubRole": pointers.StringPtr("Worker"),
+			"Nid":     pointers.IntPtr(10000),
 			"Alias": []string{
 				"ncn-w001",
 			},

--- a/internal/provider/csm/metadata_test.go
+++ b/internal/provider/csm/metadata_test.go
@@ -1,0 +1,245 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package csm
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Cray-HPE/cani/internal/inventory"
+	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/suite"
+)
+
+type MetadataStructTagSuite struct {
+	suite.Suite
+
+	structuresUnderTest []interface{}
+}
+
+func (suite *MetadataStructTagSuite) SetupSuite() {
+	suite.structuresUnderTest = []interface{}{
+		Metadata{},
+		NodeMetadata{},
+		CabinetMetadata{},
+	}
+}
+
+func (suite *MetadataStructTagSuite) verifyUniqueStructTags(structure interface{}, tagName string) {
+	for _, structure := range suite.structuresUnderTest {
+		suite.T().Logf("Validating structure: %T", structure)
+
+		foundTagValues := map[string]bool{}
+
+		// Iterate over the fields of the structure to find all tags with name
+		structType := reflect.TypeOf(structure)
+		for i := 0; i < structType.NumField(); i++ {
+			field := structType.Field(i)
+			suite.T().Logf("Checking field: %v", field.Name)
+
+			// Verify tag exists
+			tagValue, exists := field.Tag.Lookup("json")
+			suite.Truef(exists, "Structure %T is missing %s struct tag on field %v", structure, tagName, field)
+			if !exists {
+				continue
+			}
+			tagValue = strings.TrimSuffix(tagValue, ",omitempty")
+
+			// Check for duplicates
+			if _, exists := foundTagValues[tagValue]; exists {
+				suite.Fail(fmt.Sprintf("Structure %T has a non-unique %s struct tag value of %v", structure, tagName, tagValue))
+			}
+			foundTagValues[tagValue] = true
+		}
+	}
+}
+
+func (suite *MetadataStructTagSuite) TestVerifyUniqueJSONTags() {
+	for _, structure := range suite.structuresUnderTest {
+		suite.T().Logf("Validating structure: %T", structure)
+		suite.verifyUniqueStructTags(structure, "json")
+	}
+}
+
+func (suite *MetadataStructTagSuite) TestVerifyUniqueMapstructureTags() {
+	for _, structure := range suite.structuresUnderTest {
+		suite.verifyUniqueStructTags(structure, "mapstructure")
+	}
+}
+
+func (suite *MetadataStructTagSuite) TestVerifyJSONMapstructureTagsMatch() {
+	for _, structure := range suite.structuresUnderTest {
+		// Iterate over the fields of the structure to find all tags with name
+		structType := reflect.TypeOf(structure)
+		for i := 0; i < structType.NumField(); i++ {
+			field := structType.Field(i)
+			suite.T().Logf("Checking field: %v", field.Name)
+
+			// Grab JSON tag value
+			jsonTagValue, exists := field.Tag.Lookup("json")
+			suite.Truef(exists, "Structure %T is missing json struct tag on field %v", structure, field)
+			if !exists {
+				continue
+			}
+			jsonTagValue = strings.TrimSuffix(jsonTagValue, ",omitempty")
+
+			// Grab the mapstructure tag
+			mapstructTagValue, exists := field.Tag.Lookup("mapstructure")
+			suite.Truef(exists, "Structure %T is missing mapstructure struct tag on field %v", structure, field)
+			if !exists {
+				continue
+			}
+			mapstructTagValue = strings.TrimSuffix(mapstructTagValue, ",omitempty")
+
+			// Verify they are the same
+			suite.Equal(jsonTagValue, mapstructTagValue, "Structure %T has mis-match json/mapstructure tag values on field %v")
+		}
+	}
+}
+
+func TestMetadataStructTagSuite(t *testing.T) {
+	suite.Run(t, new(MetadataStructTagSuite))
+}
+
+type BuildHardwareMetadataTestSuite struct {
+	suite.Suite
+
+	csm *CSM
+}
+
+func (suite *BuildHardwareMetadataTestSuite) SetupSuite() {
+	hardwareTypeLibrary, err := hardwaretypes.NewEmbeddedLibrary()
+	suite.NoError(err)
+
+	// Stand up a minimal CSM provider to run BuildHardwareMetadata
+	suite.csm = &CSM{
+		hardwareLibrary: hardwareTypeLibrary,
+	}
+}
+
+func (suite *BuildHardwareMetadataTestSuite) TestCabinet() {
+	rawProperties := map[string]interface{}{
+		ProviderPropertyVlanId: 1234,
+	}
+
+	hardware := inventory.Hardware{
+		ID:             uuid.New(),
+		Type:           hardwaretypes.Cabinet,
+		DeviceTypeSlug: "hpe-ex4000",
+		Vendor:         "HPE",
+		Model:          "EX4000",
+		Status:         inventory.HardwareStatusStaged,
+	}
+
+	err := suite.csm.BuildHardwareMetadata(&hardware, rawProperties)
+	suite.NoError(err)
+
+	suite.NotNil(hardware.ProviderMetadata)
+	suite.Contains(hardware.ProviderMetadata, inventory.CSMProvider, "CSM Metadata is missing from cabinet")
+
+	csmMetadata, err := DecodeProviderMetadata(hardware)
+	suite.NoError(err)
+
+	suite.Nil(csmMetadata.Node, "Cabinet has Node metadata set")
+	suite.NotNil(csmMetadata.Cabinet, "Cabinet is missing node metadata")
+
+	expectedMetadata := Metadata{
+		Cabinet: &CabinetMetadata{
+			HMNVlan: IntPtr(1234),
+		},
+	}
+	suite.EqualValues(expectedMetadata, csmMetadata)
+}
+
+func (suite *BuildHardwareMetadataTestSuite) TestNode() {
+
+}
+
+func (suite *BuildHardwareMetadataTestSuite) TestNodeUpdateOneFieldExistingData() {
+
+}
+
+func TestBuildHardwareMetadataTestSuite(t *testing.T) {
+	suite.Run(t, new(BuildHardwareMetadataTestSuite))
+}
+
+type EncodeProviderMetadataTestSuite struct {
+	suite.Suite
+}
+
+func (suite *EncodeProviderMetadataTestSuite) TestCabinet() {
+	metadata := Metadata{
+		Cabinet: &CabinetMetadata{
+			HMNVlan: IntPtr(4321),
+		},
+	}
+
+	metadataRaw, err := EncodeProviderMetadata(metadata)
+	suite.NoError(err)
+
+	expectedMetadata := map[string]interface{}{
+		"Cabinet": map[string]interface{}{
+			"HMNVlan": IntPtr(4321),
+		},
+	}
+	suite.EqualValues(expectedMetadata, metadataRaw)
+}
+
+func (suite *EncodeProviderMetadataTestSuite) TestNode() {
+	metadata := Metadata{
+		Node: &NodeMetadata{
+			Role:    StringPtr("Management"),
+			SubRole: StringPtr("Worker"),
+			Nid:     IntPtr(10000),
+			Alias: []string{
+				"ncn-w001",
+			},
+		},
+	}
+
+	metadataRaw, err := EncodeProviderMetadata(metadata)
+	suite.NoError(err)
+
+	expectedMetadata := map[string]interface{}{
+		"Node": map[string]interface{}{
+			"Role":    StringPtr("Management"),
+			"SubRole": StringPtr("Worker"),
+			"Nid":     IntPtr(10000),
+			"Alias": []string{
+				"ncn-w001",
+			},
+			"AdditionalProperties": map[string]interface{}(nil),
+		},
+	}
+	suite.EqualValues(expectedMetadata, metadataRaw)
+}
+
+func TestEncodeProviderMetadataTestSuite(t *testing.T) {
+	suite.Run(t, new(EncodeProviderMetadataTestSuite))
+}

--- a/internal/provider/csm/metadata_test.go
+++ b/internal/provider/csm/metadata_test.go
@@ -146,7 +146,7 @@ func (suite *BuildHardwareMetadataTestSuite) SetupSuite() {
 
 func (suite *BuildHardwareMetadataTestSuite) TestCabinet() {
 	rawProperties := map[string]interface{}{
-		ProviderPropertyVlanId: 1234,
+		ProviderMetadataVlanId: 1234,
 	}
 
 	hardware := inventory.Hardware{

--- a/internal/provider/csm/reconcile.go
+++ b/internal/provider/csm/reconcile.go
@@ -471,17 +471,17 @@ func reconcileNetworkChanges(datastore inventory.Datastore, hardwareTypeLibrary 
 
 	// Allocate Node IPs
 	for _, node := range sortByLocationPath(allHardware.FilterHardwareByTypeStatus(inventory.HardwareStatusStaged, hardwaretypes.Node)) {
-		providerProperties, err := GetProviderMetadataT[NodeMetadata](node)
+		providerMetadata, err := DecodeProviderMetadata(node)
 		if err != nil {
 			return nil, errors.Join(fmt.Errorf("failed to get provider properties for node (%s)", node.ID), err)
 		}
 
 		var role, subRole string
-		if providerProperties.Role != nil {
-			role = *providerProperties.Role
+		if providerMetadata.Node.Role != nil {
+			role = *providerMetadata.Node.Role
 		}
-		if providerProperties.SubRole != nil {
-			subRole = *providerProperties.SubRole
+		if providerMetadata.Node.SubRole != nil {
+			subRole = *providerMetadata.Node.SubRole
 		}
 
 		switch role {
@@ -505,17 +505,17 @@ func reconcileNetworkChanges(datastore inventory.Datastore, hardwareTypeLibrary 
 
 	// Deallocate  Node IPs
 	for _, node := range allHardware.FilterHardwareByTypeStatus(inventory.HardwareStatusStaged, hardwaretypes.Node) {
-		providerProperties, err := GetProviderMetadataT[NodeMetadata](node)
+		providerMetadata, err := DecodeProviderMetadata(node)
 		if err != nil {
 			return nil, errors.Join(fmt.Errorf("failed to get provider properties for node (%s)", node.ID), err)
 		}
 
 		var role, subRole string
-		if providerProperties.Role != nil {
-			role = *providerProperties.Role
+		if providerMetadata.Node.Role != nil {
+			role = *providerMetadata.Node.Role
 		}
-		if providerProperties.SubRole != nil {
-			subRole = *providerProperties.SubRole
+		if providerMetadata.Node.SubRole != nil {
+			subRole = *providerMetadata.Node.SubRole
 		}
 
 		switch role {

--- a/internal/provider/csm/sls_state_generator.go
+++ b/internal/provider/csm/sls_state_generator.go
@@ -378,7 +378,7 @@ func BuildSLSHardware(cHardware inventory.Hardware, locationPath inventory.Locat
 		// Not represented in SLS
 		return sls_client.Hardware{}, nil
 	case hardwaretypes.Node:
-		metadata, err := GetProviderMetadataT[NodeMetadata](cHardware)
+		metadata, err := DecodeProviderMetadata(cHardware)
 		if err != nil {
 			return sls_client.Hardware{}, errors.Join(
 				fmt.Errorf("failed to get provider metadata from hardware (%s)", cHardware.ID),
@@ -393,7 +393,7 @@ func BuildSLSHardware(cHardware inventory.Hardware, locationPath inventory.Locat
 		nodeExtraProperties.CaniLastModified = time.Now().UTC().String()
 
 		// Logical metadata
-		if metadata != nil {
+		if metadata.Node != nil {
 
 			// In order to properly populate SLS several bits of information are required.
 			// This information should have been collected when hardware was added to the inventory
@@ -401,17 +401,17 @@ func BuildSLSHardware(cHardware inventory.Hardware, locationPath inventory.Locat
 			// - SubRole
 			// - NID
 			// - Alias/Common Name
-			if metadata.Role != nil {
-				nodeExtraProperties.Role = *metadata.Role
+			if metadata.Node.Role != nil {
+				nodeExtraProperties.Role = *metadata.Node.Role
 			}
-			if metadata.SubRole != nil {
-				nodeExtraProperties.Role = *metadata.SubRole
+			if metadata.Node.SubRole != nil {
+				nodeExtraProperties.Role = *metadata.Node.SubRole
 			}
-			if metadata.Nid != nil {
-				nodeExtraProperties.NID = int32(*metadata.Nid)
+			if metadata.Node.Nid != nil {
+				nodeExtraProperties.NID = int32(*metadata.Node.Nid)
 			}
-			if metadata.Alias != nil {
-				nodeExtraProperties.Aliases = metadata.Alias
+			if metadata.Node.Alias != nil {
+				nodeExtraProperties.Aliases = metadata.Node.Alias
 			}
 
 			log.Info().Any("nodeEp", nodeExtraProperties).Msgf("Generated Extra Properties for %s", xname.String())

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -51,15 +51,18 @@ type InventoryProvider interface {
 	// Reconcile CANI's inventory state with the external inventory state and apply required changes
 	Reconcile(ctx context.Context, datastore inventory.Datastore, dryrun bool) error
 
+	// RecommendCabinet returns recommended settings for adding a cabinet
+	RecommendCabinet(inv inventory.Inventory, deviceTypeSlug string) (HardwareRecommendations, error)
+
+	//
+	// Provider Hardware Metadata
+	//
+
 	// Build metadata, and add ito the hardware object
 	// This function could return the data to put into object
 	BuildHardwareMetadata(hw *inventory.Hardware, rawProperties map[string]interface{}) error
 
-	// RecommendCabinet returns recommended settings for adding a cabinet
-	RecommendCabinet(inv inventory.Inventory, deviceTypeSlug string) (HardwareRecommendations, error)
-
 	GetFields(hw *inventory.Hardware, fieldNames []string) (values []string, err error)
-
 	SetFields(hw *inventory.Hardware, values map[string]string) (result SetFieldsResult, err error)
 }
 

--- a/pkg/pointers/pointers.go
+++ b/pkg/pointers/pointers.go
@@ -1,0 +1,52 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package pointers
+
+import "fmt"
+
+func IntPtrToStr(in *int) string {
+	if in == nil {
+		return ""
+	}
+
+	return fmt.Sprintf("%d", *in)
+}
+
+func StrPtrToStr(in *string) string {
+	if in == nil {
+		return ""
+	}
+
+	return *in
+}
+
+func StringPtr(s string) *string {
+	return &s
+}
+
+func IntPtr(i int) *int {
+	return &i
+}


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

Performed some refactoring with how ProviderMetadata is handled.
- There is a top level structure in the CSM package called Metadata that is composed of the Node and Cabinet structures.
    - Removed CSM hardware structure as it basically became `csm.Metadata`
- Renamed ProviderProperties to ProviderMetadata to align naming.
- Created enums for all supported provider metadata keys.
- There is always nil or map[string]interface{} in provider metadata. There are no structs ever
  - Added `DecodeProviderMetadata` and `EncodeProviderMetadata` to `csm` package. `GetProviderMetadata`  and `GetProviderMetadataT` were removed.
  - Calls to mapstructure in the cmd package were replaced with `csm.DecodeProviderMetadata`.-
-  `inventory.Hardware` changes 
   - Removed top level fields Role/SubRole/Alias from the `inventory.Hardware` structure, as they are duplicated with the provider metadata.
    - Added `SetProviderMetadata` method to `inventory.Hardware`
    - Change type of ProviderProperties/ProviderMetadata to `map[Provider]ProviderMetadataRaw` to force the type usage for this field.
- Created `pointers` package to help with dealing with pointer values.

Heavily relying on the automated testing provided by `make test` to verify things are ok after the refractor. 

Here is what a cabinet looks like in the canidb. Notice how Provider metadata is under a different key, and that the Cabinet properties are namespaced under CSM:
```json
{
  "ID": "fcbf7a07-c0a1-4f0c-a0ba-b126a1d78786",
  "Type": "Cabinet",
  "DeviceTypeSlug": "hpe-ex2000",
  "Vendor": "HPE",
  "Model": "EX2000",
  "Status": "staged",
  "ProviderMetadata": {
    "csm": {
      "Cabinet": {
        "HMNVlan": 3006
      }
    }
  },
  "Parent": "abcdef12-3456-2789-abcd-ef1234567890",
  "Children": [
    "40b53fec-bcb2-4b9c-b18c-3b4db7862bfa",
    "72dbfa6d-9b92-43bd-b2e2-d7eb4f70d1a8",
    "e278bbb6-2cab-4ba4-a91d-3a402c83f924"
  ],
  "LocationPath": [
    {
      "HardwareType": "System",
      "Ordinal": 0
    },
    {
      "HardwareType": "Cabinet",
      "Ordinal": 9006
    }
  ],
  "LocationOrdinal": 9006
}
```


# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

