### PR TITLE
create a validation struct to avoid import cycles

### DIFF
--- a/cmd/session/session_init.go
+++ b/cmd/session/session_init.go
@@ -123,6 +123,7 @@ func startSession(cmd *cobra.Command, args []string) error {
 
 	err = root.Conf.Session.Domain.SetConfigOptions(cmd.Context(), root.Conf.Session.DomainOptions)
 	if err != nil {
+		fmt.Printf("%+v\n", root.Conf.Session.Domain)
 		return errors.Join(err,
 			errors.New("External inventory is unstable. Unable to get provider specific config options. Fix issues before starting another session."))
 	}

--- a/internal/provider/csm/config_options.go
+++ b/internal/provider/csm/config_options.go
@@ -29,6 +29,7 @@ import (
 	"context"
 
 	"github.com/Cray-HPE/cani/internal/provider"
+	"github.com/Cray-HPE/cani/internal/provider/csm/validate"
 )
 
 func (csm *CSM) ConfigOptions(ctx context.Context) (provider.ConfigOptions, error) {
@@ -46,6 +47,14 @@ func (csm *CSM) ConfigOptions(ctx context.Context) (provider.ConfigOptions, erro
 	// the fields: kubernetes-pods-cidr and kubernetes-services-cidr
 	providerConfig.K8sPodsCidr = "10.32.0.0/12"
 	providerConfig.K8sServicesCidr = "10.16.0.0/12"
+
+	tbv := &validate.ToBeValidated{}
+	tbv.K8sPodsCidr = providerConfig.K8sPodsCidr
+	tbv.K8sServicesCidr = providerConfig.K8sServicesCidr
+	tbv.ValidRoles = providerConfig.ValidRoles
+	tbv.ValidSubRoles = providerConfig.ValidSubRoles
+
+	csm.TBV = tbv
 
 	return providerConfig, nil
 }

--- a/internal/provider/csm/csm.go
+++ b/internal/provider/csm/csm.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 
 	"github.com/Cray-HPE/cani/cmd/taxonomy"
+	"github.com/Cray-HPE/cani/internal/provider/csm/validate"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 
 	hsm_client "github.com/Cray-HPE/cani/pkg/hsm-client"
@@ -65,6 +66,7 @@ type CSM struct {
 	ValidSubRoles []string
 
 	hardwareLibrary *hardwaretypes.Library
+	TBV             *validate.ToBeValidated
 }
 
 func New(opts *ProviderOpts, hardwareLibrary *hardwaretypes.Library) (*CSM, error) {

--- a/internal/provider/csm/export_sls.go
+++ b/internal/provider/csm/export_sls.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/internal/provider"
-	"github.com/Cray-HPE/cani/internal/provider/csm/validate"
 )
 
 func (csm *CSM) GetSlsJson(ctx context.Context, configOptions provider.ConfigOptions, datastore inventory.Datastore, skipValidation bool) ([]byte, error) {
@@ -53,7 +52,7 @@ func (csm *CSM) GetSlsJson(ctx context.Context, configOptions provider.ConfigOpt
 	}
 
 	if !skipValidation {
-		_, err = validate.Validate(configOptions, modifiedState)
+		_, err = csm.TBV.Validate(configOptions, modifiedState)
 		if err != nil {
 			return nil, fmt.Errorf("validation failed %v", err)
 		}

--- a/internal/provider/csm/reconcile.go
+++ b/internal/provider/csm/reconcile.go
@@ -37,7 +37,6 @@ import (
 	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/Cray-HPE/cani/internal/provider/csm/ipam"
 	"github.com/Cray-HPE/cani/internal/provider/csm/sls"
-	"github.com/Cray-HPE/cani/internal/provider/csm/validate"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	sls_client "github.com/Cray-HPE/cani/pkg/sls-client"
 	"github.com/Cray-HPE/hms-xname/xnames"
@@ -80,7 +79,7 @@ func (csm *CSM) Reconcile(ctx context.Context, configOptions provider.ConfigOpti
 		return err
 	}
 
-	_, err = validate.Validate(configOptions, modifiedState)
+	_, err = csm.TBV.Validate(configOptions, modifiedState)
 	if err != nil {
 		if ignoreExternalValidation {
 			log.Warn().Msgf("Ignoring these failures: %v\n", err)

--- a/internal/provider/csm/validate/checks/network_ip_range_check.go
+++ b/internal/provider/csm/validate/checks/network_ip_range_check.go
@@ -68,8 +68,8 @@ func (c *NetworkIpRangeCheck) Validate(results *common.ValidationResults) {
 	for i, ipRange1 := range ipRanges {
 		name1 := ipRangeMap[ipRange1].Name
 		_, net1, _ := net.ParseCIDR(ipRange1)
-		checkK8sCidr(results, "cani config file", k8sPodsCidr, "k8spodscidr", net1, name1)
-		checkK8sCidr(results, "cani config file", k8sServicesCidr, "k8sservicescidr", net1, name1)
+		checkK8sCidr(results, "CSM", k8sPodsCidr, "k8spodscidr", net1, name1)
+		checkK8sCidr(results, "CSM", k8sServicesCidr, "k8sservicescidr", net1, name1)
 		if !net1.IP.IsUnspecified() {
 			for j := i + 1; j < len(ipRanges); j++ {
 				ipRange2 := ipRanges[j]

--- a/internal/provider/csm/validate/validate.go
+++ b/internal/provider/csm/validate/validate.go
@@ -44,6 +44,13 @@ var (
 	schemas embed.FS
 )
 
+type ToBeValidated struct {
+	ValidRoles      []string
+	ValidSubRoles   []string
+	K8sPodsCidr     string
+	K8sServicesCidr string
+}
+
 type RawJson interface{}
 
 func unmarshalToInterface(bytes []byte) (RawJson, common.ValidationResult, error) {
@@ -88,7 +95,7 @@ func unmarshalToSlsState(bytes []byte) (*sls_client.SlsState, common.ValidationR
 }
 
 // Validate validates the data in the response against the SLS schema.
-func ValidateHTTPResponse(configOptions provider.ConfigOptions, slsState *sls_client.SlsState, response *http.Response) ([]common.ValidationResult, error) {
+func (tbv *ToBeValidated) ValidateHTTPResponse(configOptions provider.ConfigOptions, slsState *sls_client.SlsState, response *http.Response) ([]common.ValidationResult, error) {
 	results := make([]common.ValidationResult, 0)
 
 	// Parse HTTP response body to get raw JSON payload
@@ -114,10 +121,10 @@ func ValidateHTTPResponse(configOptions provider.ConfigOptions, slsState *sls_cl
 				Description: fmt.Sprintf("SLS failed to parse dumpstate. %s", err)})
 	}
 
-	return validate(configOptions, slsState, rawJson, results...)
+	return tbv.validate(configOptions, slsState, rawJson, results...)
 }
 
-func ValidateString(configOptions provider.ConfigOptions, slsStateBytes []byte) ([]common.ValidationResult, error) {
+func (tbv *ToBeValidated) ValidateString(onfigOptions provider.ConfigOptions, slsStateBytes []byte) ([]common.ValidationResult, error) {
 	results := make([]common.ValidationResult, 0)
 
 	rawJson, result, err := unmarshalToInterface(slsStateBytes)
@@ -132,12 +139,12 @@ func ValidateString(configOptions provider.ConfigOptions, slsStateBytes []byte) 
 		return results, err
 	}
 
-	r, err := validate(configOptions, slsState, rawJson)
+	r, err := tbv.validate(onfigOptions, slsState, rawJson)
 	results = append(results, r...)
 	return results, err
 }
 
-func Validate(configOptions provider.ConfigOptions, slsState *sls_client.SlsState) ([]common.ValidationResult, error) {
+func (tbv *ToBeValidated) Validate(configOptions provider.ConfigOptions, slsState *sls_client.SlsState) ([]common.ValidationResult, error) {
 	// If we don't get a raw SLS payload, such as validating an SLS state build inside this tool we need to create the JSON version of the payload
 	rawSLSState, err := json.Marshal(*slsState)
 	if err != nil {
@@ -151,10 +158,10 @@ func Validate(configOptions provider.ConfigOptions, slsState *sls_client.SlsStat
 		return results, err
 	}
 
-	return validate(configOptions, slsState, rawJson, results...)
+	return tbv.validate(configOptions, slsState, rawJson, results...)
 }
 
-func validate(configOptions provider.ConfigOptions, slsState *sls_client.SlsState, rawSLSState RawJson, additionalResults ...common.ValidationResult) ([]common.ValidationResult, error) {
+func (tbv *ToBeValidated) validate(configOptions provider.ConfigOptions, slsState *sls_client.SlsState, rawSLSState RawJson, additionalResults ...common.ValidationResult) ([]common.ValidationResult, error) {
 	results := common.NewValidationResults()
 	results.Add(additionalResults...)
 
@@ -171,11 +178,11 @@ func validate(configOptions provider.ConfigOptions, slsState *sls_client.SlsStat
 			slsStateExtended.TypeToHardware,
 			slsStateExtended.ParentHasChildren,
 			slsState.Networks,
-			configOptions.ValidRoles,
-			configOptions.ValidSubRoles),
+			tbv.ValidRoles,
+			tbv.ValidSubRoles),
 		checks.NewHardwareChassisBmcCheck(slsState.Hardware, slsStateExtended.TypeToHardware),
 		checks.NewRequiedNetworkCheck(slsState.Networks),
-		checks.NewNetworkIpRangeCheck(slsStateExtended, configOptions.K8sPodsCidr, configOptions.K8sServicesCidr),
+		checks.NewNetworkIpRangeCheck(slsStateExtended, tbv.K8sPodsCidr, tbv.K8sServicesCidr),
 		checks.NewNetworkSubnetCheck(slsStateExtended),
 	}
 

--- a/internal/provider/csm/validate/validate_test.go
+++ b/internal/provider/csm/validate/validate_test.go
@@ -43,14 +43,13 @@ func loadTestData(t *testing.T, name string) []byte {
 	return content
 }
 
-func GetConfigOptions() provider.ConfigOptions {
-	return provider.ConfigOptions{
+func GetConfigOptions() ToBeValidated {
+	return ToBeValidated{
 		ValidRoles:      []string{"Service", "System", "Application", "Storage", "Management", "Compute"},
 		ValidSubRoles:   []string{"LNETRouter", "UserDefined", "Master", "Worker", "Storage", "Gateway", "UAN", "Visualization"},
 		K8sPodsCidr:     "10.32.0.0/12",
 		K8sServicesCidr: "10.16.0.0/12",
 	}
-
 }
 
 func loadTestObjects(t *testing.T, filename string) (slsState *sls_client.SlsState, rawSLSState RawJson) {
@@ -129,7 +128,7 @@ func TestValidateValid(t *testing.T) {
 	datafile := "valid-mug.json"
 	slsState, rawSLSState := loadTestObjects(t, datafile)
 	configOptions := GetConfigOptions()
-	results, err := validate(configOptions, slsState, rawSLSState)
+	results, err := configOptions.validate(provider.ConfigOptions{}, slsState, rawSLSState)
 	passCount, warnCount, failCount := resultsCount(results)
 	logResults(t, results)
 	if err != nil {
@@ -157,7 +156,7 @@ func TestValidateInvalid(t *testing.T) {
 	datafile := "invalid-mug.json"
 	slsState, rawSLSState := loadTestObjects(t, datafile)
 	configOptions := GetConfigOptions()
-	results, err := validate(configOptions, slsState, rawSLSState)
+	results, err := configOptions.validate(provider.ConfigOptions{}, slsState, rawSLSState)
 	passCount, warnCount, failCount := resultsCount(results)
 	logResults(t, results)
 	if err != nil {
@@ -178,7 +177,7 @@ func TestValidateValidUsingOnlySlsState(t *testing.T) {
 	datafile := "valid-mug.json"
 	slsState, _ := loadTestObjects(t, datafile)
 	configOptions := GetConfigOptions()
-	results, err := Validate(configOptions, slsState)
+	results, err := configOptions.Validate(provider.ConfigOptions{}, slsState)
 	passCount, warnCount, failCount := resultsCount(results)
 	logResults(t, results)
 	if err != nil {

--- a/internal/provider/csm/validation.go
+++ b/internal/provider/csm/validation.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/internal/provider"
-	"github.com/Cray-HPE/cani/internal/provider/csm/validate"
 	"github.com/Cray-HPE/cani/internal/util/uuidutil"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/google/uuid"
@@ -49,7 +48,7 @@ func (csm *CSM) ValidateExternal(ctx context.Context, configOptions provider.Con
 	}
 
 	// Validate the dumpstate returned from SLS
-	_, err = validate.ValidateHTTPResponse(configOptions, &slsState, reps)
+	_, err = csm.TBV.ValidateHTTPResponse(configOptions, &slsState, reps)
 	if err != nil {
 		return fmt.Errorf("Validation failed. %v\n", err)
 	}


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

With some upcoming changes for supporting multi-providers, this is a small change to not have a package import one above it, and instead opts for a new struct within the `csm/validate` package that can be created and used within `provider/csm`.

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

