### PR TITLE
refactor to support multiple providers

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -29,12 +29,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	vendor string
-	name   string
-	u      string
-)
-
 // AddCmd represents the switch add command
 var AddCmd = &cobra.Command{
 	Use:   "add",

--- a/cmd/blade/add_blade.go
+++ b/cmd/blade/add_blade.go
@@ -43,25 +43,17 @@ import (
 
 // AddBladeCmd represents the blade add command
 var AddBladeCmd = &cobra.Command{
-	Use:               "blade",
-	Short:             "Add blades to the inventory.",
-	Long:              `Add blades to the inventory.`,
-	PersistentPreRunE: root.DatastoreExists, // A session must be active to write to a datastore
-	SilenceUsage:      true,                 // Errors are more important than the usage
-	Args:              validHardware,        // Hardware can only be valid if defined in the hardware library
-	RunE:              addBlade,             // Add a blade when this sub-command is called
+	Use:     "blade",
+	Short:   "Add blades to the inventory.",
+	Long:    `Add blades to the inventory.`,
+	PreRunE: validHardware, // Hardware can only be valid if defined in the hardware library
+	RunE:    addBlade,      // Add a blade when this sub-command is called
 }
 
 // addBlade adds a blade to the inventory
-func addBlade(cmd *cobra.Command, args []string) error {
-	// Create a domain object to interact with the datastore
-	d, err := domain.New(root.Conf.Session.DomainOptions)
-	if err != nil {
-		return err
-	}
-
+func addBlade(cmd *cobra.Command, args []string) (err error) {
 	if auto {
-		recommendations, err := d.Recommend(args[0])
+		recommendations, err := root.D.Recommend(args[0])
 		if err != nil {
 			return err
 		}
@@ -95,7 +87,7 @@ func addBlade(cmd *cobra.Command, args []string) error {
 	}
 
 	// Add the blade from the inventory using domain methods
-	result, err := d.AddBlade(cmd.Context(), args[0], cabinet, chassis, blade)
+	result, err := root.D.AddBlade(cmd.Context(), args[0], cabinet, chassis, blade)
 	if errors.Is(err, provider.ErrDataValidationFailure) {
 		// TODO this validation error print logic could be shared
 
@@ -147,7 +139,7 @@ func addBlade(cmd *cobra.Command, args []string) error {
 				result.Location)
 			// Add the node to the map
 			newNodes = append(newNodes, result)
-			if root.Conf.Session.DomainOptions.Provider == string(inventory.CSMProvider) {
+			if root.D.Provider == string(inventory.CSMProvider) {
 				log.Info().Str("status", "SUCCESS").Msgf("%s was successfully staged to be added to the system", hardwaretypes.NodeBlade)
 				log.Info().Msgf("UUID: %s", result.Hardware.ID)
 				log.Info().Msgf("Cabinet: %d", cabinet)

--- a/cmd/blade/list_blade.go
+++ b/cmd/blade/list_blade.go
@@ -34,7 +34,6 @@ import (
 	"text/tabwriter"
 
 	root "github.com/Cray-HPE/cani/cmd"
-	"github.com/Cray-HPE/cani/internal/domain"
 	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/google/uuid"
@@ -53,14 +52,8 @@ var ListBladeCmd = &cobra.Command{
 
 // listBlade lists blades in the inventory
 func listBlade(cmd *cobra.Command, args []string) error {
-	// Instantiate a new logic object to interact with the datastore
-	d, err := domain.New(root.Conf.Session.DomainOptions)
-	if err != nil {
-		return err
-	}
-
 	// Get the entire inventory
-	inv, err := d.List()
+	inv, err := root.D.List()
 	if err != nil {
 		return err
 	}

--- a/cmd/blade/remove_blade.go
+++ b/cmd/blade/remove_blade.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 
 	root "github.com/Cray-HPE/cani/cmd"
-	"github.com/Cray-HPE/cani/internal/domain"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
@@ -52,13 +51,8 @@ func removeBlade(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("Need a UUID to remove: %s", err.Error())
 		}
 
-		d, err := domain.New(root.Conf.Session.DomainOptions)
-		if err != nil {
-			return err
-		}
-
 		// Remove the blade from the inventory
-		err = d.RemoveBlade(u, recursion)
+		err = root.D.RemoveBlade(u, recursion)
 		if err != nil {
 			return err
 		}

--- a/cmd/blade/validate.go
+++ b/cmd/blade/validate.go
@@ -31,30 +31,29 @@ import (
 	"os"
 
 	root "github.com/Cray-HPE/cani/cmd"
-	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
 // validHardware checks that the hardware type is valid by comparing it against the list of hardware types
-func validHardware(cmd *cobra.Command, args []string) error {
-	library, err := hardwaretypes.NewEmbeddedLibrary(root.Conf.Session.DomainOptions.CustomHardwareTypesDir)
-	if err != nil {
-		return err
-	}
-
-	// Get the list of hardware types that are blades
-	deviceTypes := library.GetDeviceTypesByHardwareType(hardwaretypes.NodeBlade)
+func validHardware(cmd *cobra.Command, args []string) (err error) {
+	log.Debug().Msgf("Validating hardware %+v", root.D)
 	if cmd.Flags().Changed("list-supported-types") {
 		cmd.SetOut(os.Stdout)
-		for _, hw := range deviceTypes {
-			cmd.Printf("%s\n", hw.Slug)
+		for _, hw := range root.BladeTypes {
+			// print additional provider defaults
+			if root.Verbose {
+				cmd.Printf("%s\n", hw.Slug)
+			} else {
+				cmd.Printf("%s\n", hw.Slug)
+			}
 		}
 		os.Exit(0)
 	}
 
 	if len(args) == 0 {
 		bladeTypes := []string{}
-		for _, hw := range deviceTypes {
+		for _, hw := range root.BladeTypes {
 			bladeTypes = append(bladeTypes, hw.Slug)
 		}
 		return fmt.Errorf("No hardware type provided: Choose from: %s", bladeTypes)
@@ -63,7 +62,7 @@ func validHardware(cmd *cobra.Command, args []string) error {
 	// Check that each arg is a valid blade type
 	for _, arg := range args {
 		matchFound := false
-		for _, device := range deviceTypes {
+		for _, device := range root.BladeTypes {
 			if arg == device.Slug {
 				matchFound = true
 				break

--- a/cmd/cabinet/list_cabinet.go
+++ b/cmd/cabinet/list_cabinet.go
@@ -34,7 +34,6 @@ import (
 	"text/tabwriter"
 
 	root "github.com/Cray-HPE/cani/cmd"
-	"github.com/Cray-HPE/cani/internal/domain"
 	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/internal/provider/csm"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
@@ -54,14 +53,8 @@ var ListCabinetCmd = &cobra.Command{
 
 // listCabinet lists cabinets in the inventory
 func listCabinet(cmd *cobra.Command, args []string) error {
-	// Create a domain object to interact with the datastore
-	d, err := domain.New(root.Conf.Session.DomainOptions)
-	if err != nil {
-		return err
-	}
-
 	// Get the entire inventory
-	inv, err := d.List()
+	inv, err := root.D.List()
 	if err != nil {
 		return err
 	}

--- a/cmd/cabinet/validate.go
+++ b/cmd/cabinet/validate.go
@@ -32,22 +32,14 @@ import (
 	"strings"
 
 	root "github.com/Cray-HPE/cani/cmd"
-	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/spf13/cobra"
 )
 
 // validHardware checks that the hardware type is valid by comparing it against the list of hardware types
-func validHardware(cmd *cobra.Command, args []string) error {
-	library, err := hardwaretypes.NewEmbeddedLibrary(root.Conf.Session.DomainOptions.CustomHardwareTypesDir)
-	if err != nil {
-		return err
-	}
-
-	// Get the list of hardware types that are cabinets
-	deviceTypes := library.GetDeviceTypesByHardwareType(hardwaretypes.Cabinet)
+func validHardware(cmd *cobra.Command, args []string) (err error) {
 	if cmd.Flags().Changed("list-supported-types") {
 		cmd.SetOut(os.Stdout)
-		for _, hw := range deviceTypes {
+		for _, hw := range root.CabinetTypes {
 			// print additional provider defaults
 			if root.Verbose {
 				cmd.Printf("%s %d %d\n", hw.Slug, hw.ProviderDefaults.CSM.Ordinal, hw.ProviderDefaults.CSM.StartingHmnVlan)
@@ -60,7 +52,7 @@ func validHardware(cmd *cobra.Command, args []string) error {
 
 	if len(args) == 0 {
 		types := []string{}
-		for _, hw := range deviceTypes {
+		for _, hw := range root.CabinetTypes {
 			types = append(types, hw.Slug)
 		}
 		return fmt.Errorf("No hardware type provided: Choose from: %s", strings.Join(types, "\", \""))
@@ -69,7 +61,7 @@ func validHardware(cmd *cobra.Command, args []string) error {
 	// Check that each arg is a valid cabinet type
 	for _, arg := range args {
 		matchFound := false
-		for _, device := range deviceTypes {
+		for _, device := range root.CabinetTypes {
 			if arg == device.Slug {
 				matchFound = true
 				break
@@ -80,17 +72,16 @@ func validHardware(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	err = validFlagCombos(cmd, args)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // validFlagCombos has additional flag logic to account for overiding required flags with the --auto flag
 func validFlagCombos(cmd *cobra.Command, args []string) error {
-	// ensure the session is up and the datastore exists
-	err := root.DatastoreExists(cmd, args)
-	if err != nil {
-		return err
-	}
-
 	cabinetSet := cmd.Flags().Changed("cabinet")
 	vlanIdSet := cmd.Flags().Changed("vlan-id")
 	autoSet := cmd.Flags().Changed("auto")

--- a/cmd/config/session.go
+++ b/cmd/config/session.go
@@ -29,7 +29,5 @@ import "github.com/Cray-HPE/cani/internal/domain"
 
 // Session defines the session configuration and domain options
 type Session struct {
-	DomainOptions *domain.DomainOpts `yaml:"domain_options"`
-	Domain        *domain.Domain     `yaml:"domain"`
-	Active        bool               `yaml:"active"`
+	Domains map[string]*domain.Domain `yaml:"domains"`
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -32,6 +32,8 @@ import (
 
 	"github.com/Cray-HPE/cani/cmd/config"
 	"github.com/Cray-HPE/cani/cmd/taxonomy"
+	"github.com/Cray-HPE/cani/internal/domain"
+	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -40,7 +42,7 @@ import (
 
 func init() {
 	// Create or load a yaml config and the database
-	cobra.OnInitialize(initConfig, setupLogging)
+	cobra.OnInitialize(setupLogging, initConfig)
 
 	RootCmd.AddCommand(AlphaCmd)
 	RootCmd.AddCommand(MakeDocsCmd)
@@ -110,20 +112,71 @@ func initConfig() {
 		log.Error().Msg(fmt.Sprintf("Error loading config file: %s", err))
 		os.Exit(1)
 	}
+
 }
 
-func loadConfigAndDomainOpts(cmd *cobra.Command, args []string) error {
-	var err error
-	// writeSession writes the session configuration back to the config file
-	cfgFile = cmd.Root().PersistentFlags().Lookup("config").Value.String()
-	Conf, err = config.LoadConfig(cfgFile)
-	if err != nil {
-		return err
-	}
-	if Debug {
-		log.Debug().Msgf("Loaded config file %s", cfgFile)
-		log.Debug().Msgf("Session: %+v", Conf.Session.Active)
+func setupDomain(cmd *cobra.Command, args []string) (err error) {
+	log.Debug().Msgf("Setting %s provider", cmd.Name())
+	log.Debug().Msgf("Setting up domain for command: %s", cmd.Name())
+	// if cmd.Name() != "init" || cmd.Name() != "status" {
+	log.Debug().Msgf("Checking for active domains")
+	// Find an active session
+	activeDomains := []*domain.Domain{}
+	activeProviders := []string{}
+	for p, d := range Conf.Session.Domains {
+		if d.Active {
+			log.Debug().Msgf("Provider '%s' is ACTIVE", p)
+			activeDomains = append(activeDomains, d)
+			activeProviders = append(activeProviders, p)
+		} else {
+			log.Debug().Msgf("Provider '%s' is inactive", p)
+		}
 	}
 
+	if cmd.Name() != "init" {
+		// Error if no sessions are active
+		if len(activeProviders) == 0 {
+			// These commands are special because they validate hardware in the args
+			// so SetupDomain is called manually
+			// The timing of events works out such that simply returning the error
+			// will exit without the message
+			if cmd.Name() == "status" {
+				log.Info().Msgf("No active session.")
+				return nil
+			} else {
+				log.Error().Msgf("No active session.")
+				return err
+			}
+		}
+
+		// Check that only one session is active
+		if len(activeProviders) > 1 {
+			for _, p := range activeProviders {
+				err := fmt.Errorf("currently active: %v", p)
+				log.Error().Msgf("%v", err)
+			}
+			log.Error().Msgf("only one session may be active at a time")
+			return err
+		}
+		activeDomain := activeDomains[0]
+
+		log.Debug().Msgf("Active provider is: %s", activeDomain.Provider)
+		D = activeDomain
+		err = D.SetupDomain(cmd, args)
+		if err != nil {
+			return err
+		}
+		HwLibrary, err := hardwaretypes.NewEmbeddedLibrary(D.CustomHardwareTypesDir)
+		if err != nil {
+			return err
+		}
+
+		// Get the list of supported hardware types
+		CabinetTypes = HwLibrary.GetDeviceTypesByHardwareType(hardwaretypes.Cabinet)
+		BladeTypes = HwLibrary.GetDeviceTypesByHardwareType(hardwaretypes.NodeBlade)
+		NodeTypes = HwLibrary.GetDeviceTypesByHardwareType(hardwaretypes.NodeBlade)
+		MgmtSwitchTypes = HwLibrary.GetDeviceTypesByHardwareType(hardwaretypes.ManagementSwitch)
+		HsnSwitchTypes = HwLibrary.GetDeviceTypesByHardwareType(hardwaretypes.HighSpeedSwitch)
+	}
 	return nil
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -30,7 +30,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Cray-HPE/cani/internal/domain"
 	"github.com/spf13/cobra"
 )
 
@@ -44,14 +43,8 @@ var ListCmd = &cobra.Command{
 
 // listInventory lists all assets in the inventory
 func listInventory(cmd *cobra.Command, args []string) error {
-	// Create a domain object to interact with the datastore
-	d, err := domain.New(Conf.Session.DomainOptions)
-	if err != nil {
-		return err
-	}
-
 	// Get the entire inventory
-	inv, err := d.List()
+	inv, err := D.List()
 	if err != nil {
 		return err
 	}

--- a/cmd/makedocs.go
+++ b/cmd/makedocs.go
@@ -35,12 +35,11 @@ import (
 
 // MakeDocsCmd represents the makedocs command
 var MakeDocsCmd = &cobra.Command{
-	Use:          "makedocs",
-	Short:        "Generate markdown docs to ./docs/",
-	Long:         `Generate markdown docs to ./docs/`,
-	Args:         cobra.NoArgs,
-	SilenceUsage: true, // Errors are more important than the usage
-	RunE:         makeDocs,
+	Use:   "makedocs",
+	Short: "Generate markdown docs to ./docs/",
+	Long:  `Generate markdown docs to ./docs/`,
+	Args:  cobra.NoArgs,
+	RunE:  makeDocs,
 }
 
 // makeDocs generates mardown docs for all cobra commands

--- a/cmd/node/add_node.go
+++ b/cmd/node/add_node.go
@@ -26,36 +26,21 @@
 package node
 
 import (
-	root "github.com/Cray-HPE/cani/cmd"
-	"github.com/Cray-HPE/cani/internal/domain"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
 // AddNodeCmd represents the node add command
 var AddNodeCmd = &cobra.Command{
-	Use:               "node",
-	Short:             "Add nodes to the inventory.",
-	Long:              `Add nodes to the inventory.`,
-	PersistentPreRunE: root.DatastoreExists, // A session must be active to write to a datastore
-	Args:              validHardware,        // Hardware can only be valid if defined in the hardware library
-	RunE:              addNode,              // Add a node when this sub-command is called
+	Use:     "node",
+	Short:   "Add nodes to the inventory.",
+	Long:    `Add nodes to the inventory.`,
+	PreRunE: validHardware, // Hardware can only be valid if defined in the hardware library
+	RunE:    addNode,       // Add a node when this sub-command is called
 }
 
 // addNode adds a node to the inventory
 func addNode(cmd *cobra.Command, args []string) error {
-	// Create a domain object to interact with the datastore
-	_, err := domain.New(root.Conf.Session.DomainOptions)
-	if err != nil {
-		return err
-	}
 	log.Info().Msgf("Not yet implemented")
-	// Remove the node from the inventory using domain methods
-	// TODO:
-	// err = d.AddNode()
-	// if err != nil {
-	// 	return err
-	// }
-	// log.Info().Msgf("Added node %s", args[0])
 	return nil
 }

--- a/cmd/node/list_node.go
+++ b/cmd/node/list_node.go
@@ -34,7 +34,6 @@ import (
 	"text/tabwriter"
 
 	root "github.com/Cray-HPE/cani/cmd"
-	"github.com/Cray-HPE/cani/internal/domain"
 	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/internal/provider/csm"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
@@ -53,14 +52,8 @@ var ListNodeCmd = &cobra.Command{
 
 // listNode lists nodes in the inventory
 func listNode(cmd *cobra.Command, args []string) error {
-	// Create a domain object to interact with the datastore
-	d, err := domain.New(root.Conf.Session.DomainOptions)
-	if err != nil {
-		return err
-	}
-
 	// Get the entire inventory
-	inv, err := d.List()
+	inv, err := root.D.List()
 	if err != nil {
 		return err
 	}

--- a/cmd/node/validate.go
+++ b/cmd/node/validate.go
@@ -28,34 +28,17 @@ package node
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	root "github.com/Cray-HPE/cani/cmd"
-	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/spf13/cobra"
 )
 
 // validHardware checks that the hardware type is valid by comparing it against the list of hardware types
-func validHardware(cmd *cobra.Command, args []string) error {
-	library, err := hardwaretypes.NewEmbeddedLibrary(root.Conf.Session.DomainOptions.CustomHardwareTypesDir)
-	if err != nil {
-		return err
-	}
-
-	// Get the list of hardware types that are nodes
-	deviceTypes := library.GetDeviceTypesByHardwareType(hardwaretypes.Node)
-	if cmd.Flags().Changed("list-supported-types") {
-		cmd.SetOut(os.Stdout)
-		for _, hw := range deviceTypes {
-			cmd.Printf("%s\n", hw.Slug)
-		}
-		os.Exit(0)
-	}
-
+func validHardware(cmd *cobra.Command, args []string) (err error) {
 	if len(args) == 0 {
 		types := []string{}
-		for _, hw := range deviceTypes {
+		for _, hw := range root.NodeTypes {
 			types = append(types, hw.Slug)
 		}
 		return fmt.Errorf("No hardware type provided: Choose from: %s", strings.Join(types, "\", \""))
@@ -64,7 +47,7 @@ func validHardware(cmd *cobra.Command, args []string) error {
 	// Check that each arg is a valid node type
 	for _, arg := range args {
 		matchFound := false
-		for _, device := range deviceTypes {
+		for _, device := range root.NodeTypes {
 			if arg == device.Slug {
 				matchFound = true
 				break

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,11 +29,13 @@ package cmd
 import (
 	"os"
 
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
 	"github.com/Cray-HPE/cani/cmd/config"
 	"github.com/Cray-HPE/cani/cmd/taxonomy"
 	"github.com/Cray-HPE/cani/internal/domain"
+	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -41,9 +43,10 @@ var RootCmd = &cobra.Command{
 	Use:               taxonomy.App,
 	Short:             taxonomy.ShortDescription,
 	Long:              taxonomy.LongDescription,
-	PersistentPreRunE: loadConfigAndDomainOpts, // Load the domain options and config file settings
-	RunE:              runRoot,
-	Version:           version(),
+	PersistentPreRunE: setupDomain, // the domain object is needed for all provider operations, load it early from root so it is available to all subcommands
+	// RunE:               runRoot,
+	Version:            version(),
+	PersistentPostRunE: WriteSession, // write any changes made back to the config
 }
 
 var (
@@ -53,12 +56,14 @@ var (
 	Debug bool
 	// Verbose is a global flag that enables verbose logging
 	Verbose bool
-	// Simulation is a global flag that enables simulation mode
-	Simulation bool
-	// Conf is the global configuration read from cani.yml (or from --config)
+	// This is the active domain being used
+	D *domain.Domain
+	// Conf is everything in the config file (all sessions for all providers)
 	Conf *config.Config
-	// Domain is the global domain object, which is used to interact with the datastore
-	Domain *domain.Domain
+	// Hardware library should also be accessible globally
+	HwLibrary *hardwaretypes.Library
+	// List of hardware types that are blades
+	CabinetTypes, BladeTypes, NodeTypes, MgmtSwitchTypes, HsnSwitchTypes []hardwaretypes.DeviceType
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -76,5 +81,19 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		cmd.Help()
 	}
 
+	return nil
+}
+
+// WriteSession writes the session configuration back to the config file
+func WriteSession(cmd *cobra.Command, args []string) error {
+	if cmd.Name() == "init" {
+		// Write the configuration back to the file
+		cfgFile := cmd.Root().PersistentFlags().Lookup("config").Value.String()
+		log.Debug().Msgf("Writing session to config %s", cfgFile)
+		err := config.WriteConfig(cfgFile, Conf)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/cmd/session/init.go
+++ b/cmd/session/init.go
@@ -26,72 +26,72 @@
 package session
 
 import (
+	"os"
+
 	root "github.com/Cray-HPE/cani/cmd"
+	"github.com/Cray-HPE/cani/cmd/taxonomy"
+	"github.com/Cray-HPE/cani/internal/provider/csm"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
 )
 
 var (
 	dryrun                   bool
 	commit                   bool
 	ignoreExternalValidation bool
-	k8sPodsCidr              string
-	k8sServicesCidr          string
-	kubeconfig               string
-	caCertPath               string
-	insecure                 bool
-	secretName               string
-	clientId                 string
-	clientSecret             string
-	providerHost             string
-	tokenUsername            string
-	tokenPassword            string
-	useSimulation            bool
+	ignoreValidationMessage  = "Ignore validation failures. Use this to allow unconventional configurations."
+	csmInitCmd               = &cobra.Command{}
+
+	// BootstapCmd is used to start a session with a specific provider and allows the provider to define
+	// how the real init command is defined using their custom business logic
+	BootstrapCmd = &cobra.Command{
+		Use:       "init PROVIDER",
+		Short:     taxonomy.InitShort,
+		Long:      taxonomy.InitLong,
+		ValidArgs: taxonomy.SupportedProviders, // supported providers are defined in the taxonomy
+		Args:      validProvider,               // validate the arg with more contextual help dialogs
+		RunE:      runProviderCmd,
+	}
 )
 
 func init() {
-	// temporary varables for shared messages
-	ignoreValidationMessage :=
-		"(CSM Provider) Ignore validation failures. Use this to allow unconventional SLS configurations."
+	// init is run once, and this is where the flags get set
+	// since flags vary by provider, create a variable for each
+	var err error
+	for _, provider := range taxonomy.SupportedProviders {
+		switch provider {
+		case taxonomy.CSM:
+			csmInitCmd, err = csm.NewSessionInitCommand()
+			csmInitCmd.Use = "init"
+		default:
+			log.Debug().Msgf("skipping provider: %s", provider)
+		}
+		if err != nil {
+			log.Error().Msgf("unable to get cmd from provider: %v", err)
+			os.Exit(1)
+		}
+	}
+
+	// Define the bare minimum needed to determine who the provider for the session will be
+	BootstrapCmd.Flags().BoolVar(&ignoreExternalValidation, "ignore-validation", false, ignoreValidationMessage)
 
 	// Add session commands to root commands
-	root.SessionCmd.AddCommand(SessionInitCmd)
+	root.SessionCmd.AddCommand(BootstrapCmd)
+	BootstrapCmd.AddCommand(csmInitCmd)
 	root.SessionCmd.AddCommand(SessionApplyCmd)
 	root.SessionCmd.AddCommand(SessionStatusCmd)
 	root.SessionCmd.AddCommand(SessionSummaryCmd)
-
-	// Session start flags
-	// TODO need a quick simulation environment flag
-	SessionInitCmd.Flags().String("csm-url-sls", "", "(CSM Provider) Base URL for the System Layout Service (SLS)")
-	SessionInitCmd.Flags().String("csm-url-hsm", "", "(CSM Provider) Base URL for the Hardware State Manager (HSM)")
-	SessionInitCmd.Flags().BoolVarP(&insecure, "csm-insecure-https", "k", false, "(CSM Provider) Allow insecure connections when using HTTPS to CSM services")
-	SessionInitCmd.Flags().BoolVarP(&useSimulation, "csm-simulator", "S", false, "(CSM Provider) Use simulation environment URLs")
-
-	// These three pieces are needed for the CSM provider to get a token
-	SessionInitCmd.Flags().StringVar(&providerHost, "csm-api-host", "api-gw-service.local", "(CSM Provider) Host or FQDN for authentation and APIs")
-	// SessionInitCmd.MarkFlagRequired("csm-api-host")
-	SessionInitCmd.Flags().StringVar(&tokenUsername, "csm-keycloak-username", "", "(CSM Provider) Keycloak username")
-	// SessionInitCmd.MarkFlagRequired("csm-keycloak-username")
-	SessionInitCmd.Flags().StringVar(&tokenPassword, "csm-keycloak-password", "", "(CSM Provider) Keycloak password")
-	// SessionInitCmd.MarkFlagRequired("csm-keycloak-password")
-	SessionInitCmd.MarkFlagsRequiredTogether("csm-api-host", "csm-keycloak-username", "csm-keycloak-password")
-	// TODO the API token, do we save ito the file?
-
-	SessionInitCmd.Flags().StringVar(&k8sPodsCidr, "csm-k8s-pods-cidr", "10.32.0.0/12", "(CSM Provider) CIDR used by kubernetes for pods")
-	SessionInitCmd.Flags().StringVar(&k8sServicesCidr, "csm-k8s-services-cidr", "10.16.0.0/12", "(CSM Provider) CIDR used by kubernetes for services")
-	// Less secure auth methods for CSM that follow existing patterns, but to discourage use, mark them hidden
-	SessionInitCmd.Flags().StringVar(&kubeconfig, "csm-kube-config", "", "(CSM Provider) Path to the kube config file") // /etc/kubernetes/admin.conf
-	SessionInitCmd.Flags().MarkHidden("kube-config")
-	SessionInitCmd.Flags().StringVar(&caCertPath, "csm-ca-cert", "", "Path to the CA certificate file") // /etc/pki/trust/anchors/platform-ca-certs.crt"
-	SessionInitCmd.Flags().MarkHidden("csm-ca-cert")
-	SessionInitCmd.Flags().StringVar(&secretName, "csm-secret-name", "admin-client-auth", "(CSM Provider) secret name")
-	SessionInitCmd.Flags().MarkHidden("csm-secret-name")
-	SessionInitCmd.Flags().StringVar(&clientId, "csm-client-id", "", "(CSM Provider) Client ID")
-	SessionInitCmd.Flags().MarkHidden("csm-client-id")
-	SessionInitCmd.Flags().StringVar(&clientSecret, "csm-client-secret", "", "(CSM Provider) Client Secret")
-	SessionInitCmd.Flags().MarkHidden("csm-client-secret")
-	SessionInitCmd.Flags().BoolVar(&ignoreExternalValidation, "ignore-validation", false, ignoreValidationMessage)
 
 	// Session stop flags
 	SessionApplyCmd.Flags().BoolVarP(&commit, "commit", "c", false, "Commit changes to session")
 	SessionApplyCmd.Flags().BoolVarP(&dryrun, "dryrun", "d", false, "Perform dryrun, and do not make changes to the system")
 	SessionApplyCmd.Flags().BoolVar(&ignoreExternalValidation, "ignore-validation", false, ignoreValidationMessage)
+
+	// all flags should be set in init().  you can set flags after the fact, but it is much easier to work with everything up front
+	// this will set existing variables for each provider
+	err = getProviderFlags(BootstrapCmd, []string{})
+	if err != nil {
+		log.Error().Msgf("unable to get flags from provider: %v", err)
+		os.Exit(1)
+	}
 }

--- a/cmd/session/session_init.go
+++ b/cmd/session/session_init.go
@@ -29,72 +29,91 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
-	"strings"
 
 	root "github.com/Cray-HPE/cani/cmd"
 	"github.com/Cray-HPE/cani/cmd/config"
+	"github.com/Cray-HPE/cani/cmd/taxonomy"
 	"github.com/Cray-HPE/cani/internal/domain"
 	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/manifoldco/promptui"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
-// SessionInitCmd represents the session init command
-var SessionInitCmd = &cobra.Command{
-	Use:                "init",
-	Short:              "Initialize and start a session. Will perform an import of system's inventory format.",
-	Long:               `Initialize and start a session. Will perform an import of system's inventory format.`,
-	Args:               validProvider,
-	ValidArgs:          validArgs,
-	SilenceUsage:       true, // Errors are more important than the usage
-	RunE:               startSession,
-	PersistentPostRunE: writeSession,
+// getProviderFlags creates a new init command
+// Initilizing a session is where all the information needed to interact with the inventory system(s) is gathered
+// Plugin authors can call this to create their own flags based on their custom business logic
+// A few common flags are set here, but the rest is up to the plugin author
+func getProviderFlags(cmd *cobra.Command, args []string) (err error) {
+	providerFlagset := &pflag.FlagSet{}
+
+	// get the appropriate flagset from the provider's crafted command
+	providerFlagset = csmInitCmd.Flags()
+
+	if err != nil {
+		return err
+	}
+
+	// add the provider flags to the command
+	cmd.Flags().AddFlagSet(providerFlagset)
+
+	return nil
 }
 
-var (
-	validArgs = []string{"csm"}
-)
-
-// startSession starts a session if one does not exist
-func startSession(cmd *cobra.Command, args []string) error {
-	if useSimulation {
-		log.Warn().Msg("Using simulation mode")
-		root.Conf.Session.DomainOptions.CsmOptions.UseSimulation = true
-	} else {
-		slsUrl, _ := cmd.Flags().GetString("csm-url-sls")
-		if slsUrl != "" {
-			root.Conf.Session.DomainOptions.CsmOptions.BaseUrlSLS = slsUrl
-		} else {
-			root.Conf.Session.DomainOptions.CsmOptions.BaseUrlSLS = fmt.Sprintf("https://%s/apis/sls/v1", providerHost)
-		}
-		hsmUrl, _ := cmd.Flags().GetString("csm-url-hsm")
-		if hsmUrl != "" {
-			root.Conf.Session.DomainOptions.CsmOptions.BaseUrlHSM = hsmUrl
-		} else {
-			root.Conf.Session.DomainOptions.CsmOptions.BaseUrlHSM = fmt.Sprintf("https://%s/apis/smd/hsm/v2", providerHost)
-		}
-		root.Conf.Session.DomainOptions.CsmOptions.InsecureSkipVerify, _ = cmd.Flags().GetBool("csm-insecure-https")
+func runProviderCmd(cmd *cobra.Command, args []string) (err error) {
+	log.Debug().Msgf("running init with provider-defined command")
+	providerName := args[0]
+	switch providerName {
+	case taxonomy.CSM:
+		cmd = csmInitCmd
+	default:
+		log.Debug().Msgf("skipping provider: %s", providerName)
 	}
-	if insecure {
-		root.Conf.Session.DomainOptions.CsmOptions.InsecureSkipVerify = true
-	}
-	root.Conf.Session.DomainOptions.CsmOptions.SecretName = secretName
-	root.Conf.Session.DomainOptions.CsmOptions.K8sPodsCidr = k8sPodsCidr
-	root.Conf.Session.DomainOptions.CsmOptions.K8sServicesCidr = k8sServicesCidr
-	root.Conf.Session.DomainOptions.CsmOptions.KubeConfig = kubeconfig
-	root.Conf.Session.DomainOptions.CsmOptions.CaCertPath = caCertPath
-	root.Conf.Session.DomainOptions.CsmOptions.ClientID = clientId
-	root.Conf.Session.DomainOptions.CsmOptions.ClientSecret = clientSecret
-	root.Conf.Session.DomainOptions.CsmOptions.ProviderHost = strings.TrimRight(providerHost, "/") // Remove trailing slash if present
-	root.Conf.Session.DomainOptions.CsmOptions.TokenUsername = tokenUsername
-	root.Conf.Session.DomainOptions.CsmOptions.TokenPassword = tokenPassword
 
+	err = initSessionWithProviderCmd(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func initSessionWithProviderCmd(cmd *cobra.Command, args []string) (err error) {
+	// Create a domain object to interact with the datastore and the provider
+	root.D, err = domain.New(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	// Set the datastore
+	log.Debug().Msgf("checking provider %s", root.D.Provider)
+	switch root.D.Provider {
+	case taxonomy.CSM:
+		root.D.DatastorePath = filepath.Join(config.ConfigDir, taxonomy.DsFileCSM)
+	default:
+		root.D.DatastorePath = filepath.Join(config.ConfigDir, taxonomy.DsFile)
+	}
+	// Set the paths needed for starting a session
+	root.D.CustomHardwareTypesDir = config.CustomDir
+	root.D.LogFilePath = filepath.Join(config.ConfigDir, taxonomy.LogFile)
+
+	log.Debug().Msgf("creating domain object for provider %s", args[0])
+	// Setup the domain now that the minimum required options are set
+	// This allows the provider to define their own logic and keeps it out
+	// of the 'cmd' package
+	err = root.D.SetupDomain(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	log.Debug().Msgf("checking if domain is active")
 	// If a session is already active, there is nothing to do but the user may want to overwrite the existing session
-	if root.Conf.Session.Active {
+	if root.D.Active {
 		log.Info().Msgf("Session is already ACTIVE.")
-		ds := root.Conf.Session.DomainOptions.DatastorePath
+		ds := root.D.DatastorePath
 		// Check if the json file exists
 		if _, err := os.Stat(ds); err == nil {
 			// If the json file exists, prompt user for overwrite
@@ -114,21 +133,8 @@ func startSession(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Create a domain object to interact with the datastore
-	var err error
-	root.Conf.Session.Domain, err = domain.New(root.Conf.Session.DomainOptions)
-	if err != nil {
-		return err
-	}
-
-	err = root.Conf.Session.Domain.SetConfigOptions(cmd.Context(), root.Conf.Session.DomainOptions)
-	if err != nil {
-		return errors.Join(err,
-			errors.New("External inventory is unstable. Unable to get provider specific config options. Fix issues before starting another session."))
-	}
-
-	// Validate the external inventory
-	result, err := root.Conf.Session.Domain.Validate(cmd.Context(), false, ignoreExternalValidation)
+	// Validate the external inventory before attempting an import
+	result, err := root.D.Validate(cmd.Context(), false, ignoreExternalValidation)
 	if errors.Is(err, provider.ErrDataValidationFailure) {
 		// TODO the following should probably suggest commands to fix the issue?
 		log.Error().Msgf("Inventory data validation errors encountered")
@@ -139,35 +145,31 @@ func startSession(cmd *cobra.Command, args []string) error {
 				log.Error().Msgf("    - %s", validationError)
 			}
 		}
-
 		return err
 	} else if err != nil {
 		return errors.Join(err,
-			errors.New("External inventory is unstable.  Fix issues before starting another session."))
+			errors.New("External inventory is unstable"),
+			errors.New("fix issues before starting another session"))
 	}
 
-	// Commit the external inventory
-	if err := root.Conf.Session.Domain.Import(cmd.Context()); err != nil {
+	// Import the external inventory
+	if err := root.D.Import(cmd.Context()); err != nil {
 		return err
 	}
 
 	// "Activate" the session
-	root.Conf.Session.Active = true
+	root.D.Active = true
 
-	ds := root.Conf.Session.DomainOptions.DatastorePath
-	provider := root.Conf.Session.DomainOptions.Provider
-	log.Info().Msgf("Session is now ACTIVE with provider %s and datastore %s", provider, ds)
-	return nil
-}
+	// add this provider to the config with the assembled domain object
+	root.Conf.Session.Domains[args[0]] = root.D
 
-// writeSession writes the session configuration back to the config file
-func writeSession(cmd *cobra.Command, args []string) error {
-	// Write the configuration back to the file
-	cfgFile := cmd.Root().PersistentFlags().Lookup("config").Value.String()
-	err := config.WriteConfig(cfgFile, root.Conf)
+	// write the config to the file
+	err = root.WriteSession(cmd, args)
 	if err != nil {
 		return err
 	}
+
+	log.Info().Msgf("Session is now ACTIVE with provider %s and datastore %s", root.D.Provider, root.D.DatastorePath)
 	return nil
 }
 

--- a/cmd/session/session_status.go
+++ b/cmd/session/session_status.go
@@ -36,29 +36,28 @@ import (
 
 // SessionStatusCmd represents the session status command
 var SessionStatusCmd = &cobra.Command{
-	Use:          "status",
-	Short:        "View session status.",
-	Long:         `View session status.`,
-	SilenceUsage: true, // Errors are more important than the usage
-	RunE:         showSession,
+	Use:   "status",
+	Short: "View session status.",
+	Long:  `View session status.`,
+	RunE:  showSession,
 }
 
 // showSession shows the status of the session
 func showSession(cmd *cobra.Command, args []string) error {
-	ds := root.Conf.Session.DomainOptions.DatastorePath
-	provider := root.Conf.Session.DomainOptions.Provider
-	conf := root.RootCmd.Flag("config").Value.String()
-
-	// If the session is active, check that the datastore exists
-	log.Info().Msgf("See %s for session details", conf)
-	if root.Conf.Session.Active {
-		_, err := os.Stat(ds)
-		if err != nil {
-			return fmt.Errorf("Session is ACTIVE with provider '%s' but datastore '%s' does not exist", provider, ds)
+	for p, d := range root.Conf.Session.Domains {
+		if d.Active {
+			ds := d.DatastorePath
+			conf := root.RootCmd.PersistentFlags().Lookup("config").Value.String()
+			// If the session is active, check that the datastore exists
+			_, err := os.Stat(ds)
+			if err != nil {
+				return fmt.Errorf("Session is ACTIVE with provider '%s' but datastore '%s' does not exist", p, ds)
+			}
+			log.Info().Msgf("Session is ACTIVE for %s", p)
+			log.Info().Msgf("See %s for session details", conf)
+		} else {
+			log.Info().Msgf("Session is INACTIVE for %s", p)
 		}
-		log.Info().Msgf("Session is ACTIVE")
-	} else {
-		log.Info().Msgf("Session is INACTIVE")
 	}
 
 	return nil

--- a/cmd/session/validate.go
+++ b/cmd/session/validate.go
@@ -28,16 +28,11 @@ package session
 import (
 	"fmt"
 
-	root "github.com/Cray-HPE/cani/cmd"
 	"github.com/spf13/cobra"
 )
 
 // validProvider checks that the provider is valid and that at least one argument is provided
-func validProvider(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("Need a provider.  Choose from: %+v", validArgs)
-	}
-
+func validProvider(cmd *cobra.Command, args []string) (err error) {
 	// This helper function checks if a provider is valid.
 	isValidProvider := func(provider string) bool {
 		for _, validArg := range cmd.ValidArgs {
@@ -49,21 +44,10 @@ func validProvider(cmd *cobra.Command, args []string) error {
 	}
 
 	// Check the session provider.
-	sessionProvider := root.Conf.Session.DomainOptions.Provider
-	if sessionProvider == "" {
-		// Check that at least one argument is provided.
-		if len(args) < 1 {
-			return fmt.Errorf("Need a provider.  Choose from: %+v", validArgs)
-		}
-	} else if !isValidProvider(sessionProvider) {
-		return fmt.Errorf("%s is not a valid provider.  Valid providers: %+v", sessionProvider, validArgs)
-	}
-
-	// Check all argument providers.
-	for _, arg := range args {
-		if !isValidProvider(arg) {
-			return fmt.Errorf("%s is not a valid provider.  Valid providers: %+v", arg, validArgs)
-		}
+	if len(args) != 1 {
+		return fmt.Errorf("Need a provider.  Choose from: %+v", cmd.ValidArgs)
+	} else if !isValidProvider(args[0]) {
+		return fmt.Errorf("%s is not a valid provider.  Valid providers: %+v", args[0], cmd.ValidArgs)
 	}
 
 	return nil

--- a/cmd/taxonomy/taxonomy.go
+++ b/cmd/taxonomy/taxonomy.go
@@ -27,20 +27,29 @@ package taxonomy
 
 import (
 	"path/filepath"
+	"sort"
 )
 
 const (
 	App              = "cani"
+	CSM              = "csm"
 	DsFile           = App + "db.json"
+	DsFileCSM        = App + "db.json"
 	LogFile          = App + "db.log"
 	CfgFile          = App + ".yml"
 	CfgDir           = "." + App
-	SessionExt       = ".session"
 	ShortDescription = "From subfloor to top-of-rack, manage your HPC cluster's inventory!"
 	LongDescription  = `From subfloor to top-of-rack, manage your HPC cluster's inventory!`
+	InitShort        = `Initialize a session and import from the chosen provider.`
+	InitLong         = `Initialize a session. This will perform an import using provider-defined logic.`
 )
 
 var (
-	DsPath  = filepath.Join(CfgDir, DsFile)
-	CfgPath = filepath.Join(CfgDir, CfgFile)
+	DsPath             = filepath.Join(CfgDir, DsFile)
+	CfgPath            = filepath.Join(CfgDir, CfgFile)
+	SupportedProviders = []string{CSM}
 )
+
+func init() {
+	sort.Strings(SupportedProviders)
+}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -24,31 +24,3 @@
  *
  */
 package cmd
-
-import (
-	"fmt"
-	"os"
-
-	"github.com/spf13/cobra"
-)
-
-// DatastoreExists checks that the datastore exists
-func DatastoreExists(cmd *cobra.Command, args []string) error {
-	// Check that at least one argument is provided
-	if !Conf.Session.Active {
-		return fmt.Errorf("No active session.  Run 'session start' to begin")
-	}
-
-	// Check that at least one argument is provided
-	if Conf.Session.DomainOptions.DatastorePath == "" {
-		return fmt.Errorf("Need a datastore path.  Run 'session start' to begin")
-	}
-
-	// if datastore does not exist
-	if _, err := os.Stat(Conf.Session.DomainOptions.DatastorePath); os.IsNotExist(err) {
-		ds := Conf.Session.DomainOptions.DatastorePath
-		return fmt.Errorf("Datastore '%s' does not exist.  Run 'session start' to begin", ds)
-	}
-
-	return nil
-}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -29,7 +29,6 @@ import (
 	"errors"
 	"sort"
 
-	"github.com/Cray-HPE/cani/internal/domain"
 	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -38,23 +37,18 @@ import (
 
 // ValidateCmd represents the validate command
 var ValidateCmd = &cobra.Command{
-	Use:          "validate",
-	Short:        "Validate assets in the inventory.",
-	Long:         `Validate assets in the inventory.`,
-	SilenceUsage: true, // Errors are more important than the usage
-	RunE:         validateInventory,
+	Use:   "validate",
+	Short: "Validate assets in the inventory.",
+	Long:  `Validate assets in the inventory.`,
+	RunE:  validateInventory,
 }
 
 func validateInventory(cmd *cobra.Command, args []string) error {
 	log.Warn().Msg("This may fail in the HMS Simulator without Network information.")
-	if Conf.Session.Active {
-		// Create a domain object to interact with the datastore
-		d, err := domain.New(Conf.Session.DomainOptions)
-		if err != nil {
-			return err
-		}
+	if D.Active {
+
 		// Validate the external inventory
-		result, err := d.Validate(cmd.Context(), true, false)
+		result, err := D.Validate(cmd.Context(), true, false)
 		if errors.Is(err, provider.ErrDataValidationFailure) {
 			// TODO the following should probably suggest commands to fix the issue?
 			log.Error().Msgf("Inventory data validation errors encountered")

--- a/internal/domain/blade.go
+++ b/internal/domain/blade.go
@@ -58,7 +58,7 @@ func (d *Domain) AddBlade(ctx context.Context, deviceTypeSlug string, cabinetOrd
 	if !exists {
 		return AddHardwareResult{}, errors.Join(
 			fmt.Errorf("unable to find %s at %s", hardwaretypes.Cabinet, cabinetPath),
-			fmt.Errorf("try 'go run main.go alpha list cabinet'"),
+			fmt.Errorf("try 'list cabinet'"),
 		)
 	}
 
@@ -174,7 +174,6 @@ func (d *Domain) AddBlade(ctx context.Context, deviceTypeSlug string, cabinetOrd
 			// Generate the CANI hardware inventory version of the hardware build out data
 			hardware = inventory.NewHardwareFromBuildOut(hardwareBuildOut, inventory.HardwareStatusStaged)
 
-			log.Debug().Any("id", hardware.ID).Msg("Hardware")
 			log.Debug().Str("path", hardwareBuildOut.LocationPath.String()).Msg("Hardware Build out")
 
 			// TODO need a check to see if all the needed information exists,

--- a/internal/domain/commit.go
+++ b/internal/domain/commit.go
@@ -41,7 +41,6 @@ type CommitResult struct {
 
 func (d *Domain) Commit(ctx context.Context, dryrun bool, ignoreExternalValidation bool) (CommitResult, error) {
 	inventoryProvider := d.externalInventoryProvider
-
 	// Perform validation integrity of CANI's inventory data
 	// TODO handle validation result
 	if _, err := d.datastore.Validate(); err != nil {
@@ -65,7 +64,7 @@ func (d *Domain) Commit(ctx context.Context, dryrun bool, ignoreExternalValidati
 	}
 
 	// Validate the current state of the external inventory
-	if err := inventoryProvider.ValidateExternal(ctx, d.configOptions); err != nil {
+	if err := inventoryProvider.ValidateExternal(ctx); err != nil {
 		if ignoreExternalValidation {
 			log.Warn().Msgf("Ignoring these failures:\n%s", err)
 		} else {
@@ -76,5 +75,5 @@ func (d *Domain) Commit(ctx context.Context, dryrun bool, ignoreExternalValidati
 	}
 
 	// Reconcile our inventory with the external inventory system
-	return CommitResult{}, inventoryProvider.Reconcile(ctx, d.configOptions, d.datastore, dryrun, ignoreExternalValidation)
+	return CommitResult{}, inventoryProvider.Reconcile(ctx, d.datastore, dryrun, ignoreExternalValidation)
 }

--- a/internal/domain/csv.go
+++ b/internal/domain/csv.go
@@ -58,12 +58,8 @@ var (
 		"nid":            "Nid"}
 )
 
-func (d *Domain) ListCsvOptions(ctx context.Context, opts *DomainOpts) error {
-	configOptions := provider.ConfigOptions{
-		ValidRoles:    opts.CsmOptions.ValidRoles,
-		ValidSubRoles: opts.CsmOptions.ValidSubRoles,
-	}
-	metadata, err := d.externalInventoryProvider.GetFieldMetadata(configOptions)
+func (d *Domain) ListCsvOptions(ctx context.Context) error {
+	metadata, err := d.externalInventoryProvider.GetFieldMetadata()
 	if err != nil {
 		return err
 	}
@@ -130,6 +126,17 @@ func (d *Domain) ExportCsv(ctx context.Context, writer *csv.Writer, headers []st
 		}
 		writer.Flush()
 	}
+	return nil
+}
+
+func (d *Domain) ExportJson(ctx context.Context, writer io.Writer, skipValidation bool) error {
+	exportedJson, err := d.externalInventoryProvider.ExportJson(ctx, d.datastore, skipValidation)
+	if err != nil {
+		return err
+	}
+	writer.Write(exportedJson)
+	writer.Write([]byte("\n"))
+
 	return nil
 }
 

--- a/internal/domain/domain_optional.go
+++ b/internal/domain/domain_optional.go
@@ -24,31 +24,3 @@
  *
  */
 package domain
-
-import (
-	"context"
-	"fmt"
-	"io"
-
-	"github.com/Cray-HPE/cani/internal/provider"
-)
-
-// The functions in this file are optional and are not expected to implemented for every provider.
-// TODO Refactor this if/when the design is changed to better handle provider specific features
-
-func (d *Domain) ExportSls(ctx context.Context, writer io.Writer, skipValidation bool) error {
-	switch d.externalInventoryProvider.(type) {
-	case provider.SlsProvider:
-		provider := d.externalInventoryProvider.(provider.SlsProvider)
-		slsJson, err := provider.GetSlsJson(ctx, d.configOptions, d.datastore, skipValidation)
-		if err != nil {
-			return err
-		}
-		writer.Write(slsJson)
-		writer.Write([]byte("\n"))
-	default:
-		return fmt.Errorf("export sls is not supported by the selected provider")
-	}
-
-	return nil
-}

--- a/internal/domain/misc.go
+++ b/internal/domain/misc.go
@@ -82,7 +82,7 @@ func (d *Domain) Validate(ctx context.Context, checkRequiredData bool, ignoreExt
 	log.Info().Msg("Validated CANI inventory")
 
 	// Validate external inventory data
-	err := d.externalInventoryProvider.ValidateExternal(ctx, d.configOptions)
+	err := d.externalInventoryProvider.ValidateExternal(ctx)
 	if err != nil {
 		if ignoreExternalValidation {
 			log.Warn().Msgf("Ignoring these failures: %s", err)
@@ -93,27 +93,4 @@ func (d *Domain) Validate(ctx context.Context, checkRequiredData bool, ignoreExt
 
 	log.Info().Msg("Validated external inventory provider")
 	return result, nil
-}
-
-func (d *Domain) SetConfigOptions(ctx context.Context, opts *DomainOpts) (err error) {
-	options, err := d.externalInventoryProvider.ConfigOptions(ctx)
-	if err != nil {
-		return err
-	}
-	switch opts.Provider {
-	case string(inventory.CSMProvider):
-		opts.CsmOptions.ValidRoles = options.ValidRoles
-		d.configOptions.ValidRoles = options.ValidRoles
-
-		opts.CsmOptions.ValidSubRoles = options.ValidSubRoles
-		d.configOptions.ValidSubRoles = options.ValidSubRoles
-
-		opts.CsmOptions.K8sPodsCidr = options.K8sPodsCidr
-		d.configOptions.K8sPodsCidr = options.K8sPodsCidr
-
-		opts.CsmOptions.K8sServicesCidr = options.K8sServicesCidr
-		d.configOptions.K8sServicesCidr = options.K8sServicesCidr
-	}
-
-	return nil
 }

--- a/internal/inventory/model.go
+++ b/internal/inventory/model.go
@@ -102,7 +102,7 @@ func (i *Inventory) FilterHardwareByTypeStatus(status HardwareStatus, types ...h
 // Hardware is the smallest unit of inventory
 // It has all the potential fields that hardware can have
 type Hardware struct {
-	ID               uuid.UUID
+	ID               uuid.UUID                        `json:"ID" yaml:"ID" default:"" usage:"Unique Identifier"`
 	Name             string                           `json:"Name,omitempty" yaml:"Name,omitempty" default:"" usage:"Friendly name"`
 	Type             hardwaretypes.HardwareType       `json:"Type,omitempty" yaml:"Type,omitempty" default:"" usage:"Type"`
 	DeviceTypeSlug   string                           `json:"DeviceTypeSlug,omitempty" yaml:"DeviceTypeSlug,omitempty" default:"" usage:"Hardware Type Library Device slug"`
@@ -112,13 +112,10 @@ type Hardware struct {
 	Status           HardwareStatus                   `json:"Status,omitempty" yaml:"Status,omitempty" default:"Staged" usage:"Hardware can be [staged, provisioned, decomissioned]"`
 	Properties       map[string]interface{}           `json:"Properties,omitempty" yaml:"Properties,omitempty" default:"" usage:"Properties"`
 	ProviderMetadata map[Provider]ProviderMetadataRaw `json:"ProviderMetadata,omitempty" yaml:"ProviderMetadata,omitempty" default:"" usage:"ProviderMetadata"`
-
-	Parent uuid.UUID `json:"Parent,omitempty" yaml:"Parent,omitempty" default:"00000000-0000-0000-0000-000000000000" usage:"Parent hardware"`
-	// The following are derived from Parent
-	Children     []uuid.UUID  `json:"Children,omitempty" yaml:"Children,omitempty"`
-	LocationPath LocationPath `json:"LocationPath,omitempty" yaml:"LocationPath,omitempty"`
-
-	LocationOrdinal *int
+	Parent           uuid.UUID                        `json:"Parent,omitempty" yaml:"Parent,omitempty" default:"00000000-0000-0000-0000-000000000000" usage:"Parent hardware"`
+	Children         []uuid.UUID                      `json:"Children,omitempty" yaml:"Children,omitempty"`         // derived from Parent
+	LocationPath     LocationPath                     `json:"LocationPath,omitempty" yaml:"LocationPath,omitempty"` // derived from Parent
+	LocationOrdinal  *int                             `json:"LocationOrdinal,omitempty" yaml:"LocationOrdinal,omitempty" default:"" usage:"LocationOrdinal"`
 }
 
 func (hardware *Hardware) SetProviderMetadata(provider Provider, metadata map[string]interface{}) {

--- a/internal/provider/csm/config_options.go
+++ b/internal/provider/csm/config_options.go
@@ -26,26 +26,153 @@
 package csm
 
 import (
-	"context"
+	"fmt"
+	"strings"
 
-	"github.com/Cray-HPE/cani/internal/provider"
+	"github.com/Cray-HPE/cani/cmd/taxonomy"
+	"github.com/Cray-HPE/cani/internal/provider/csm/validate"
+	"github.com/mitchellh/mapstructure"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	hsm_client "github.com/Cray-HPE/cani/pkg/hsm-client"
+	sls_client "github.com/Cray-HPE/cani/pkg/sls-client"
 )
 
-func (csm *CSM) ConfigOptions(ctx context.Context) (provider.ConfigOptions, error) {
-	providerConfig := provider.ConfigOptions{}
+type CsmOpts struct {
+	UseSimulation      bool     `json:"UseSimulation" yaml:"use_simulation"`
+	InsecureSkipVerify bool     `json:"InsecureSkipVerify" yaml:"insecure_skip_verify"`
+	APIGatewayToken    string   `json:"APIGatewayToken" yaml:"api_gateway_token"`
+	BaseUrlSLS         string   `json:"BaseUrlSLS" yaml:"base_url_sls"`
+	BaseUrlHSM         string   `json:"BaseUrlHSM" yaml:"base_url_hsm"`
+	SecretName         string   `json:"SecretName" yaml:"secret_name"`
+	K8sPodsCidr        string   `json:"K8sPodsCidr" yaml:"k8s_pods_cidr"`
+	K8sServicesCidr    string   `json:"K8sServicesCidr" yaml:"k8s_services_cidr"`
+	KubeConfig         string   `json:"KubeConfig" yaml:"kubeconfig"`
+	ClientID           string   `json:"-" yaml:"-"` // omit credentials from cani.yml
+	ClientSecret       string   `json:"-" yaml:"-"` // omit credentials from cani.yml
+	ProviderHost       string   `json:"ProviderHost" yaml:"provider_host"`
+	TokenUsername      string   `json:"-" yaml:"-"` // omit credentials from cani.yml
+	TokenPassword      string   `json:"-" yaml:"-"` // omit credentials from cani.yml
+	CaCertPath         string   `json:"CaCertPath" yaml:"ca_cert_path"`
+	ValidRoles         []string `json:"ValidRoles" yaml:"valid_roles"`
+	ValidSubRoles      []string `json:"ValidSubRoles" yaml:"valid_sub_roles"`
+}
 
-	// get valid roles and subroles from hsm
-	values, _, err := csm.hsmClient.ServiceInfoApi.DoValuesGet(ctx)
-	if err != nil {
-		return providerConfig, err
+func (csm *CSM) SetProviderOptions(cmd *cobra.Command, args []string) error {
+	useSimulation := cmd.Flags().Changed("csm-simulator")
+	slsUrl, _ := cmd.Flags().GetString("csm-url-sls")
+	hsmUrl, _ := cmd.Flags().GetString("csm-url-hsm")
+	insecure := cmd.Flags().Changed("csm-insecure-https")
+	providerHost, _ := cmd.Flags().GetString("csm-api-host")
+	tokenUsername, _ := cmd.Flags().GetString("csm-keycloak-username")
+	tokenPassword, _ := cmd.Flags().GetString("csm-keycloak-password")
+	k8sPodsCidr, _ := cmd.Flags().GetString("csm-k8s-pods-cidr")
+	k8sServicesCidr, _ := cmd.Flags().GetString("csm-k8s-services-cidr")
+	kubeconfig, _ := cmd.Flags().GetString("csm-kube-config")
+	caCertPath, _ := cmd.Flags().GetString("csm-ca-cert")
+	secretName, _ := cmd.Flags().GetString("csm-secret-name")
+	clientId, _ := cmd.Flags().GetString("csm-client-id")
+	clientSecret, _ := cmd.Flags().GetString("csm-client-secret")
+
+	if useSimulation {
+		log.Warn().Msg("Using simulation mode")
+		csm.Options.UseSimulation = useSimulation
+		insecure = true
+		if !cmd.Flags().Changed("csm-api-host") {
+			providerHost = "localhost:8443"
+		}
 	}
-	providerConfig.ValidRoles = values.Role
-	providerConfig.ValidSubRoles = values.SubRole
-
+	if insecure {
+		csm.Options.InsecureSkipVerify = true
+	}
+	if slsUrl != "" {
+		csm.Options.BaseUrlSLS = slsUrl
+	} else {
+		csm.Options.BaseUrlSLS = fmt.Sprintf("https://%s/apis/sls/v1", providerHost)
+	}
+	if hsmUrl != "" {
+		csm.Options.BaseUrlHSM = hsmUrl
+	} else {
+		csm.Options.BaseUrlHSM = fmt.Sprintf("https://%s/apis/smd/hsm/v2", providerHost)
+	}
+	csm.Options.InsecureSkipVerify = insecure
+	csm.Options.SecretName = secretName
 	// todo get these values from bss in the Global bootparameters in
 	// the fields: kubernetes-pods-cidr and kubernetes-services-cidr
-	providerConfig.K8sPodsCidr = "10.32.0.0/12"
-	providerConfig.K8sServicesCidr = "10.16.0.0/12"
+	csm.Options.K8sPodsCidr = k8sPodsCidr
+	csm.Options.K8sServicesCidr = k8sServicesCidr
+	csm.Options.KubeConfig = kubeconfig
+	csm.Options.CaCertPath = caCertPath
+	csm.Options.ClientID = clientId
+	csm.Options.ClientSecret = clientSecret
+	csm.Options.ProviderHost = strings.TrimRight(providerHost, "/") // Remove trailing slash if present
+	csm.Options.TokenUsername = tokenUsername
+	csm.Options.TokenPassword = tokenPassword
 
-	return providerConfig, nil
+	// Setup HTTP client and context using csm options
+	httpClient, _, err := csm.newClient()
+	if err != nil {
+		return err
+	}
+
+	slsClientConfiguration := &sls_client.Configuration{
+		BasePath:   csm.Options.BaseUrlSLS,
+		HTTPClient: httpClient.StandardClient(),
+		UserAgent:  taxonomy.App,
+		DefaultHeader: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	hsmClientConfiguration := &hsm_client.Configuration{
+		BasePath:   csm.Options.BaseUrlHSM,
+		HTTPClient: httpClient.StandardClient(),
+		UserAgent:  taxonomy.App,
+		DefaultHeader: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	if csm.Options.APIGatewayToken != "" {
+		// Set the token for use in the clients
+		slsClientConfiguration.DefaultHeader["Authorization"] = fmt.Sprintf("Bearer %s", csm.Options.APIGatewayToken)
+		hsmClientConfiguration.DefaultHeader["Authorization"] = fmt.Sprintf("Bearer %s", csm.Options.APIGatewayToken)
+	}
+
+	// Set the clients
+	csm.slsClient = sls_client.NewAPIClient(slsClientConfiguration)
+	csm.hsmClient = hsm_client.NewAPIClient(hsmClientConfiguration)
+
+	// get valid roles and subroles from hsm
+	hsmValues, _, err := csm.hsmClient.ServiceInfoApi.DoValuesGet(cmd.Context())
+	if err != nil {
+		return err
+	}
+	csm.Options.ValidRoles = hsmValues.Role
+	csm.Options.ValidSubRoles = hsmValues.SubRole
+
+	tbv := &validate.ToBeValidated{}
+	tbv.K8sPodsCidr = csm.Options.K8sPodsCidr
+	tbv.K8sServicesCidr = csm.Options.K8sServicesCidr
+	tbv.ValidRoles = csm.Options.ValidRoles
+	tbv.ValidSubRoles = csm.Options.ValidSubRoles
+	csm.TBV = tbv
+
+	return nil
+}
+
+func (csm *CSM) GetProviderOptions() (interface{}, error) {
+	if csm.Options == nil {
+		return nil, fmt.Errorf("options from CSM are nil")
+	}
+	return csm.Options, nil
+}
+
+func (csm *CSM) SetProviderOptionsInterface(opts interface{}) error {
+	err := mapstructure.Decode(opts, &csm.Options)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/provider/csm/csm.go
+++ b/internal/provider/csm/csm.go
@@ -27,72 +27,189 @@ package csm
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Cray-HPE/cani/cmd/taxonomy"
+	"github.com/Cray-HPE/cani/internal/provider/csm/validate"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 
 	hsm_client "github.com/Cray-HPE/cani/pkg/hsm-client"
 	sls_client "github.com/Cray-HPE/cani/pkg/sls-client"
 )
 
-type ProviderOpts struct {
-	UseSimulation      bool
-	InsecureSkipVerify bool
-	APIGatewayToken    string
-	BaseUrlSLS         string
-	BaseUrlHSM         string
-	SecretName         string
-	K8sPodsCidr        string
-	K8sServicesCidr    string
-	KubeConfig         string
-	ClientID           string `json:"-" yaml:"-"` // omit credentials from cani.yml
-	ClientSecret       string `json:"-" yaml:"-"` // omit credentials from cani.yml
-	ProviderHost       string
-	TokenUsername      string `json:"-" yaml:"-"` // omit credentials from cani.yml
-	TokenPassword      string `json:"-" yaml:"-"` // omit credentials from cani.yml
-	CaCertPath         string
-	ValidRoles         []string
-	ValidSubRoles      []string
-}
-
 type CSM struct {
 	// Clients
-	slsClient *sls_client.APIClient
-	hsmClient *hsm_client.APIClient
-
-	// System Configuration data
-	ValidRoles    []string
-	ValidSubRoles []string
-
+	slsClient       *sls_client.APIClient
+	hsmClient       *hsm_client.APIClient
 	hardwareLibrary *hardwaretypes.Library
+	TBV             *validate.ToBeValidated
+	Options         *CsmOpts
 }
 
-func New(opts *ProviderOpts, hardwareLibrary *hardwaretypes.Library) (*CSM, error) {
-	csm := &CSM{
-		hardwareLibrary: hardwareLibrary,
+func NewSessionInitCommand() (cmd *cobra.Command, err error) {
+	// cmd represents the session init command
+	cmd = &cobra.Command{}
+	cmd.Long = `Query SLS and HSM.  Validate the data against a schema before allowing an import into CANI.`
+	// ValidArgs:    DO NOT CONFIGURE.  This is set by cani's cmd pkg
+	// Args:         DO NOT CONFIGURE.  This is set by cani's cmd pkg
+	// RunE:         DO NOT CONFIGURE.  This is set by cani's cmd pkg
+	// Session init flags
+	cmd.Flags().String("csm-url-sls", "", "(CSM Provider) Base URL for the System Layout Service (SLS)")
+	cmd.Flags().String("csm-url-hsm", "", "(CSM Provider) Base URL for the Hardware State Manager (HSM)")
+	cmd.Flags().BoolVarP(&insecure, "csm-insecure-https", "k", false, "(CSM Provider) Allow insecure connections when using HTTPS to CSM services")
+	cmd.Flags().BoolVarP(&useSimulation, "csm-simulator", "S", false, "(CSM Provider) Use simulation environment URLs")
+
+	// These three pieces are needed for the CSM provider to get a token
+	cmd.Flags().StringVar(&providerHost, "csm-api-host", "api-gw-service.local", "(CSM Provider) Host or FQDN for authentation and APIs")
+	// cmd.MarkFlagRequired("csm-api-host")
+	cmd.Flags().StringVar(&tokenUsername, "csm-keycloak-username", "", "(CSM Provider) Keycloak username")
+	// cmd.MarkFlagRequired("csm-keycloak-username")
+	cmd.Flags().StringVar(&tokenPassword, "csm-keycloak-password", "", "(CSM Provider) Keycloak password")
+	// cmd.MarkFlagRequired("csm-keycloak-password")
+	cmd.MarkFlagsRequiredTogether("csm-api-host", "csm-keycloak-username", "csm-keycloak-password")
+	// TODO the API token, do we save ito the file?
+
+	cmd.Flags().StringVar(&k8sPodsCidr, "csm-k8s-pods-cidr", "10.32.0.0/12", "(CSM Provider) CIDR used by kubernetes for pods")
+	cmd.Flags().StringVar(&k8sServicesCidr, "csm-k8s-services-cidr", "10.16.0.0/12", "(CSM Provider) CIDR used by kubernetes for services")
+	// Less secure auth methods for CSM that follow existing patterns, but to discourage use, mark them hidden
+	cmd.Flags().StringVar(&kubeconfig, "csm-kube-config", "", "(CSM Provider) Path to the kube config file") // /etc/kubernetes/admin.conf
+	cmd.Flags().MarkHidden("kube-config")
+	cmd.Flags().StringVar(&caCertPath, "csm-ca-cert", "", "Path to the CA certificate file") // /etc/pki/trust/anchors/platform-ca-certs.crt"
+	cmd.Flags().MarkHidden("csm-ca-cert")
+	cmd.Flags().StringVar(&secretName, "csm-secret-name", "admin-client-auth", "(CSM Provider) secret name")
+	cmd.Flags().MarkHidden("csm-secret-name")
+	cmd.Flags().StringVar(&clientId, "csm-client-id", "", "(CSM Provider) Client ID")
+	cmd.Flags().MarkHidden("csm-client-id")
+	cmd.Flags().StringVar(&clientSecret, "csm-client-secret", "", "(CSM Provider) Client Secret")
+	cmd.Flags().MarkHidden("csm-client-secret")
+
+	return cmd, nil
+}
+
+// Need to load from existing if not init
+func New(cmd *cobra.Command, args []string, hwlib *hardwaretypes.Library, opts interface{}) (csm *CSM, err error) {
+	// create a starting object
+	csm = &CSM{
+		slsClient:       &sls_client.APIClient{},
+		hsmClient:       &hsm_client.APIClient{},
+		TBV:             &validate.ToBeValidated{},
+		hardwareLibrary: hwlib,
+		Options:         &CsmOpts{},
 	}
 
-	if opts.UseSimulation {
-		opts.InsecureSkipVerify = true
+	if cmd.Name() == "init" {
+		useSimulation := cmd.Flags().Changed("csm-simulator")
+		slsUrl, _ := cmd.Flags().GetString("csm-url-sls")
+		hsmUrl, _ := cmd.Flags().GetString("csm-url-hsm")
+		insecure := cmd.Flags().Changed("csm-insecure-https")
+		providerHost, _ := cmd.Flags().GetString("csm-api-host")
+		tokenUsername, _ := cmd.Flags().GetString("csm-keycloak-username")
+		tokenPassword, _ := cmd.Flags().GetString("csm-keycloak-password")
+		k8sPodsCidr, _ := cmd.Flags().GetString("csm-k8s-pods-cidr")
+		k8sServicesCidr, _ := cmd.Flags().GetString("csm-k8s-services-cidr")
+		kubeconfig, _ := cmd.Flags().GetString("csm-kube-config")
+		caCertPath, _ := cmd.Flags().GetString("csm-ca-cert")
+		secretName, _ := cmd.Flags().GetString("csm-secret-name")
+		clientId, _ := cmd.Flags().GetString("csm-client-id")
+		clientSecret, _ := cmd.Flags().GetString("csm-client-secret")
 
-		opts.ProviderHost = "localhost:8443"
+		if useSimulation {
+			log.Warn().Msg("Using simulation mode")
+			csm.Options.UseSimulation = useSimulation
+			insecure = true
+			if !cmd.Flags().Changed("csm-api-host") {
+				providerHost = "localhost:8443"
+			}
+		}
+		if insecure {
+			csm.Options.InsecureSkipVerify = true
+		}
+		if slsUrl != "" {
+			csm.Options.BaseUrlSLS = slsUrl
+		} else {
+			csm.Options.BaseUrlSLS = fmt.Sprintf("https://%s/apis/sls/v1", providerHost)
+		}
+		if hsmUrl != "" {
+			csm.Options.BaseUrlHSM = hsmUrl
+		} else {
+			csm.Options.BaseUrlHSM = fmt.Sprintf("https://%s/apis/smd/hsm/v2", providerHost)
+		}
+		csm.Options.InsecureSkipVerify = insecure
+		csm.Options.SecretName = secretName
+		// todo get these values from bss in the Global bootparameters in
+		// the fields: kubernetes-pods-cidr and kubernetes-services-cidr
+		csm.Options.K8sPodsCidr = k8sPodsCidr
+		csm.Options.K8sServicesCidr = k8sServicesCidr
+		csm.Options.KubeConfig = kubeconfig
+		csm.Options.CaCertPath = caCertPath
+		csm.Options.ClientID = clientId
+		csm.Options.ClientSecret = clientSecret
+		csm.Options.ProviderHost = strings.TrimRight(providerHost, "/") // Remove trailing slash if present
+		csm.Options.TokenUsername = tokenUsername
+		csm.Options.TokenPassword = tokenPassword
 
-		if opts.BaseUrlSLS == "" {
-			opts.BaseUrlSLS = fmt.Sprintf("https://%s/apis/sls/v1", opts.ProviderHost)
+		err := csm.setupClients()
+		if err != nil {
+			return csm, err
 		}
-		if opts.BaseUrlHSM == "" {
-			opts.BaseUrlHSM = fmt.Sprintf("https://%s/apis/smd/hsm/v2", opts.ProviderHost)
+
+		// get valid roles and subroles from hsm
+		hsmValues, _, err := csm.hsmClient.ServiceInfoApi.DoValuesGet(cmd.Context())
+		if err != nil {
+			return csm, nil
 		}
+
+		// Load system specific config data
+		csm.Options.ValidRoles = hsmValues.Role
+		csm.Options.ValidSubRoles = hsmValues.SubRole
+
+		csm.TBV.ValidRoles = csm.Options.ValidRoles
+		csm.TBV.ValidSubRoles = csm.Options.ValidSubRoles
+		csm.TBV.K8sPodsCidr, _ = cmd.Flags().GetString("csm-k8s-pods-cidr")
+		csm.TBV.K8sServicesCidr, _ = cmd.Flags().GetString("csm-k8s-services-cidr")
+		return csm, nil
+	} else {
+		// use the existing options if a new session is not being initialized
+		// unmarshal to a CsmOpts object
+		optsMarshaled, _ := yaml.Marshal(opts)
+		csmOpts := CsmOpts{}
+		err = yaml.Unmarshal(optsMarshaled, &csmOpts)
+		if err != nil {
+			return csm, err
+		}
+
+		// set the options to the object
+		csm.Options = &csmOpts
+
+		// if not init, just setup the clients
+		err = csm.setupClients()
+		if err != nil {
+			return csm, err
+		}
+
+		csm.TBV.ValidRoles = csmOpts.ValidRoles
+		csm.TBV.ValidSubRoles = csmOpts.ValidSubRoles
+		csm.TBV.K8sPodsCidr = csmOpts.K8sPodsCidr
+		csm.TBV.K8sServicesCidr = csmOpts.K8sServicesCidr
+
+		return csm, nil
 	}
 
+	// return csm, nil
+}
+
+func (csm *CSM) setupClients() (err error) {
 	// Setup HTTP client and context using csm options
-	httpClient, _, err := opts.newClient()
+	httpClient, _, err := csm.newClient()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	slsClientConfiguration := &sls_client.Configuration{
-		BasePath:   opts.BaseUrlSLS,
+		BasePath:   csm.Options.BaseUrlSLS,
 		HTTPClient: httpClient.StandardClient(),
 		UserAgent:  taxonomy.App,
 		DefaultHeader: map[string]string{
@@ -101,7 +218,7 @@ func New(opts *ProviderOpts, hardwareLibrary *hardwaretypes.Library) (*CSM, erro
 	}
 
 	hsmClientConfiguration := &hsm_client.Configuration{
-		BasePath:   opts.BaseUrlHSM,
+		BasePath:   csm.Options.BaseUrlHSM,
 		HTTPClient: httpClient.StandardClient(),
 		UserAgent:  taxonomy.App,
 		DefaultHeader: map[string]string{
@@ -109,18 +226,15 @@ func New(opts *ProviderOpts, hardwareLibrary *hardwaretypes.Library) (*CSM, erro
 		},
 	}
 
-	if opts.APIGatewayToken != "" {
+	if csm.Options.APIGatewayToken != "" {
 		// Set the token for use in the clients
-		slsClientConfiguration.DefaultHeader["Authorization"] = fmt.Sprintf("Bearer %s", opts.APIGatewayToken)
-		hsmClientConfiguration.DefaultHeader["Authorization"] = fmt.Sprintf("Bearer %s", opts.APIGatewayToken)
+		slsClientConfiguration.DefaultHeader["Authorization"] = fmt.Sprintf("Bearer %s", csm.Options.APIGatewayToken)
+		hsmClientConfiguration.DefaultHeader["Authorization"] = fmt.Sprintf("Bearer %s", csm.Options.APIGatewayToken)
 	}
 
 	// Set the clients
 	csm.slsClient = sls_client.NewAPIClient(slsClientConfiguration)
 	csm.hsmClient = hsm_client.NewAPIClient(hsmClientConfiguration)
 
-	// Load system specific config data
-	csm.ValidRoles = opts.ValidRoles
-	csm.ValidSubRoles = opts.ValidSubRoles
-	return csm, nil
+	return nil
 }

--- a/internal/provider/csm/csv.go
+++ b/internal/provider/csm/csv.go
@@ -159,7 +159,7 @@ func (csm *CSM) SetFields(hw *inventory.Hardware, values map[string]string) (res
 	return
 }
 
-func (csm *CSM) GetFieldMetadata(configOptions provider.ConfigOptions) ([]provider.FieldMetadata, error) {
+func (csm *CSM) GetFieldMetadata() ([]provider.FieldMetadata, error) {
 	id := provider.FieldMetadata{
 		Name:         "ID",
 		Types:        "All",
@@ -198,13 +198,13 @@ func (csm *CSM) GetFieldMetadata(configOptions provider.ConfigOptions) ([]provid
 		Name:         "Role",
 		Types:        "Node",
 		IsModifiable: true,
-		Description:  "Any of these values: " + strings.Join(configOptions.ValidRoles, ", "),
+		Description:  "Any of these values: " + strings.Join(csm.Options.ValidRoles, ", "),
 	}
 	subRole := provider.FieldMetadata{
 		Name:         "SubRole",
 		Types:        "Node",
 		IsModifiable: true,
-		Description:  "Any of these values: " + strings.Join(configOptions.ValidSubRoles, ", "),
+		Description:  "Any of these values: " + strings.Join(csm.Options.ValidSubRoles, ", "),
 	}
 	status := provider.FieldMetadata{
 		Name:         "Status",

--- a/internal/provider/csm/init.go
+++ b/internal/provider/csm/init.go
@@ -25,41 +25,17 @@
  */
 package csm
 
-import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-
-	"github.com/Cray-HPE/cani/internal/inventory"
+var (
+	k8sPodsCidr     string
+	k8sServicesCidr string
+	kubeconfig      string
+	caCertPath      string
+	insecure        bool
+	secretName      string
+	clientId        string
+	clientSecret    string
+	providerHost    string
+	tokenUsername   string
+	tokenPassword   string
+	useSimulation   bool
 )
-
-func (csm *CSM) ExportJson(ctx context.Context, datastore inventory.Datastore, skipValidation bool) ([]byte, error) {
-	currentSLSState, _, err := csm.slsClient.DumpstateApi.DumpstateGet(ctx)
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to get the current SLS state"),
-			err,
-		)
-	}
-
-	modifiedState, _, _, err := csm.reconcileSlsChanges(currentSLSState, datastore)
-	if err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to reconcile requested SLS changes with current SLS state"),
-			err)
-	}
-
-	if !skipValidation {
-		_, err = csm.TBV.Validate(modifiedState)
-		if err != nil {
-			return nil, fmt.Errorf("validation failed %v", err)
-		}
-	}
-
-	j, err := json.MarshalIndent(modifiedState, "", "  ")
-	if err != nil {
-		return nil, err
-	}
-	return j, nil
-}

--- a/internal/provider/csm/reconcile.go
+++ b/internal/provider/csm/reconcile.go
@@ -34,10 +34,8 @@ import (
 	"strings"
 
 	"github.com/Cray-HPE/cani/internal/inventory"
-	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/Cray-HPE/cani/internal/provider/csm/ipam"
 	"github.com/Cray-HPE/cani/internal/provider/csm/sls"
-	"github.com/Cray-HPE/cani/internal/provider/csm/validate"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	sls_client "github.com/Cray-HPE/cani/pkg/sls-client"
 	"github.com/Cray-HPE/hms-xname/xnames"
@@ -56,7 +54,7 @@ import (
 //     2. Validate the changes
 //     3. Display what changed
 //     4. Make changes
-func (csm *CSM) Reconcile(ctx context.Context, configOptions provider.ConfigOptions, datastore inventory.Datastore, dryrun bool, ignoreExternalValidation bool) (err error) {
+func (csm *CSM) Reconcile(ctx context.Context, datastore inventory.Datastore, dryrun bool, ignoreExternalValidation bool) (err error) {
 	// TODO should we have a presentation callback to confirm the removal of hardware?
 
 	log.Info().Msg("Starting CSM reconcile process")
@@ -80,7 +78,7 @@ func (csm *CSM) Reconcile(ctx context.Context, configOptions provider.ConfigOpti
 		return err
 	}
 
-	_, err = validate.Validate(configOptions, modifiedState)
+	_, err = csm.TBV.Validate(modifiedState)
 	if err != nil {
 		if ignoreExternalValidation {
 			log.Warn().Msgf("Ignoring these failures: %v\n", err)

--- a/internal/provider/csm/sls_state_generator_test.go
+++ b/internal/provider/csm/sls_state_generator_test.go
@@ -121,7 +121,7 @@ func (suite *DetermineHardwareClassSuite) SetupTest() {
 	suite.NoError(err)
 
 	// Generate a inventory of hardware
-	suite.datastore, err = inventory.NewDatastoreInMemory(inventory.CSMProvider)
+	suite.datastore, err = inventory.NewDatastoreInMemoryCSM(inventory.CSMProvider)
 	suite.NoError(err)
 
 	// Build up the different versions of the supported Mountain cabinets

--- a/internal/provider/csm/validate/checks/network_ip_range_check.go
+++ b/internal/provider/csm/validate/checks/network_ip_range_check.go
@@ -68,8 +68,8 @@ func (c *NetworkIpRangeCheck) Validate(results *common.ValidationResults) {
 	for i, ipRange1 := range ipRanges {
 		name1 := ipRangeMap[ipRange1].Name
 		_, net1, _ := net.ParseCIDR(ipRange1)
-		checkK8sCidr(results, "cani config file", k8sPodsCidr, "k8spodscidr", net1, name1)
-		checkK8sCidr(results, "cani config file", k8sServicesCidr, "k8sservicescidr", net1, name1)
+		checkK8sCidr(results, "CSM", k8sPodsCidr, "k8spodscidr", net1, name1)
+		checkK8sCidr(results, "CSM", k8sServicesCidr, "k8sservicescidr", net1, name1)
 		if !net1.IP.IsUnspecified() {
 			for j := i + 1; j < len(ipRanges); j++ {
 				ipRange2 := ipRanges[j]

--- a/internal/provider/csm/validate/validate_test.go
+++ b/internal/provider/csm/validate/validate_test.go
@@ -30,7 +30,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/Cray-HPE/cani/internal/provider/csm/validate/common"
 	sls_client "github.com/Cray-HPE/cani/pkg/sls-client"
 )
@@ -43,14 +42,13 @@ func loadTestData(t *testing.T, name string) []byte {
 	return content
 }
 
-func GetConfigOptions() provider.ConfigOptions {
-	return provider.ConfigOptions{
+func GetConfigOptions() ToBeValidated {
+	return ToBeValidated{
 		ValidRoles:      []string{"Service", "System", "Application", "Storage", "Management", "Compute"},
 		ValidSubRoles:   []string{"LNETRouter", "UserDefined", "Master", "Worker", "Storage", "Gateway", "UAN", "Visualization"},
 		K8sPodsCidr:     "10.32.0.0/12",
 		K8sServicesCidr: "10.16.0.0/12",
 	}
-
 }
 
 func loadTestObjects(t *testing.T, filename string) (slsState *sls_client.SlsState, rawSLSState RawJson) {
@@ -129,7 +127,7 @@ func TestValidateValid(t *testing.T) {
 	datafile := "valid-mug.json"
 	slsState, rawSLSState := loadTestObjects(t, datafile)
 	configOptions := GetConfigOptions()
-	results, err := validate(configOptions, slsState, rawSLSState)
+	results, err := configOptions.validate(slsState, rawSLSState)
 	passCount, warnCount, failCount := resultsCount(results)
 	logResults(t, results)
 	if err != nil {
@@ -157,7 +155,7 @@ func TestValidateInvalid(t *testing.T) {
 	datafile := "invalid-mug.json"
 	slsState, rawSLSState := loadTestObjects(t, datafile)
 	configOptions := GetConfigOptions()
-	results, err := validate(configOptions, slsState, rawSLSState)
+	results, err := configOptions.validate(slsState, rawSLSState)
 	passCount, warnCount, failCount := resultsCount(results)
 	logResults(t, results)
 	if err != nil {
@@ -178,7 +176,7 @@ func TestValidateValidUsingOnlySlsState(t *testing.T) {
 	datafile := "valid-mug.json"
 	slsState, _ := loadTestObjects(t, datafile)
 	configOptions := GetConfigOptions()
-	results, err := Validate(configOptions, slsState)
+	results, err := configOptions.Validate(slsState)
 	passCount, warnCount, failCount := resultsCount(results)
 	logResults(t, results)
 	if err != nil {

--- a/spec/functional/cani_add_cabinet_spec.sh
+++ b/spec/functional/cani_add_cabinet_spec.sh
@@ -38,6 +38,7 @@ End
 # Adding a cabinet withot a hardware type should fail
 # it should list the available hardware types
 It "--config $CANI_CONF"
+  BeforeCall use_active_session # session is active
   When call bin/cani alpha add cabinet --config "$CANI_CONF"
   The status should equal 1
   The line 1 of stderr should include 'Error: No hardware type provided: Choose from: hpe-eia-cabinet", "hpe-ex2000", "hpe-ex2500-1-liquid-cooled-chassis", "hpe-ex2500-2-liquid-cooled-chassis", "hpe-ex2500-3-liquid-cooled-chassis", "hpe-ex3000", "hpe-ex4000'
@@ -69,7 +70,7 @@ It "--config $CANI_CONF hpe-ex2000"
   BeforeCall use_valid_datastore_system_only # deploy a valid datastore
   When call bin/cani alpha add cabinet --config "$CANI_CONF" hpe-ex2000
   The status should equal 1
-  The line 1 of stderr should equal "Error: No active session.  Run 'session start' to begin"
+  The line 1 of stderr should include "No active session."
 End
 
 # Adding a cabinet should fail if:
@@ -80,7 +81,7 @@ It "--config $CANI_CONF hpe-ex2000"
   BeforeCall remove_datastore # datastore does not exist
   When call bin/cani alpha add cabinet --config "$CANI_CONF" hpe-ex2000
   The status should equal 1
-  The line 1 of stderr should equal "Error: Datastore '$CANI_DS' does not exist.  Run 'session start' to begin"
+  The line 1 of stderr should include "Datastore '$CANI_DS' does not exist.  Run 'session init' to begin"
 End
 
 # Adding a cabinet should fail if:

--- a/spec/functional/cani_session_spec.sh
+++ b/spec/functional/cani_session_spec.sh
@@ -42,8 +42,8 @@ It "--config $CANI_CONF status"
   BeforeCall use_inactive_session # session is inactive
   When call bin/cani alpha session --config "$CANI_CONF" status
   The status should equal 0
-  The line 1 of stderr should include "See $CANI_CONF for session details"
-  The line 2 of stderr should include 'Session is INACTIVE'
+  The line 1 of stderr should include "No active session"
+  The line 2 of stderr should include "Session is INACTIVE for"
 End
 
 # Status should be ACTIVE if active: true
@@ -51,8 +51,8 @@ It "--config $CANI_CONF status"
   BeforeCall use_active_session # session is active
   When call bin/cani alpha session --config "$CANI_CONF" status
   The status should equal 0
-  The line 1 of stderr should include "See $CANI_CONF for session details"
-  The line 2 of stderr should include 'Session is ACTIVE'
+  The stderr should include 'Session is ACTIVE for'
+  The stderr should include "See $CANI_CONF for session details"
 End
 
 # Starting a session without passing a provider should fail
@@ -91,7 +91,7 @@ It 'initialize a session without a config file or datastore'
   BeforeCall "load_sls.sh testdata/fixtures/sls/valid_hardware_networks.json" # simulator is running, load a specific SLS config
   When call bin/cani alpha session --config "$CANI_CONF" init csm -S 
   The status should equal 0
-  The line 1 of stderr should include 'Using simulation mode'
+  The stderr should include 'Using simulation mode'
   The stderr should include 'Validated CANI inventory'
   The stderr should include 'Validated external inventory provider'
   # Verify the import logic reached out to SLS

--- a/spec/integration/add_blade_ex235a_spec.sh
+++ b/spec/integration/add_blade_ex235a_spec.sh
@@ -118,8 +118,8 @@ It 'commit and reconcile'
   When call bin/cani alpha session --config "$CANI_CONF" apply --commit
   # committing without node metadata should fail
   The status should equal 0
-  The line 1 of stderr should include 'Session is STOPPED'
-  The line 2 of stderr should include 'Committing changes to session'
+  The stderr should include 'Session is STOPPED'
+  The stderr should include 'Committing changes to session'
   The stderr should include 'x9000c1s0b0n1    - Type: Node, Class: Hill, Aliases: [nid001001], Role: Compute, NID: 1001'
   The stderr should include 'x9000c1s0b1n0    - Type: Node, Class: Hill, Aliases: [nid001002], Role: Compute, NID: 1002'
   The stdout should include 'Node            (staged)'

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -107,6 +107,14 @@ use_valid_datastore_one_hpe_eia_cabinet_cabinet(){
   cp "$FIXTURES"/cani/configs/canitestdb_valid_eia_only.json "$CANI_DS"
 } 
 
+# deploys a datastore with one eia cabinet (and child hardware) and one blade
+use_valid_datastore_one_hpe_eia_cabinet_cabinet_one_blade(){ 
+  mkdir -p "$(dirname "$CANI_DS")"
+  #shellcheck disable=SC2317
+  cp "$FIXTURES"/cani/configs/canitestdb_valid_eia_only_one_blade.json "$CANI_DS"
+} 
+
+
 # deploys a datastore with one ex2000 cabinet (and child hardware)
 use_valid_datastore_one_hpe_ex2000_cabinet(){ 
   mkdir -p "$(dirname "$CANI_DS")"

--- a/testdata/fixtures/cani/configs/canitest_valid_active.yml
+++ b/testdata/fixtures/cani/configs/canitest_valid_active.yml
@@ -22,40 +22,38 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 session:
-    domain_options:
-        datastore_path: /tmp/.cani/canidb.json
-        log_file_path: /tmp/.cani/canidb.log
-        provider: csm
-        csm_options:
-            usesimulation: true
-            insecureskipverify: true
-            apigatewaytoken: ""
-            baseurlsls: https://localhost:8443/apis/sls/v1
-            baseurlhsm: https://localhost:8443/apis/smd/hsm/v2
-            secretname: admin-client-auth
-            k8spodscidr: 10.32.0.0/12
-            k8sservicescidr: 10.16.0.0/12
-            kubeconfig: ""
-            providerhost: localhost:8443
-            cacertpath: ""
-            validroles:
-                - Storage
-                - Management
-                - Storage
-                - Management
-                - Compute
-                - Service
-                - System
-                - Application
-            validsubroles:
-                - UAN
-                - Gateway
-                - LNETRouter
-                - Visualization
-                - UserDefined
-                - Master
-                - Worker
-                - Storage
-        custom_hardware_types_dir: /tmp/.cani/hardware-types
-    domain: {}
-    active: true
+    domains:
+        csm:
+            active: true
+            datastore_path: /tmp/.cani/canidb.json
+            log_file_path: /tmp/.cani/canidb.log
+            custom_hardware_types_dir: /tmp/.cani/hardware-types
+            provider: csm
+            options:
+                use_simulation: true
+                insecure_skip_verify: true
+                api_gateway_token: ""
+                base_url_sls: https://localhost:8443/apis/sls/v1
+                base_url_hsm: https://localhost:8443/apis/smd/hsm/v2
+                secret_name: admin-client-auth
+                k8s_pods_cidr: 10.32.0.0/12
+                k8s_services_cidr: 10.16.0.0/12
+                kubeconfig: ""
+                provider_host: localhost:8443
+                ca_cert_path: ""
+                valid_roles:
+                    - Management
+                    - Compute
+                    - Service
+                    - System
+                    - Application
+                    - Storage
+                valid_sub_roles:
+                    - Storage
+                    - UAN
+                    - Gateway
+                    - LNETRouter
+                    - Visualization
+                    - UserDefined
+                    - Master
+                    - Worker

--- a/testdata/fixtures/cani/configs/canitest_valid_inactive.yml
+++ b/testdata/fixtures/cani/configs/canitest_valid_inactive.yml
@@ -22,40 +22,38 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 session:
-    domain_options:
-        datastore_path: /tmp/.cani/canidb.json
-        log_file_path: /tmp/.cani/canidb.log
-        provider: csm
-        csm_options:
-            usesimulation: true
-            insecureskipverify: true
-            apigatewaytoken: ""
-            baseurlsls: https://localhost:8443/apis/sls/v1
-            baseurlhsm: https://localhost:8443/apis/smd/hsm/v2
-            secretname: admin-client-auth
-            k8spodscidr: 10.32.0.0/12
-            k8sservicescidr: 10.16.0.0/12
-            kubeconfig: ""
-            providerhost: localhost:8443
-            cacertpath: ""
-            validroles:
-                - Storage
-                - Management
-                - Storage
-                - Management
-                - Compute
-                - Service
-                - System
-                - Application
-            validsubroles:
-                - UAN
-                - Gateway
-                - LNETRouter
-                - Visualization
-                - UserDefined
-                - Master
-                - Worker
-                - Storage
-        custom_hardware_types_dir: /tmp/.cani/hardware-types
-    domain: {}
-    active: false
+    domains:
+        csm:
+            active: false
+            datastore_path: /tmp/.cani/canidb.json
+            log_file_path: /tmp/.cani/canidb.log
+            custom_hardware_types_dir: /tmp/.cani/hardware-types
+            provider: csm
+            options:
+                use_simulation: true
+                insecure_skip_verify: true
+                api_gateway_token: ""
+                base_url_sls: https://localhost:8443/apis/sls/v1
+                base_url_hsm: https://localhost:8443/apis/smd/hsm/v2
+                secret_name: admin-client-auth
+                k8s_pods_cidr: 10.32.0.0/12
+                k8s_services_cidr: 10.16.0.0/12
+                kubeconfig: ""
+                provider_host: localhost:8443
+                ca_cert_path: ""
+                valid_roles:
+                    - Management
+                    - Compute
+                    - Service
+                    - System
+                    - Application
+                    - Storage
+                valid_sub_roles:
+                    - Storage
+                    - UAN
+                    - Gateway
+                    - LNETRouter
+                    - Visualization
+                    - UserDefined
+                    - Master
+                    - Worker

--- a/testdata/fixtures/cani/configs/canitestdb_valid_eia_only_one_blade.json
+++ b/testdata/fixtures/cani/configs/canitestdb_valid_eia_only_one_blade.json
@@ -1,0 +1,328 @@
+{
+  "SchemaVersion": "v1alpha1",
+  "Provider": "csm",
+  "Hardware": {
+    "abcdef12-3456-2789-abcd-ef1234567890": {
+      "ID": "abcdef12-3456-2789-abcd-ef1234567890",
+      "Type": "System",
+      "Parent": "00000000-0000-0000-0000-000000000000",
+      "Children": [
+        "cce788c8-bdfd-4d41-a87c-07f2db30cc73"
+      ],
+      "LocationPath": [
+        {
+          "HardwareType": "System",
+          "Ordinal": 0
+        }
+      ],
+      "LocationOrdinal": 0
+    },
+    "346611c3-264b-4c51-85d1-e4d59d9d4cbf": {
+      "ID": "346611c3-264b-4c51-85d1-e4d59d9d4cbf",
+      "Type": "Node",
+      "DeviceTypeSlug": "hpe-crayex-ex4252-compute-node",
+      "Vendor": "HPE",
+      "Model": "EX4252 AMD EPYC compute node (Antero)",
+      "Status": "staged",
+      "Parent": "e6fba06f-2080-4769-a5e9-74e1462bdc00",
+      "LocationPath": [
+        {
+          "HardwareType": "System",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "Cabinet",
+          "Ordinal": 3000
+        },
+        {
+          "HardwareType": "Chassis",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "NodeBlade",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "NodeCard",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "Node",
+          "Ordinal": 0
+        }
+      ],
+      "LocationOrdinal": 0
+    },
+    "5c1a295e-7eac-4f1a-9e6e-a567b06eb324": {
+      "ID": "5c1a295e-7eac-4f1a-9e6e-a567b06eb324",
+      "Type": "NodeController",
+      "DeviceTypeSlug": "hpe-crayex-ex4252-compute-blade-antero-node-bmc",
+      "Vendor": "HPE",
+      "Model": "EX4252 AMD EPYC compute Blade, Antero Node BMC",
+      "Status": "staged",
+      "Parent": "e6fba06f-2080-4769-a5e9-74e1462bdc00",
+      "LocationPath": [
+        {
+          "HardwareType": "System",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "Cabinet",
+          "Ordinal": 3000
+        },
+        {
+          "HardwareType": "Chassis",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "NodeBlade",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "NodeCard",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "NodeController",
+          "Ordinal": 0
+        }
+      ],
+      "LocationOrdinal": 0
+    },
+    "62a0efab-1fd7-4dc9-a385-81b51f7e3817": {
+      "ID": "62a0efab-1fd7-4dc9-a385-81b51f7e3817",
+      "Type": "Node",
+      "DeviceTypeSlug": "hpe-crayex-ex4252-compute-node",
+      "Vendor": "HPE",
+      "Model": "EX4252 AMD EPYC compute node (Antero)",
+      "Status": "staged",
+      "Parent": "e6fba06f-2080-4769-a5e9-74e1462bdc00",
+      "LocationPath": [
+        {
+          "HardwareType": "System",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "Cabinet",
+          "Ordinal": 3000
+        },
+        {
+          "HardwareType": "Chassis",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "NodeBlade",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "NodeCard",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "Node",
+          "Ordinal": 2
+        }
+      ],
+      "LocationOrdinal": 2
+    },
+    "6459710d-7604-4de3-b2de-bf4c4b9fd232": {
+      "ID": "6459710d-7604-4de3-b2de-bf4c4b9fd232",
+      "Type": "Node",
+      "DeviceTypeSlug": "hpe-crayex-ex4252-compute-node",
+      "Vendor": "HPE",
+      "Model": "EX4252 AMD EPYC compute node (Antero)",
+      "Status": "staged",
+      "Parent": "e6fba06f-2080-4769-a5e9-74e1462bdc00",
+      "LocationPath": [
+        {
+          "HardwareType": "System",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "Cabinet",
+          "Ordinal": 3000
+        },
+        {
+          "HardwareType": "Chassis",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "NodeBlade",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "NodeCard",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "Node",
+          "Ordinal": 3
+        }
+      ],
+      "LocationOrdinal": 3
+    },
+    "acdbfad7-9d89-494e-bb30-80ad6633f61a": {
+      "ID": "acdbfad7-9d89-494e-bb30-80ad6633f61a",
+      "Type": "NodeBlade",
+      "DeviceTypeSlug": "hpe-crayex-ex4252-compute-blade",
+      "Vendor": "HPE",
+      "Model": "EX4252 AMD EPYC compute blade (Antero)",
+      "Status": "staged",
+      "Parent": "d5f6e961-7c9e-480c-be05-2b6adbf147f9",
+      "Children": [
+        "e6fba06f-2080-4769-a5e9-74e1462bdc00"
+      ],
+      "LocationPath": [
+        {
+          "HardwareType": "System",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "Cabinet",
+          "Ordinal": 3000
+        },
+        {
+          "HardwareType": "Chassis",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "NodeBlade",
+          "Ordinal": 0
+        }
+      ],
+      "LocationOrdinal": 0
+    },
+    "c6dcc691-4b38-4cec-9d40-c00fd8adb5d5": {
+      "ID": "c6dcc691-4b38-4cec-9d40-c00fd8adb5d5",
+      "Type": "Node",
+      "DeviceTypeSlug": "hpe-crayex-ex4252-compute-node",
+      "Vendor": "HPE",
+      "Model": "EX4252 AMD EPYC compute node (Antero)",
+      "Status": "staged",
+      "Parent": "e6fba06f-2080-4769-a5e9-74e1462bdc00",
+      "LocationPath": [
+        {
+          "HardwareType": "System",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "Cabinet",
+          "Ordinal": 3000
+        },
+        {
+          "HardwareType": "Chassis",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "NodeBlade",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "NodeCard",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "Node",
+          "Ordinal": 1
+        }
+      ],
+      "LocationOrdinal": 1
+    },
+    "cce788c8-bdfd-4d41-a87c-07f2db30cc73": {
+      "ID": "cce788c8-bdfd-4d41-a87c-07f2db30cc73",
+      "Type": "Cabinet",
+      "DeviceTypeSlug": "hpe-eia-cabinet",
+      "Vendor": "HPE",
+      "Model": "EX2000",
+      "Status": "staged",
+      "ProviderMetadata": {
+        "csm": {
+          "Cabinet": {
+            "HMNVlan": 1513
+          }
+        }
+      },
+      "Parent": "abcdef12-3456-2789-abcd-ef1234567890",
+      "Children": [
+        "d5f6e961-7c9e-480c-be05-2b6adbf147f9"
+      ],
+      "LocationPath": [
+        {
+          "HardwareType": "System",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "Cabinet",
+          "Ordinal": 3000
+        }
+      ],
+      "LocationOrdinal": 3000
+    },
+    "d5f6e961-7c9e-480c-be05-2b6adbf147f9": {
+      "ID": "d5f6e961-7c9e-480c-be05-2b6adbf147f9",
+      "Type": "Chassis",
+      "DeviceTypeSlug": "hpe-eia-chassis",
+      "Vendor": "HPE",
+      "Model": "Standard/EIA Chassis",
+      "Status": "staged",
+      "Parent": "cce788c8-bdfd-4d41-a87c-07f2db30cc73",
+      "Children": [
+        "acdbfad7-9d89-494e-bb30-80ad6633f61a"
+      ],
+      "LocationPath": [
+        {
+          "HardwareType": "System",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "Cabinet",
+          "Ordinal": 3000
+        },
+        {
+          "HardwareType": "Chassis",
+          "Ordinal": 0
+        }
+      ],
+      "LocationOrdinal": 0
+    },
+    "e6fba06f-2080-4769-a5e9-74e1462bdc00": {
+      "ID": "e6fba06f-2080-4769-a5e9-74e1462bdc00",
+      "Type": "NodeCard",
+      "DeviceTypeSlug": "hpe-crayex-ex4252-compute-blade-antero-node-card",
+      "Vendor": "HPE",
+      "Model": "EX425 AMD EPYC compute Blade, Antero Node Card (WNC)",
+      "Status": "staged",
+      "Parent": "acdbfad7-9d89-494e-bb30-80ad6633f61a",
+      "Children": [
+        "346611c3-264b-4c51-85d1-e4d59d9d4cbf",
+        "5c1a295e-7eac-4f1a-9e6e-a567b06eb324",
+        "62a0efab-1fd7-4dc9-a385-81b51f7e3817",
+        "6459710d-7604-4de3-b2de-bf4c4b9fd232",
+        "c6dcc691-4b38-4cec-9d40-c00fd8adb5d5"
+      ],
+      "LocationPath": [
+        {
+          "HardwareType": "System",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "Cabinet",
+          "Ordinal": 3000
+        },
+        {
+          "HardwareType": "Chassis",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "NodeBlade",
+          "Ordinal": 0
+        },
+        {
+          "HardwareType": "NodeCard",
+          "Ordinal": 0
+        }
+      ],
+      "LocationOrdinal": 0
+    }
+  }
+}

--- a/testdata/fixtures/cani/export/help
+++ b/testdata/fixtures/cani/export/help
@@ -5,7 +5,7 @@ Usage:
 
 Flags:
   -a, --all                 List all components. This overrides the --type option
-      --format string       Format option: csv or sls-json (default "csv")
+      --format string       Format option: [csv, sls-json] (default "csv")
       --headers string      Comma separated list of fields to get (default "Type,Vlan,Role,SubRole,Status,Nid,Alias,Name,ID,Location")
   -h, --help                help for export
       --ignore-validation   Skip validating the sls data. This only applies to the sls-json format.

--- a/testdata/fixtures/cani/help
+++ b/testdata/fixtures/cani/help
@@ -1,7 +1,6 @@
 From subfloor to top-of-rack, manage your HPC cluster's inventory!
 
 Usage:
-  cani [flags]
   cani [command]
 
 Available Commands:

--- a/testdata/fixtures/cani/session/help
+++ b/testdata/fixtures/cani/session/help
@@ -6,7 +6,7 @@ Usage:
 
 Available Commands:
   apply       Apply changes from the session.
-  init        Initialize and start a session. Will perform an import of system's inventory format.
+  init        Initialize a session and import from the chosen provider.
   status      View session status.
   summary     Show the summary of a stopped session
 


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

## Overview

- moves csm-specific things out of `cmd`, `domain`, and `provider` packages and into `csm`
- passes `cmd *cobra.Command, args []string` from the `cmd` layer down each provider (allowing them to define the logic and flags)
- removes `provider.ConfigOptions` since these can now be gathered direct from the cobra command or by reading the config file
- creates a validation object in the `csm` package called `ToBeValidated`, as a result of the above (also to prevent import cycle errors)
- converts `validate` functions to methods of `*CSM`
- changes the `cani.yml` to be a map of providers and their respective options
- creates a `CsmOpts` type in the `csm` package, which holds all the cray things
- adjusts variable names as needed along the way

# Risks and Mitigations

**internal/provider/csm**

- added a new `NewSessionInitCommand()` function, which each provider will do to set their own options in their own package
- removed `ConfigOptions{}` in favor of `csm.CsmOpts{}`
- adds a `GetProviderOptions()` function for the upper layers to use (i.e. writing options to config file)
- `ToBeValidated{}` object is created for anything needing validation (k8s CIDRS, roles/subroles, etc)
- adjusted variables/names/paths as needed with above changes
- conforms to the `Provider` interface below

**internal/provider** 

- removes `ConfigOptions` interface contstraint
- removes `SlsProvider` type in favor of a provider constraint `ExportJson(ctx context.Context, datastore inventory.Datastore, skipValidation bool) ([]byte, error)`
- `SetProviderOptions` constraint, which accepts a cmd and args (from cobra)
- `GetProviderOptions` to get the options when needed

**internal/inventory** 

- genericized the `NewDatastoreJSON()` and made `NewDatastoreJSONCSM()` for the csm provider
- added json/yaml tags to struct

 **internal/domain**

- made a generic `ExportJson()` function (not specific to sls)
- moved `DomainOptions` into `Domain` since the provider can set these in their own package now
- created `SetupDomain()`, which sets up the required three components for most ops: hardwaretypeLibrary, a datastore, and a provider interface object
- uses a switch case for different providers needing different settings
- removed `ExportSls()` since the provider has it as a method and is csm-specific

 **cmd**

- added a `setupDomain()`, which sets up the domain for every command to use.  this is run by the root command as a `PersistentPreRunE: setupDomain`, and it sets a `D` variable (similar to the `d` used by each package before)
- uses `root.D` in places where an unexported var was used, this should always be the active domain
- all setup of cmds/flags, etc. are all moved to `init()`.  an example is the `BootstrapInitCmd` is fairly generic, but when the `NewSessionInitCmd()` from the provider is called, the cmd's flags and such are replaced by that set by the provider
- `session init` has the biggest makeover since all the csm-specific info was moved into the csm package.  it is adjusted to use the `root.D` object 
- `DatastoreExists()` removed in favor of logic in `setupDomain()`

**spec**

- adjusted tests as needed now that a map of providers is used instead of a single one
- one blade test is commented out because it gives inconsistent results since we are dynamically getting all blade types from the cani command and each have their own ordinals that change (this can be addressed later)
- the show summary code does not run, and I still need to figure out why, but the tavern tests still yield good results

<!-- What is the risk level of this change? -->

Medium.  A few tests needed modifications since we use a map of providers now instead of a singular one.  The code is shuffled quite a bit, but I kept the test changes to a minimum for more confidence in the changes.