### PR TITLE
merge provider cmd flags with bootstrap init command on a per-provider basis

### DIFF
--- a/cmd/session/session_init.go
+++ b/cmd/session/session_init.go
@@ -43,40 +43,22 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// getProviderFlags creates a new init command
+// mergeProviderFlags creates a new init command
 // Initilizing a session is where all the information needed to interact with the inventory system(s) is gathered
 // Plugin authors can call this to create their own flags based on their custom business logic
 // A few common flags are set here, but the rest is up to the plugin author
-func getProviderFlags(cmd *cobra.Command, args []string) (err error) {
+func mergeProviderFlags(bootstrapCmd *cobra.Command, providerCmd *cobra.Command) (err error) {
 	providerFlagset := &pflag.FlagSet{}
 
 	// get the appropriate flagset from the provider's crafted command
-	providerFlagset = csmInitCmd.Flags()
+	providerFlagset = providerCmd.Flags()
 
 	if err != nil {
 		return err
 	}
 
 	// add the provider flags to the command
-	cmd.Flags().AddFlagSet(providerFlagset)
-
-	return nil
-}
-
-func runProviderCmd(cmd *cobra.Command, args []string) (err error) {
-	log.Debug().Msgf("running init with provider-defined command")
-	providerName := args[0]
-	switch providerName {
-	case taxonomy.CSM:
-		cmd = csmInitCmd
-	default:
-		log.Debug().Msgf("skipping provider: %s", providerName)
-	}
-
-	err = initSessionWithProviderCmd(cmd, args)
-	if err != nil {
-		return err
-	}
+	bootstrapCmd.Flags().AddFlagSet(providerFlagset)
 
 	return nil
 }


### PR DESCRIPTION


# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- Generalizes the provider-provided init command by changing `csmInitCmd` to `ProviderCmd`. 
- `mergeProviderFlags()` now accepts two commands (bootstrap and provider) and merges the flags at runtime providing accurate context to the command


# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Low.  This sets up the code a bit more for adding a non-csm provider in a generic way. 