### PR TITLE
Added support for standard in on csv import

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -74,7 +74,7 @@ func importAssets(cmd *cobra.Command, args []string) error {
 			return errors.New("missing the csv input. This can be either a file or standard input")
 		}
 	} else {
-		return errors.New("missing the csv input. This can be either a file or standard input")
+		return errors.New("too many arguments")
 	}
 
 	// Create a domain object to interact with the datastore


### PR DESCRIPTION

# Summary and Scope

Added support for standard in on csv import

These methods can be used to pass the csv data to the import command
    cat file.csv | cani alpha import
    cat file.csv | cani alpha import -
    cani alpha import file.csv




# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

