### PR TITLE
fix crash if no hardware when reconciling and instead show the error

### DIFF
--- a/internal/provider/csm/reconcile.go
+++ b/internal/provider/csm/reconcile.go
@@ -98,6 +98,11 @@ func (csm *CSM) Reconcile(ctx context.Context, configOptions provider.ConfigOpti
 	if err != nil {
 		return errors.Join(fmt.Errorf("unable to copy SLS state"), err)
 	}
+
+	if modifiedState.Hardware == nil {
+		modifiedState.Hardware = map[string]sls_client.Hardware{}
+	}
+
 	for _, hardware := range hardwareChanges.Removed {
 		delete(modifiedState.Hardware, hardware.Xname)
 	}


### PR DESCRIPTION


# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

Fixes a crash in unconventional SLS configurations (no hardware)

```
2:32PM INF   x9000c3b0        - Type: ChassisBMC, Class: Hill
2:32PM INF
2:32PM INF Hardware removed from system
2:32PM INF   None
2:32PM INF
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/Cray-HPE/cani/internal/provider/csm.(*CSM).Reconcile(0x1400038fe50, {0x103386218, 0x14000024090}, {{0x140002eec00, 0x8, 0x8}, {0x140002eec80, 0x8, 0x8}, {0x1400034eb20, ...}, ...}, ...)
        /Users/jsalmela/git/csminv/internal/provider/csm/reconcile.go:107 +0x550
github.com/Cray-HPE/cani/internal/domain.(*Domain).Commit(0x140002eed80, {0x103386218, 0x14000024090}, 0x0?, 0x0)
        /Users/jsalmela/git/csminv/internal/domain/commit.go:79 +0x2d8
github.com/Cray-HPE/cani/cmd/session.stopSession(0x103686420, {0x1031712b3?, 0x2?, 0x2?})
        /Users/jsalmela/git/csminv/cmd/session/session_apply.go:87 +0x204
github.com/spf13/cobra.(*Command).execute(0x103686420, {0x140002d3140, 0x2, 0x2})
        /Users/jsalmela/git/csminv/vendor/github.com/spf13/cobra/command.go:940 +0x5c4
github.com/spf13/cobra.(*Command).ExecuteC(0x103681960)
        /Users/jsalmela/git/csminv/vendor/github.com/spf13/cobra/command.go:1068 +0x340
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/jsalmela/git/csminv/vendor/github.com/spf13/cobra/command.go:992
github.com/Cray-HPE/cani/cmd.Execute()
        /Users/jsalmela/git/csminv/cmd/root.go:65 +0x24
main.main()
        /Users/jsalmela/git/csminv/main.go:41 +0x1c
```


# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

