### PR TITLE
Added more network validation checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ unittest: bin
 	     github.com/Cray-HPE/cani/internal/provider/csm/ipam \
 	     github.com/Cray-HPE/cani/internal/provider/csm/sls \
 	     github.com/Cray-HPE/cani/internal/provider/csm/validate \
+	     github.com/Cray-HPE/cani/internal/provider/csm/validate/checks \
 	     github.com/Cray-HPE/cani/internal/provider/csm/validate/common
 
 spec: bin

--- a/internal/provider/csm/validate/checks/network_subnet_check.go
+++ b/internal/provider/csm/validate/checks/network_subnet_check.go
@@ -1,0 +1,249 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+package checks
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+
+	"github.com/Cray-HPE/cani/internal/provider/csm/validate/common"
+	sls_client "github.com/Cray-HPE/cani/pkg/sls-client"
+)
+
+const (
+	CidrConsistent   common.ValidationCheck = "cidr-consistent"
+	CidrValid        common.ValidationCheck = "cidr-valid"
+	CidrContainsCidr common.ValidationCheck = "cidr-contains-other-cidr"
+	CidrContainsIp   common.ValidationCheck = "cidr-contains-ip"
+	IpStartAndEnd    common.ValidationCheck = "ip-start-and-end"
+	VlanConflict     common.ValidationCheck = "vlan-conflict"
+	NameConflict     common.ValidationCheck = "name-conflict"
+)
+
+type NetworkSubnet struct {
+	Network     *sls_client.Network
+	Props       map[string]interface{}
+	Subnet      map[string]interface{}
+	ComponentId string
+	Cidr        string
+	CidrIpNet   *net.IPNet
+	SubnetCidr  string
+	SubnetName  string
+	Vlan        string
+}
+
+type NetworkSubnetCheck struct {
+	slsStateExtended *common.SlsStateExtended
+}
+
+func NewNetworkSubnetCheck(slsStateExtended *common.SlsStateExtended) *NetworkSubnetCheck {
+	networkSubnetCheck := NetworkSubnetCheck{
+		slsStateExtended: slsStateExtended,
+	}
+	return &networkSubnetCheck
+}
+
+func (c *NetworkSubnetCheck) Validate(results *common.ValidationResults) {
+	subnets := make([]NetworkSubnet, 0)
+	vlans := make(map[string][]*NetworkSubnet)
+	names := make(map[string][]*NetworkSubnet)
+	for name, network := range c.slsStateExtended.SlsState.Networks {
+		props, _ := common.GetMap(network.ExtraProperties)
+		s, _ := common.GetSliceOfMaps(props["Subnets"])
+		n := c.slsStateExtended.SlsState.Networks[name]
+		cidr := ""
+		if len(network.IPRanges) > 0 {
+			cidr = network.IPRanges[0]
+		}
+		subnetCidr, _ := common.GetString(props, "CIDR")
+		componentId := fmt.Sprintf("/Networks/%s", network.Name)
+		checkCidrConsistancy(results, componentId, network.Name, cidr, subnetCidr)
+		cidrIpNet := parseAndCheckCidr(results, componentId, network.Name, cidr)
+		for _, subnet := range s {
+			subnetName, _ := common.GetString(subnet, "Name")
+			subnetCidr, _ := common.GetString(subnet, "CIDR")
+			vlan, _ := common.GetString(subnet, "VlanID")
+			ns := NetworkSubnet{
+				Network:     &n,
+				Props:       props,
+				ComponentId: componentId,
+				Cidr:        cidr,
+				CidrIpNet:   cidrIpNet,
+				Subnet:      subnet,
+				SubnetName:  subnetName,
+				SubnetCidr:  subnetCidr,
+				Vlan:        vlan,
+			}
+			subnets = append(subnets, ns)
+			vlans[vlan] = append(vlans[vlan], &ns)
+			names[subnetName] = append(vlans[subnetName], &ns)
+		}
+	}
+
+	for _, subnet := range subnets {
+		switch subnet.Network.Name {
+		case "HMN_MTN":
+			fallthrough
+		case "HMN_RVR":
+			fallthrough
+		case "NMN_MTN":
+			fallthrough
+		case "HNN_RVR":
+			_, subnetCidrIpNet, err := net.ParseCIDR(subnet.SubnetCidr)
+			if err != nil {
+				results.Fail(
+					CidrValid,
+					subnet.ComponentId,
+					fmt.Sprintf("Invalid CIDR: %s, details: %v.", subnet.SubnetCidr, err))
+			}
+
+			checkDhcpStartAndEnd(results, &subnet, subnetCidrIpNet)
+			checkSubnetCidr(results, &subnet, subnetCidrIpNet)
+			checkVlanUniqueness(results, vlans, &subnet)
+			checkNameUniqueness(results, names, &subnet)
+		}
+	}
+}
+
+func parseAndCheckCidr(results *common.ValidationResults, componentId, networkName, cidr string) *net.IPNet {
+	if cidr != "" {
+		_, cidrIpNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			results.Fail(
+				CidrValid,
+				componentId,
+				fmt.Sprintf("Invalid CIDR: %s, details: %v.", cidr, err))
+		}
+		return cidrIpNet
+	}
+	return nil
+}
+
+func checkCidrConsistancy(results *common.ValidationResults, componentId, networkName, networkCidr, subnetCidr string) {
+	switch networkName {
+	case "HMN_MTN":
+		fallthrough
+	case "HMN_RVR":
+		fallthrough
+	case "NMN_MTN":
+		fallthrough
+	case "HNN_RVR":
+		if networkCidr == subnetCidr {
+			results.Pass(
+				CidrConsistent,
+				componentId,
+				fmt.Sprintf("In IPRanges the first value '%s' matches the CIDR '%s' in ExtraProperties.", networkCidr, subnetCidr))
+		} else {
+			results.Fail(
+				CidrConsistent,
+				componentId,
+				fmt.Sprintf("In IPRanges the first value '%s' does not match the CIDR '%s' in ExtraProperties.", networkCidr, subnetCidr))
+		}
+	}
+}
+
+func checkVlanUniqueness(results *common.ValidationResults, vlans map[string][]*NetworkSubnet, subnet *NetworkSubnet) {
+	if subnet.Vlan != "" {
+		vlanSubnets := vlans[subnet.Vlan]
+		if len(vlanSubnets) > 1 {
+			description := descriptionOfNetworkCidrs(vlanSubnets, subnet.Network.Name)
+			results.Fail(
+				VlanConflict,
+				subnet.ComponentId,
+				fmt.Sprintf("Vlan %s conflicts with a vlan in %s.", subnet.Vlan, description))
+		}
+	}
+}
+
+func checkNameUniqueness(results *common.ValidationResults, names map[string][]*NetworkSubnet, subnet *NetworkSubnet) {
+	if subnet.SubnetName != "" {
+		nameSubnets := names[subnet.SubnetName]
+		if len(nameSubnets) > 1 {
+			description := descriptionOfNetworkCidrs(nameSubnets, subnet.Network.Name)
+			results.Fail(
+				NameConflict,
+				subnet.ComponentId,
+				fmt.Sprintf("Subnet name %s conflicts with the names of these subnets %s.", subnet.Cidr, description))
+		}
+	}
+}
+
+// check that the subnet CIDR is contained in the ExtraProperties CIDR
+func checkSubnetCidr(results *common.ValidationResults, subnet *NetworkSubnet, subnetCidrIpNet *net.IPNet) {
+	if subnet.CidrIpNet != nil && subnetCidrIpNet != nil {
+		if !subnet.CidrIpNet.Contains(subnetCidrIpNet.IP) {
+			results.Fail(
+				CidrContainsCidr,
+				subnet.ComponentId,
+				fmt.Sprintf("CIDR: %s is not a sub CIDR of: %s.", subnet.SubnetCidr, subnet.Cidr))
+		}
+	}
+}
+
+func checkDhcpStartAndEnd(results *common.ValidationResults, subnet *NetworkSubnet, subnetCidrIpNet *net.IPNet) {
+	dhcpStart, _ := common.GetString(subnet.Subnet, "DHCPStart")
+	dhcpStartIp := net.ParseIP(dhcpStart)
+	if !subnetCidrIpNet.Contains(dhcpStartIp) {
+		results.Fail(
+			CidrContainsCidr,
+			subnet.ComponentId,
+			fmt.Sprintf("DHCPStart %s is not CIDR %s.", dhcpStart, subnet.SubnetCidr))
+	}
+
+	dhcpEnd, _ := common.GetString(subnet.Subnet, "DHCPEnd")
+	dhcpEndIp := net.ParseIP(dhcpEnd)
+	if !subnetCidrIpNet.Contains(dhcpEndIp) {
+		results.Fail(
+			CidrContainsCidr,
+			subnet.ComponentId,
+			fmt.Sprintf("DHCPEnd %s is not CIDR %s.", dhcpEnd, subnet.SubnetCidr))
+	}
+
+	if bytes.Compare(dhcpStartIp.To16(), dhcpEndIp.To16()) > 0 {
+		results.Fail(
+			IpStartAndEnd,
+			subnet.ComponentId,
+			fmt.Sprintf("DHCPStart %s is after DHCPEnd %s.", dhcpStart, dhcpEnd))
+	}
+}
+
+func descriptionOfNetworkCidrs(subnets []*NetworkSubnet, excludeNetwork ...string) string {
+	description := ""
+	haveAddedFirst := false
+	for _, subnet := range subnets {
+		if contains(subnet.Network.Name, excludeNetwork) {
+			continue
+		}
+		if haveAddedFirst {
+			description = description + ", "
+		}
+		description += fmt.Sprintf("%s %s", subnet.Network.Name, subnet.SubnetCidr)
+		haveAddedFirst = true
+	}
+	return description
+}

