### PR TITLE
make hardware types library extensible with additional user-defined yaml files

### DIFF
--- a/cmd/blade/validate.go
+++ b/cmd/blade/validate.go
@@ -30,13 +30,14 @@ import (
 	"fmt"
 	"os"
 
+	root "github.com/Cray-HPE/cani/cmd"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/spf13/cobra"
 )
 
 // validHardware checks that the hardware type is valid by comparing it against the list of hardware types
 func validHardware(cmd *cobra.Command, args []string) error {
-	library, err := hardwaretypes.NewEmbeddedLibrary()
+	library, err := hardwaretypes.NewEmbeddedLibrary(root.Conf.Session.DomainOptions.CustomHardwareTypesDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/cabinet/validate.go
+++ b/cmd/cabinet/validate.go
@@ -38,7 +38,7 @@ import (
 
 // validHardware checks that the hardware type is valid by comparing it against the list of hardware types
 func validHardware(cmd *cobra.Command, args []string) error {
-	library, err := hardwaretypes.NewEmbeddedLibrary()
+	library, err := hardwaretypes.NewEmbeddedLibrary(root.Conf.Session.DomainOptions.CustomHardwareTypesDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/cdu/validate.go
+++ b/cmd/cdu/validate.go
@@ -31,13 +31,14 @@ import (
 	"os"
 	"strings"
 
+	root "github.com/Cray-HPE/cani/cmd"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/spf13/cobra"
 )
 
 // validHardware checks that the hardware type is valid by comparing it against the list of hardware types
 func validHardware(cmd *cobra.Command, args []string) error {
-	library, err := hardwaretypes.NewEmbeddedLibrary()
+	library, err := hardwaretypes.NewEmbeddedLibrary(root.Conf.Session.DomainOptions.CustomHardwareTypesDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/chassis/validate.go
+++ b/cmd/chassis/validate.go
@@ -31,13 +31,14 @@ import (
 	"os"
 	"strings"
 
+	root "github.com/Cray-HPE/cani/cmd"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/spf13/cobra"
 )
 
 // validHardware checks that the hardware type is valid by comparing it against the list of hardware types
 func validHardware(cmd *cobra.Command, args []string) error {
-	library, err := hardwaretypes.NewEmbeddedLibrary()
+	library, err := hardwaretypes.NewEmbeddedLibrary(root.Conf.Session.DomainOptions.CustomHardwareTypesDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/node/validate.go
+++ b/cmd/node/validate.go
@@ -31,13 +31,14 @@ import (
 	"os"
 	"strings"
 
+	root "github.com/Cray-HPE/cani/cmd"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/spf13/cobra"
 )
 
 // validHardware checks that the hardware type is valid by comparing it against the list of hardware types
 func validHardware(cmd *cobra.Command, args []string) error {
-	library, err := hardwaretypes.NewEmbeddedLibrary()
+	library, err := hardwaretypes.NewEmbeddedLibrary(root.Conf.Session.DomainOptions.CustomHardwareTypesDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/pdu/validate.go
+++ b/cmd/pdu/validate.go
@@ -31,13 +31,14 @@ import (
 	"os"
 	"strings"
 
+	root "github.com/Cray-HPE/cani/cmd"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/spf13/cobra"
 )
 
 // validHardware checks that the hardware type is valid by comparing it against the list of hardware types
 func validHardware(cmd *cobra.Command, args []string) error {
-	library, err := hardwaretypes.NewEmbeddedLibrary()
+	library, err := hardwaretypes.NewEmbeddedLibrary(root.Conf.Session.DomainOptions.CustomHardwareTypesDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/switch/validate.go
+++ b/cmd/switch/validate.go
@@ -31,13 +31,14 @@ import (
 	"os"
 	"strings"
 
+	root "github.com/Cray-HPE/cani/cmd"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/spf13/cobra"
 )
 
 // validHardware checks that the hardware type is valid by comparing it against the list of hardware types
 func validHardware(cmd *cobra.Command, args []string) error {
-	library, err := hardwaretypes.NewEmbeddedLibrary()
+	library, err := hardwaretypes.NewEmbeddedLibrary(root.Conf.Session.DomainOptions.CustomHardwareTypesDir)
 	if err != nil {
 		return err
 	}

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -47,10 +47,11 @@ type Domain struct {
 
 // NewOpts are the options for creating a new Domain
 type NewOpts struct {
-	DatastorePath string      `yaml:"datastore_path"`
-	LogFilePath   string      `yaml:"log_file_path"`
-	Provider      string      `yaml:"provider"`
-	CsmOptions    csm.NewOpts `yaml:"csm_options"`
+	DatastorePath          string      `yaml:"datastore_path"`
+	LogFilePath            string      `yaml:"log_file_path"`
+	Provider               string      `yaml:"provider"`
+	CsmOptions             csm.NewOpts `yaml:"csm_options"`
+	CustomHardwareTypesDir string      `yaml:"custom_hardware_types_dir"`
 }
 
 // New returns a new Domain using the provided options
@@ -60,7 +61,7 @@ func New(opts *NewOpts) (*Domain, error) {
 
 	// Load the hardware type library
 	// TODO make this be able to be loaded from a directory
-	domain.hardwareTypeLibrary, err = hardwaretypes.NewEmbeddedLibrary()
+	domain.hardwareTypeLibrary, err = hardwaretypes.NewEmbeddedLibrary(opts.CustomHardwareTypesDir)
 	if err != nil {
 		return nil, errors.Join(
 			fmt.Errorf("failed to load embedded hardware type library"),

--- a/internal/provider/csm/metadata_test.go
+++ b/internal/provider/csm/metadata_test.go
@@ -135,7 +135,7 @@ type BuildHardwareMetadataTestSuite struct {
 }
 
 func (suite *BuildHardwareMetadataTestSuite) SetupSuite() {
-	hardwareTypeLibrary, err := hardwaretypes.NewEmbeddedLibrary()
+	hardwareTypeLibrary, err := hardwaretypes.NewEmbeddedLibrary("")
 	suite.NoError(err)
 
 	// Stand up a minimal CSM provider to run BuildHardwareMetadata

--- a/internal/provider/csm/sls_state_generator_test.go
+++ b/internal/provider/csm/sls_state_generator_test.go
@@ -117,7 +117,7 @@ func (suite *DetermineHardwareClassSuite) getHardwareInCabinet(cabinetOrdinal in
 
 func (suite *DetermineHardwareClassSuite) SetupTest() {
 	var err error
-	suite.hardwareTypeLibrary, err = hardwaretypes.NewEmbeddedLibrary()
+	suite.hardwareTypeLibrary, err = hardwaretypes.NewEmbeddedLibrary("")
 	suite.NoError(err)
 
 	// Generate a inventory of hardware

--- a/spec/cani_add_cabinet_spec.sh
+++ b/spec/cani_add_cabinet_spec.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+#
 # MIT License
 #
 # (C) Copyright 2023 Hewlett Packard Enterprise Development LP
@@ -20,8 +21,7 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-
-
+#
 Describe 'cani add cabinet'
 
 # help output should succeed and match the fixture
@@ -443,4 +443,39 @@ It "--config canitest.yml $1 --auto --accept"
   The line 6 of stderr should include " Cabinet Number: $2"
   The line 7 of stderr should include " VLAN ID: $3"
 End
+
+It 'validates a custom hardware type appears in the list of supported hardware'
+  BeforeCall use_active_session
+  BeforeCall use_custom_hw_type
+  BeforeCall use_valid_datastore_system_only
+  When call bin/cani --config canitest.yml alpha add cabinet -L
+  The status should equal 0
+  The line 8 of stderr should equal '- my-custom-cabinet'
+End
+
+It '--config canitest.yml my-custom-cabinet --auto --accept'
+  BeforeCall use_active_session
+  BeforeCall use_custom_hw_type
+  BeforeCall use_valid_datastore_system_only
+  When call bin/cani alpha add cabinet --config canitest.yml my-custom-cabinet --auto --accept
+  The status should equal 0
+  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 2 of stderr should include " Suggested cabinet number: 4321"
+  The line 3 of stderr should include " Suggested VLAN ID: 1111"
+  The line 4 of stderr should include " was successfully staged to be added to the system"
+  The line 5 of stderr should include " UUID: "
+  The line 6 of stderr should include " Cabinet Number: 4321"
+  The line 7 of stderr should include " VLAN ID: 1111"
+End
+
+It 'validate cabinet is added'
+  BeforeCall use_custom_hw_type
+  When call bin/cani alpha list cabinet --config canitest.yml
+  The status should equal 0
+  The line 2 of stdout should include "staged"
+  The line 2 of stdout should include "my-custom-cabinet"
+  The line 2 of stdout should include "1111"
+  The line 2 of stdout should include "System:0->Cabinet:4321"
+End
+
 End

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -76,6 +76,11 @@ spec_helper_configure() {
     cp "$FIXTURES"/cani/configs/canitest_valid_inactive.yml canitest.yml
   } 
 
+  use_custom_hw_type(){ 
+    #shellcheck disable=SC2317
+    cp "$FIXTURES"/cani/configs/my_custom_hw.yml "$PWD"/hardware-types/my_custom_hw.yml
+  } 
+
   # deploys a datastore with one system only
   use_valid_datastore_system_only(){ 
     #shellcheck disable=SC2317

--- a/testdata/fixtures/cani/configs/canitest_valid_inactive.yml
+++ b/testdata/fixtures/cani/configs/canitest_valid_inactive.yml
@@ -33,24 +33,27 @@ session:
             baseurlsls: https://localhost:8443/apis/sls/v1
             baseurlhsm: https://localhost:8443/apis/smd/hsm/v2
             secretname: admin-client-auth
+            k8spodscidr: 10.32.0.0/12
+            k8sservicescidr: 10.16.0.0/12
             kubeconfig: ""
-            tokenhost: ""
+            providerhost: localhost:8443
             cacertpath: ""
             validroles:
+                - Storage
+                - Management
                 - Compute
                 - Service
                 - System
                 - Application
-                - Storage
-                - Management
             validsubroles:
-                - Worker
-                - Master
-                - Storage
                 - UAN
                 - Gateway
                 - LNETRouter
                 - Visualization
                 - UserDefined
+                - Master
+                - Worker
+                - Storage
+        custom_hardware_types_dir: ./hardware-types
     domain: {}
     active: false

--- a/testdata/fixtures/cani/configs/my_custom_hw.yml
+++ b/testdata/fixtures/cani/configs/my_custom_hw.yml
@@ -21,39 +21,37 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-session:
-    domain_options:
-        datastore_path: ./canitestdb.json
-        log_file_path: ./canitestdb.log
-        provider: csm
-        csm_options:
-            usesimulation: true
-            insecureskipverify: true
-            apigatewaytoken: ""
-            baseurlsls: https://localhost:8443/apis/sls/v1
-            baseurlhsm: https://localhost:8443/apis/smd/hsm/v2
-            secretname: admin-client-auth
-            k8spodscidr: 10.32.0.0/12
-            k8sservicescidr: 10.16.0.0/12
-            kubeconfig: ""
-            providerhost: localhost:8443
-            cacertpath: ""
-            validroles:
-                - Storage
-                - Management
-                - Compute
-                - Service
-                - System
-                - Application
-            validsubroles:
-                - UAN
-                - Gateway
-                - LNETRouter
-                - Visualization
-                - UserDefined
-                - Master
-                - Worker
-                - Storage
-        custom_hardware_types_dir: ./hardware-types
-    domain: {}
-    active: true
+---
+manufacturer: HPE
+model: EX2000
+hardware-type: Cabinet
+slug: my-custom-cabinet
+
+device-bays:
+  - name: Chassis 0
+    allowed:
+      slug: [my-custom-chassis]
+    default:
+      slug: my-custom-chassis
+    ordinal: 0
+
+provider_defaults:
+  csm:
+    Class: River
+    Ordinal: 4321
+    StartingHmnVlan: 1111
+    EndingHmnVlan: 1769
+
+---
+manufacturer: HPE
+model: Standard/EIA Chassis
+hardware-type: Chassis
+slug: my-custom-chassis
+
+provider_defaults:
+  csm:
+    Class: River
+    starting_cabinet: 4321
+    StartingHmnVlan: 1111
+    EndingHmnVlan: 1769
+


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- reads in custom hardware type files from `hardware-types` directory in the same dir as the `cani.yml` file
- adds `CustomHardwareTypesDir` to the domain options
- updates `config` package to use `os` instead of the deprecated `ioutil`
```
1:05PM DBG Looking for built-in hardware-types in /Users/jsalmela/.cani/hardware-types
1:05PM DBG Looking for custom hardware-types in /Users/jsalmela/.cani/hardware-types
1:05PM DBG Parsing built-in hardware-type: hardware-types/hpe-cabinet-crayex-common.yaml
1:05PM DBG Registering device type: hpe-crayex-cabinet-environmental-controller
1:05PM DBG Registering device type: hpe-crayex-chassis
1:05PM DBG Registering device type: hpe-crayex-chassis-management-module
...
...
1:05PM DBG Parsing custom hardware-type: /Users/jsalmela/.cani/hardware-types/my_custom_hw.yml
1:05PM DBG Registering device type: my-custom-cabinet
1:05PM DBG Registering device type: my-custom-chassis

% bin/cani alpha add cabinet -L                                                                                                                                                                        
- hpe-eia-cabinet
- hpe-ex2000
- hpe-ex2500-1-liquid-cooled-chassis
- hpe-ex2500-2-liquid-cooled-chassis
- hpe-ex2500-3-liquid-cooled-chassis
- hpe-ex3000
- hpe-ex4000
- my-custom-cabinet
```
# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Low