### PR TITLE
set a default csm-api-host

### DIFF
--- a/cmd/session/init.go
+++ b/cmd/session/init.go
@@ -66,7 +66,7 @@ func init() {
 	SessionInitCmd.Flags().BoolVarP(&useSimulation, "csm-simulator", "S", false, "(CSM Provider) Use simulation environment URLs")
 
 	// These three pieces are needed for the CSM provider to get a token
-	SessionInitCmd.Flags().StringVar(&providerHost, "csm-api-host", "", "(CSM Provider) Host or FQDN for authentation and APIs")
+	SessionInitCmd.Flags().StringVar(&providerHost, "csm-api-host", "api-gw-service.local", "(CSM Provider) Host or FQDN for authentation and APIs")
 	// SessionInitCmd.MarkFlagRequired("csm-api-host")
 	SessionInitCmd.Flags().StringVar(&tokenUsername, "csm-keycloak-username", "", "(CSM Provider) Keycloak username")
 	// SessionInitCmd.MarkFlagRequired("csm-keycloak-username")

--- a/internal/provider/csm/csm.go
+++ b/internal/provider/csm/csm.go
@@ -75,9 +75,7 @@ func New(opts *NewOpts, hardwareLibrary *hardwaretypes.Library) (*CSM, error) {
 	if opts.UseSimulation {
 		opts.InsecureSkipVerify = true
 
-		if opts.ProviderHost == "" {
-			opts.ProviderHost = "localhost:8443"
-		}
+		opts.ProviderHost = "localhost:8443"
 
 		if opts.BaseUrlSLS == "" {
 			opts.BaseUrlSLS = fmt.Sprintf("https://%s/apis/sls/v1", opts.ProviderHost)

--- a/spec/functional/cani_session_spec.sh
+++ b/spec/functional/cani_session_spec.sh
@@ -64,9 +64,9 @@ It "--config $CANI_CONF init"
 End
 
 # Starting a session without passing a provider should fail
-It "--config $CANI_CONF init fake"
+It "--config $CANI_CONF init fake -S --csm-api-host localhost:8443"
   BeforeCall remove_config
-  When call bin/cani alpha session --config "$CANI_CONF" init fake
+  When call bin/cani alpha session --config "$CANI_CONF" init fake -S --csm-api-host localhost:8443
   The status should equal 1
   The line 1 of stderr should equal 'Error: fake is not a valid provider.  Valid providers: [csm]'
 End
@@ -74,21 +74,22 @@ End
 # Starting a session should fail with:
 #  - a valid proivder
 #  - no connection to SLS
-It "(no connection to provider) --config $CANI_CONF init csm"
+It "(timeout, no connection to provider) --config $CANI_CONF init csm"
   BeforeCall remove_config
   BeforeCall remove_datastore
   When call bin/cani alpha session --config "$CANI_CONF" init csm
   The status should equal 1
   The line 1 of stderr should include "$CANI_DS does not exist, creating default datastore"
   The line 2 of stderr should include 'No API Gateway token provided, getting one from provider '
-  The line 3 of stderr should include '/keycloak/realms/shasta/protocol/openid-connect/token'
+  The line 3 of stderr should include 'https://api-gw-service.local/keycloak/realms/shasta/protocol/openid-connect/token'
+  The stderr should include 'Failed to get token'
 End
 
 It 'initialize a session without a config file or datastore'
   BeforeCall remove_config
   BeforeCall remove_datastore
   BeforeCall "load_sls.sh testdata/fixtures/sls/valid_hardware_networks.json" # simulator is running, load a specific SLS config
-  When call bin/cani alpha session --config "$CANI_CONF" init csm -S
+  When call bin/cani alpha session --config "$CANI_CONF" init csm -S 
   The status should equal 0
   The line 1 of stderr should include 'Using simulation mode'
   The stderr should include 'Validated CANI inventory'


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

Fixes a bug where the host was empty and CANI could not initialize a session.

Always sets a host when uses simulation mode.  Adjusts tests accordingly

Previous behavior:
```
% go run main.go alpha session init csm   
1:37PM INF Session is already ACTIVE.
File /Users/jsalmela/.cani/canidb.json already exists. Keep session active but overwrite the datastore: y
2023/09/07 13:37:18 [DEBUG] GET https:///apis/smd/hsm/v2/service/values
2023/09/07 13:37:18 [ERR] GET https:///apis/smd/hsm/v2/service/values request failed: Get "https:///apis/smd/hsm/v2/service/values": http: no Host in request URL
2023/09/07 13:37:18 [DEBUG] GET https:///apis/smd/hsm/v2/service/values: retrying in 1s (4 left)
2023/09/07 13:37:19 [ERR] GET https:///apis/smd/hsm/v2/service/values request failed: Get "https:///apis/smd/hsm/v2/service/values": http: no Host in request URL
2023/09/07 13:37:19 [DEBUG] GET https:///apis/smd/hsm/v2/service/values: retrying in 2s (3 left)
```

New behavior:
```
% go run main.go alpha session init csm                                                        
1:38PM INF Session is already ACTIVE.
File /Users/jsalmela/.cani/canidb.json already exists. Keep session active but overwrite the datastore: y
2023/09/07 13:38:21 [DEBUG] GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values
```

I think there are actually some additional toggles we can enable in terms of flags required/required together

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Low