--- a/internal/provider/csm/validate/checks/network_subnet_check_test.go
+++ b/internal/provider/csm/validate/checks/network_subnet_check_test.go
@@ -1,0 +1,423 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+package checks
+
+import (
+	"net"
+	"testing"
+
+	"github.com/Cray-HPE/cani/internal/provider/csm/validate/common"
+	sls_client "github.com/Cray-HPE/cani/pkg/sls-client"
+)
+
+func TestParseAndCheckCidr(t *testing.T) {
+	componentId := "/Networks/NMN_RVR"
+	networkName := "NMN_RVR"
+
+	// test empty string
+	results := common.NewValidationResults()
+	cidr := ""
+	ipNet := parseAndCheckCidr(results, componentId, networkName, cidr)
+	if ipNet != nil {
+		t.Errorf("Expected nil for empty CIDR, CIDR net: %v", ipNet)
+	}
+	if len(results.GetResults()) != 0 {
+		t.Errorf("Expected empty results for an empty CIDR, results: %v", results.GetResults())
+	}
+
+	// test bad cidr
+	results = common.NewValidationResults()
+	cidr = "junk"
+	ipNet = parseAndCheckCidr(results, componentId, networkName, cidr)
+	if ipNet != nil {
+		t.Errorf("Expected nil for bad  CIDR: %s, CIDR net: %v", cidr, ipNet)
+	}
+	if len(results.GetResults()) != 1 {
+		t.Errorf("Expected one result for an bad CIDR: %s, results: %v", cidr, results.GetResults())
+	}
+
+	// test good cidr
+	results = common.NewValidationResults()
+	cidr = "10.106.0.0/22"
+	ipNet = parseAndCheckCidr(results, componentId, networkName, cidr)
+	if ipNet == nil {
+		t.Errorf("Expected nil for good CIDR, CIDR: %s, net: %v", cidr, ipNet)
+	}
+	if len(results.GetResults()) != 0 {
+		t.Errorf("Expected one result for an good CIDR: %s results: %v", cidr, results.GetResults())
+	}
+}
+
+func TestCheckCidrConsistancy(t *testing.T) {
+	// test matching cidr
+	results := common.NewValidationResults()
+	networkName := "HMN_MTN"
+	componentId := "/Networks/" + networkName
+	networkCidr := "10.106.0.0/22"
+	subnetCidr := "10.106.0.0/22"
+	checkCidrConsistancy(results, componentId, networkName, networkCidr, subnetCidr)
+	if len(results.GetResults()) != 1 {
+		t.Fatalf(
+			"Expected one result for name: %s, networkCidr: %s, subnetCidr: %s, results: %v",
+			networkName, networkCidr, subnetCidr, results.GetResults())
+	}
+	if results.GetResults()[0].Result != common.Pass {
+		t.Errorf(
+			"Expected passing result for name: %s, networkCidr: %s, subnetCidr: %s, result: %v",
+			networkName, networkCidr, subnetCidr, results.GetResults()[0])
+	}
+
+	// test cidrs that don't match
+	results = common.NewValidationResults()
+	networkName = "HMN_MTN"
+	componentId = "/Networks/" + networkName
+	networkCidr = "10.106.0.0/22"
+	subnetCidr = "10.106.0.0/21"
+	checkCidrConsistancy(results, componentId, networkName, networkCidr, subnetCidr)
+	if len(results.GetResults()) != 1 {
+		t.Fatalf(
+			"Expected one result for name: %s, networkCidr: %s, subnetCidr: %s, results: %v",
+			networkName, networkCidr, subnetCidr, results.GetResults())
+	}
+	if results.GetResults()[0].Result != common.Fail {
+		t.Errorf(
+			"Expected failing result for name: %s, networkCidr: %s, subnetCidr: %s, result: %v",
+			networkName, networkCidr, subnetCidr, results.GetResults()[0])
+	}
+
+	// test network type that is not checked by the checker
+	results = common.NewValidationResults()
+	networkName = "NMNLB"
+	componentId = "/Networks/" + networkName
+	networkCidr = "10.106.0.0/22"
+	subnetCidr = "10.106.0.0/22"
+	checkCidrConsistancy(results, componentId, networkName, networkCidr, subnetCidr)
+	if len(results.GetResults()) != 0 {
+		t.Errorf(
+			"Expected zero results for name: %s, networkCidr: %s, subnetCidr: %s, results: %v",
+			networkName, networkCidr, subnetCidr, results.GetResults())
+	}
+}
+
+func TestCheckVlanUniqueness(t *testing.T) {
+	// test with unique vlans
+	vlan := "1000"
+	vlan2 := "1001"
+	subnet := newNetworkSubnetWithVlan(vlan)
+	subnet2 := newNetworkSubnetWithVlan(vlan2)
+	vlans := make(map[string][]*NetworkSubnet)
+	vlans[vlan] = append(vlans[vlan], subnet)
+	vlans[vlan2] = append(vlans[vlan2], subnet2)
+	results := common.NewValidationResults()
+	checkVlanUniqueness(results, vlans, subnet)
+	if len(results.GetResults()) != 0 {
+		t.Fatalf(
+			"Expected zero results for vlan: %s, results: %v",
+			vlan, results.GetResults())
+	}
+
+	// test with conflicting vlans
+	vlan = "2000"
+	subnet = newNetworkSubnetWithVlan(vlan)
+	subnet2 = newNetworkSubnetWithVlan(vlan)
+	vlans = make(map[string][]*NetworkSubnet)
+	vlans[vlan] = append(vlans[vlan], subnet)
+	vlans[vlan] = append(vlans[vlan], subnet2)
+	results = common.NewValidationResults()
+	checkVlanUniqueness(results, vlans, subnet)
+	if len(results.GetResults()) != 1 {
+		t.Fatalf(
+			"Expected one result for conflicting vlans. vlan: %s, results: %v",
+			vlan, results.GetResults())
+	}
+	if results.GetResults()[0].Result != common.Fail {
+		t.Errorf(
+			"Expected failing result for conflicting vlans. vlan: %s, result: %v",
+			vlan, results.GetResults()[0])
+	}
+
+	// test with the vlan not in the map
+	vlan = "3000"
+	vlan2 = "3001"
+	subnet = newNetworkSubnetWithVlan(vlan)
+	subnet2 = newNetworkSubnetWithVlan(vlan2)
+	vlans = make(map[string][]*NetworkSubnet)
+	vlans[vlan2] = append(vlans[vlan2], subnet2)
+	results = common.NewValidationResults()
+	checkVlanUniqueness(results, vlans, subnet)
+	if len(results.GetResults()) != 0 {
+		t.Fatalf(
+			"Expected zero results for no mapped vlans. vlan: %s, results: %v",
+			vlan, results.GetResults())
+	}
+}
+
+func TestCheckNameUniqueness(t *testing.T) {
+	// test with unique names
+	name := "cabinet_1000"
+	name2 := "cabinet_1001"
+	subnet := newNetworkSubnetWithName(name)
+	subnet2 := newNetworkSubnetWithName(name2)
+	names := make(map[string][]*NetworkSubnet)
+	names[name] = append(names[name], subnet)
+	names[name2] = append(names[name2], subnet2)
+	results := common.NewValidationResults()
+	checkNameUniqueness(results, names, subnet)
+	if len(results.GetResults()) != 0 {
+		t.Fatalf(
+			"Expected zero results for name: %s, results: %v",
+			name, results.GetResults())
+	}
+
+	// test with conflicting names
+	name = "cabinet_2000"
+	subnet = newNetworkSubnetWithName(name)
+	subnet2 = newNetworkSubnetWithName(name)
+	names = make(map[string][]*NetworkSubnet)
+	names[name] = append(names[name], subnet)
+	names[name] = append(names[name], subnet2)
+	results = common.NewValidationResults()
+	checkNameUniqueness(results, names, subnet)
+	if len(results.GetResults()) != 1 {
+		t.Fatalf(
+			"Expected one result for conflicting names. name: %s, results: %v",
+			name, results.GetResults())
+	}
+	if results.GetResults()[0].Result != common.Fail {
+		t.Errorf(
+			"Expected failing result for conflicting names. name: %s, result: %v",
+			name, results.GetResults()[0])
+	}
+
+	// test with the name not in the map
+	name = "cabinet_3000"
+	name2 = "cabinet_3001"
+	subnet = newNetworkSubnetWithName(name)
+	subnet2 = newNetworkSubnetWithName(name2)
+	names = make(map[string][]*NetworkSubnet)
+	names[name2] = append(names[name2], subnet2)
+	results = common.NewValidationResults()
+	checkNameUniqueness(results, names, subnet)
+	if len(results.GetResults()) != 0 {
+		t.Fatalf(
+			"Expected zero results for no mapped names. name: %s, results: %v",
+			name, results.GetResults())
+	}
+}
+
+func TestCheckSubnetCidr(t *testing.T) {
+	// test with good cidrs
+	cidr := "10.100.0.0/17"
+	subnetCidr := "10.100.0.0/22"
+	subnet, subnetCidrIpNet := newNetworkSubnetWithCidr(t, cidr, subnetCidr)
+	results := common.NewValidationResults()
+	checkSubnetCidr(results, subnet, subnetCidrIpNet)
+	if len(results.GetResults()) != 0 {
+		t.Fatalf(
+			"Expected zero results for cidr check. cidr: %s, subnet cidr: %s, results: %v",
+			cidr, subnetCidr, results.GetResults())
+	}
+
+	// test with bad cidrs
+	cidr = "10.100.0.0/17"
+	subnetCidr = "10.106.0.0/22"
+	subnet, subnetCidrIpNet = newNetworkSubnetWithCidr(t, cidr, subnetCidr)
+	results = common.NewValidationResults()
+	checkSubnetCidr(results, subnet, subnetCidrIpNet)
+	if len(results.GetResults()) != 1 {
+		t.Fatalf(
+			"Expected one result for cidr check. cidr: %s, subnet cidr: %s, results: %v",
+			cidr, subnetCidr, results.GetResults())
+	}
+	if results.GetResults()[0].Result != common.Fail {
+		t.Errorf(
+			"Expected failing result for cidr check. cidr: %s, subnet cidr: %s, result: %v",
+			cidr, subnetCidr, results.GetResults()[0])
+	}
+}
+
+func TestCheckSubnetStartAndEnd(t *testing.T) {
+	// test with start and end IPs in order
+	subnetCidr := "10.100.0.0/22"
+	startIp := "10.100.0.10"
+	endIp := "10.100.3.254"
+	subnet, subnetCidrIpNet := newNetworkSubnetWithDhcpStartAndEnd(t, subnetCidr, startIp, endIp)
+	results := common.NewValidationResults()
+	checkDhcpStartAndEnd(results, subnet, subnetCidrIpNet)
+	if len(results.GetResults()) != 0 {
+		t.Fatalf(
+			"Expected zero results for start and end ip check. subnet cidr: %s, startIp: %s, endIp: %s, results: %v",
+			subnetCidr, startIp, endIp, results.GetResults())
+	}
+
+	// test with out of order IPs
+	subnetCidr = "10.100.0.0/22"
+	startIp = "10.100.3.254"
+	endIp = "10.100.0.10"
+	subnet, subnetCidrIpNet = newNetworkSubnetWithDhcpStartAndEnd(t, subnetCidr, startIp, endIp)
+	results = common.NewValidationResults()
+	checkDhcpStartAndEnd(results, subnet, subnetCidrIpNet)
+	if len(results.GetResults()) != 1 {
+		t.Fatalf(
+			"Expected one result for start and end ip check. subnet cidr: %s, startIp: %s, endIp: %s, results: %v",
+			subnetCidr, startIp, endIp, results.GetResults())
+	}
+	if results.GetResults()[0].Result != common.Fail {
+		t.Errorf(
+			"Expected failing result for start and end ip check. subnet cidr: %s, startIp:%s, endIp: %s, result: %v",
+			subnetCidr, startIp, endIp, results.GetResults()[0])
+	}
+
+	// test with bad end IP
+	subnetCidr = "10.100.0.0/22"
+	startIp = "10.100.3.254"
+	endIp = ""
+	subnet, subnetCidrIpNet = newNetworkSubnetWithDhcpStartAndEnd(t, subnetCidr, startIp, endIp)
+	results = common.NewValidationResults()
+	checkDhcpStartAndEnd(results, subnet, subnetCidrIpNet)
+	if len(results.GetResults()) != 2 {
+		t.Fatalf(
+			"Expected two results for start and end ip check. subnet cidr: %s, startIp: %s, endIp: %s, results: %v",
+			subnetCidr, startIp, endIp, results.GetResults())
+	}
+	if results.GetResults()[0].Result != common.Fail || results.GetResults()[1].Result != common.Fail {
+		t.Errorf(
+			"Expected failing result for start and end ip check. subnet cidr: %s, startIp:%s, endIp: %s, result0: %v, result1: %v",
+			subnetCidr, startIp, endIp, results.GetResults()[0], results.GetResults()[1])
+	}
+
+	// test with bad start IP
+	subnetCidr = "10.100.0.0/22"
+	startIp = ""
+	endIp = "10.100.3.254"
+	subnet, subnetCidrIpNet = newNetworkSubnetWithDhcpStartAndEnd(t, subnetCidr, startIp, endIp)
+	results = common.NewValidationResults()
+	checkDhcpStartAndEnd(results, subnet, subnetCidrIpNet)
+	if len(results.GetResults()) != 1 {
+		t.Fatalf(
+			"Expected one result for start and end ip check. subnet cidr: %s, startIp: %s, endIp: %s, results: %v",
+			subnetCidr, startIp, endIp, results.GetResults())
+	}
+	if results.GetResults()[0].Result != common.Fail {
+		t.Errorf(
+			"Expected failing result for start and end ip check. subnet cidr: %s, startIp:%s, endIp: %s, result: %v",
+			subnetCidr, startIp, endIp, results.GetResults()[0])
+	}
+
+	// test with unparse-able IPs
+	subnetCidr = "10.100.0.0/22"
+	startIp = "start_junk"
+	endIp = "end_junk"
+	subnet, subnetCidrIpNet = newNetworkSubnetWithDhcpStartAndEnd(t, subnetCidr, startIp, endIp)
+	results = common.NewValidationResults()
+	checkDhcpStartAndEnd(results, subnet, subnetCidrIpNet)
+	if len(results.GetResults()) != 2 {
+		t.Fatalf(
+			"Expected two results for start and end ip check. subnet cidr: %s, startIp: %s, endIp: %s, results: %v",
+			subnetCidr, startIp, endIp, results.GetResults())
+	}
+	if results.GetResults()[0].Result != common.Fail || results.GetResults()[1].Result != common.Fail {
+		t.Errorf(
+			"Expected failing result for start and end ip check. subnet cidr: %s, startIp:%s, endIp: %s, result0: %v, result1: %v",
+			subnetCidr, startIp, endIp, results.GetResults()[0], results.GetResults()[1])
+	}
+}
+
+func newNetworkSubnetWithVlan(vlan string) *NetworkSubnet {
+	network := sls_client.Network{
+		Name: "Network_for_vlan_" + vlan,
+	}
+	return &NetworkSubnet{
+		Network: &network,
+		Vlan:    vlan,
+	}
+}
+
+func newNetworkSubnetWithName(name string) *NetworkSubnet {
+	network := sls_client.Network{
+		Name: "Network_for_" + name,
+	}
+	return &NetworkSubnet{
+		Network:    &network,
+		SubnetName: name,
+	}
+}
+
+func newNetworkSubnetWithCidr(t *testing.T, cidr string, subnetCidr string) (*NetworkSubnet, *net.IPNet) {
+	network := sls_client.Network{
+		Name: "Network_for_cidr_" + cidr,
+	}
+
+	_, cidrIpNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf(
+			"Expected cidr to be parseable. subnetCidr: %s, error: %v",
+			cidr, err)
+	}
+
+	_, subnetCidrIpNet, err := net.ParseCIDR(subnetCidr)
+	if err != nil {
+		t.Fatalf(
+			"Expected cidr to be parseable. subnetCidr: %s, error: %v",
+			subnetCidr, err)
+	}
+
+	subnet := &NetworkSubnet{
+		Network:    &network,
+		Cidr:       cidr,
+		CidrIpNet:  cidrIpNet,
+		SubnetCidr: subnetCidr,
+	}
+
+	return subnet, subnetCidrIpNet
+}
+
+func newNetworkSubnetWithDhcpStartAndEnd(t *testing.T, subnetCidr, startIp, endIp string) (*NetworkSubnet, *net.IPNet) {
+	network := sls_client.Network{
+		Name: "Network_for_cidr_" + subnetCidr,
+	}
+
+	_, subnetCidrIpNet, err := net.ParseCIDR(subnetCidr)
+	if err != nil {
+		t.Fatalf(
+			"Expected cidr to be parseable. subnetCidr: %s, error: %v",
+			subnetCidr, err)
+	}
+
+	subnetProps := map[string]interface{}{
+		"DHCPStart": startIp,
+		"DHCPEnd":   endIp,
+	}
+
+	subnet := &NetworkSubnet{
+		Network:    &network,
+		Subnet:     subnetProps,
+		SubnetCidr: subnetCidr,
+	}
+
+	return subnet, subnetCidrIpNet
+}

--- a/internal/provider/csm/validate/validate.go
+++ b/internal/provider/csm/validate/validate.go
@@ -175,6 +175,7 @@ func validate(configOptions provider.ConfigOptions, slsState *sls_client.SlsStat
 			configOptions.ValidSubRoles),
 		checks.NewRequiedNetworkCheck(slsState.Networks),
 		checks.NewNetworkIpRangeCheck(slsStateExtended),
+		checks.NewNetworkSubnetCheck(slsStateExtended),
 	}
 
 	for _, checker := range checkers {


### PR DESCRIPTION


# Summary and Scope

Added these validation checks for HMN_MTN, HMN_RVR, NMN_MTN, and NMN_RVR:
- unique vlans
- unique subnet names
- unique cidr
- matching cidr between ExtraProperties and IPRanges
- DHCP Start/End is in the right order and within the subnet


# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

