### PR TITLE
dont auto-generate release notes as they override github ones

### DIFF
--- a/.github/workflows/promote-prerelease.yml
+++ b/.github/workflows/promote-prerelease.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: ncipollo/release-action@v1
         with:
           allowUpdates: true # if the job is re-ran to catch missed artifacts, allow updates
-          generateReleaseNotes: true
+          generateReleaseNotes: false
           artifacts: ${{ env.DIR_UPLOAD }}/*
           prerelease: true
           makeLatest: false

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: ncipollo/release-action@v1
         with:
           allowUpdates: true # if the job is re-ran to catch missed artifacts, allow updates
-          generateReleaseNotes: true
+          generateReleaseNotes: false
           artifacts: ${{ env.DIR_UPLOAD }}/*
           prerelease: false
           makeLatest: true


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

When I made a release and the action worked, it overrode my GIthub generated notes, which are formatted nicer than the ones created by the action we are using to make the release.

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

