### PR TITLE
actually overwrite the datastore if the user chooses yes

### DIFF
--- a/cmd/session/session_init.go
+++ b/cmd/session/session_init.go
@@ -105,6 +105,11 @@ func startSession(cmd *cobra.Command, args []string) error {
 			if !overwrite {
 				// User chose not to overwrite the file
 				os.Exit(0)
+			} else {
+				err = os.Remove(ds)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

The prompt does not actually overwrite the file.

To reproduce before this change:
```
./spec/support/bin/load_sls.sh testdata/fixtures/sls/no_hardware.json       
rm -rf ~/.cani && bin/cani alpha session init csm -S
bin/cani alpha add cabinet hpe-ex2000 --auto --accept      
shasum -a 256 ~/.cani/canidb.json       
bin/cani alpha session init csm -S                                                                                                                                                                                            
shasum -a 256 ~/.cani/canidb.json 
```

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

