### PR TITLE
generalize add cabinet workflow by moving cobra command down to provider layer

### DIFF
--- a/cmd/blade/add_blade.go
+++ b/cmd/blade/add_blade.go
@@ -53,7 +53,7 @@ var AddBladeCmd = &cobra.Command{
 // addBlade adds a blade to the inventory
 func addBlade(cmd *cobra.Command, args []string) (err error) {
 	if auto {
-		recommendations, err := root.D.Recommend(args[0])
+		recommendations, err := root.D.Recommend(cmd, args, auto)
 		if err != nil {
 			return err
 		}

--- a/cmd/cabinet/init.go
+++ b/cmd/cabinet/init.go
@@ -35,7 +35,6 @@ import (
 
 var (
 	cabinetNumber         int
-	vlanId                int
 	auto                  bool
 	accept                bool
 	format                string
@@ -44,6 +43,8 @@ var (
 )
 
 func init() {
+	var err error
+
 	// Add variants to root commands
 	root.AddCmd.AddCommand(AddCabinetCmd)
 	root.ListCmd.AddCommand(ListCabinetCmd)
@@ -54,10 +55,6 @@ func init() {
 
 	// Cabinets
 	AddCabinetCmd.Flags().IntVar(&cabinetNumber, "cabinet", 1001, "Cabinet number.")
-	// AddCabinetCmd.MarkFlagRequired("cabinet")
-	AddCabinetCmd.Flags().IntVar(&vlanId, "vlan-id", -1, "Vlan ID for the cabinet.")
-	// AddCabinetCmd.MarkFlagRequired("vlan-id")
-	AddCabinetCmd.MarkFlagsRequiredTogether("cabinet", "vlan-id")
 	AddCabinetCmd.Flags().BoolVar(&auto, "auto", false, "Automatically recommend and assign required flags.")
 	AddCabinetCmd.MarkFlagsMutuallyExclusive("auto")
 	AddCabinetCmd.Flags().BoolVarP(&accept, "accept", "y", false, "Automatically accept recommended values.")
@@ -67,7 +64,7 @@ func init() {
 
 	// Merge CANI's command with the provider-specified command
 	// this allows for CANI's operations to remain consistent, while adding provider config on top
-	err := root.MergeProviderCommand(AddCabinetCmd, ProviderAddCabinetCmd)
+	err = root.MergeProviderCommand(AddCabinetCmd, ProviderAddCabinetCmd)
 	if err != nil {
 		log.Error().Msgf("%+v", err)
 		os.Exit(1)

--- a/cmd/node/init.go
+++ b/cmd/node/init.go
@@ -50,6 +50,7 @@ var (
 )
 
 func init() {
+	var err error
 	// Add variants to root commands
 	root.AddCmd.AddCommand(AddNodeCmd)
 	root.ListCmd.AddCommand(ListNodeCmd)
@@ -59,6 +60,7 @@ func init() {
 	// Add a flag to show supported types
 	AddNodeCmd.Flags().BoolP("list-supported-types", "L", false, "List supported hardware types.")
 
+	// TODO remove more cray-sauce
 	AddNodeCmd.Flags().StringVar(&role, "role", "", "Role of the node")
 	AddNodeCmd.Flags().StringVar(&subrole, "subrole", "", "Subrole of the node")
 	AddNodeCmd.Flags().IntVar(&nid, "nid", 0, "NID of the node")
@@ -70,13 +72,6 @@ func init() {
 	UpdateNodeCmd.Flags().IntVar(&blade, "blade", 1, "Parent blade")
 	UpdateNodeCmd.Flags().IntVar(&nodecard, "nodecard", 1, "Parent node card")
 	UpdateNodeCmd.Flags().IntVar(&node, "node", 1, "Node to update")
-
-	// CSM specific options
-	// TODO a thought, it might be neat if the options that CANI shows changes based on the active provider
-	UpdateNodeCmd.Flags().StringVar(&role, "role", "", "Role of the node")
-	UpdateNodeCmd.Flags().StringVar(&subrole, "subrole", "", "Subrole of the node")
-	UpdateNodeCmd.Flags().IntVar(&nid, "nid", 0, "NID of the node")
-	UpdateNodeCmd.Flags().StringVar(&alias, "alias", "", "Alias of the node")
 	UpdateNodeCmd.Flags().StringVar(&nodeUuid, "uuid", "", "UUID of the node to update")
 
 	UpdateNodeCmd.MarkFlagsRequiredTogether("cabinet", "chassis", "blade", "nodecard", "node")
@@ -86,7 +81,7 @@ func init() {
 
 	// Merge CANI's command with the provider-specified command
 	// this allows for CANI's operations to remain consistent, while adding provider config on top
-	err := root.MergeProviderCommand(UpdateNodeCmd, ProviderUpdateNodeCmd)
+	err = root.MergeProviderCommand(UpdateNodeCmd, ProviderUpdateNodeCmd)
 	if err != nil {
 		log.Error().Msgf("%+v", err)
 		os.Exit(1)

--- a/cmd/node/update_node.go
+++ b/cmd/node/update_node.go
@@ -31,7 +31,6 @@ import (
 
 	root "github.com/Cray-HPE/cani/cmd"
 	"github.com/Cray-HPE/cani/internal/provider"
-	"github.com/Cray-HPE/cani/internal/provider/csm"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -47,24 +46,6 @@ var UpdateNodeCmd = &cobra.Command{
 
 // updateNode updates a node to the inventory
 func updateNode(cmd *cobra.Command, args []string) (err error) {
-	// Push all the CLI flags that were provided into a generic map
-	// TODO Need to figure out how to specify to unset something
-	// Right now the build metadata function in the CSM provider will
-	// unset options if nil is passed in.
-	nodeMeta := map[string]interface{}{}
-	if cmd.Flags().Changed("role") {
-		nodeMeta[csm.ProviderMetadataRole] = role
-	}
-	if cmd.Flags().Changed("subrole") {
-		nodeMeta[csm.ProviderMetadataSubRole] = subrole
-	}
-	if cmd.Flags().Changed("alias") {
-		nodeMeta[csm.ProviderMetadataAlias] = alias
-	}
-	if cmd.Flags().Changed("nid") {
-		nodeMeta[csm.ProviderMetadataNID] = nid
-	}
-
 	// Remove the node from the inventory using domain methods
 	if cmd.Flags().Changed("uuid") {
 		// parse the passed in uuid
@@ -87,7 +68,7 @@ func updateNode(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
-	result, err := root.D.UpdateNode(cmd.Context(), cabinet, chassis, blade, nodecard, node, nodeMeta)
+	result, err := root.D.UpdateNode(cmd, args, cabinet, chassis, blade, nodecard, node)
 	if errors.Is(err, provider.ErrDataValidationFailure) {
 		// TODO the following should probably suggest commands to fix the issue?
 		log.Error().Msgf("Inventory data validation errors encountered")

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -69,7 +69,14 @@ func MergeProviderCommand(bootstrapCmd *cobra.Command, providerCmd *cobra.Comman
 				case "add":
 					providerCmd, err = csm.NewAddCabinetCommand()
 				}
+			case "node":
+				// check for add/update variants
+				switch bootstrapCmd.Parent().Name() {
+				case "update":
+					providerCmd, err = csm.NewUpdateNodeCommand()
+				}
 			}
+
 		default:
 			log.Debug().Msgf("skipping provider: %s", provider)
 		}
@@ -103,6 +110,12 @@ func MergeProviderCommand(bootstrapCmd *cobra.Command, providerCmd *cobra.Comman
 				switch bootstrapCmd.Parent().Name() {
 				case "add":
 					err = csm.UpdateAddCabinetCommand(bootstrapCmd)
+				}
+			case "node":
+				// check for add/update variants
+				switch bootstrapCmd.Parent().Name() {
+				case "update":
+					err = csm.UpdateUpdateNodeCommand(bootstrapCmd)
 				}
 			}
 		default:

--- a/internal/domain/cabinet.go
+++ b/internal/domain/cabinet.go
@@ -26,7 +26,6 @@
 package domain
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -35,15 +34,16 @@ import (
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
 )
 
 // AddCabinet adds a cabinet to the inventory
-func (d *Domain) AddCabinet(ctx context.Context, deviceTypeSlug string, cabinetOrdinal int, metadata map[string]interface{}) (AddHardwareResult, error) {
+func (d *Domain) AddCabinet(cmd *cobra.Command, args []string, recommendations provider.HardwareRecommendations) (AddHardwareResult, error) {
 	// Validate provided cabinet exists
 	// Craft the path to the cabinet
 	cabinetLocationPath := inventory.LocationPath{
 		{HardwareType: hardwaretypes.System, Ordinal: 0},
-		{HardwareType: hardwaretypes.Cabinet, Ordinal: cabinetOrdinal},
+		{HardwareType: hardwaretypes.Cabinet, Ordinal: recommendations.CabinetOrdinal},
 	}
 
 	// Check if the cabinet already exists
@@ -58,7 +58,7 @@ func (d *Domain) AddCabinet(ctx context.Context, deviceTypeSlug string, cabinetO
 	if exists {
 		return AddHardwareResult{},
 			errors.Join(
-				fmt.Errorf("%s number %d is already in use", hardwaretypes.Cabinet, cabinetOrdinal),
+				fmt.Errorf("%s number %d is already in use", hardwaretypes.Cabinet, recommendations.CabinetOrdinal),
 				fmt.Errorf("please re-run the command with an available %s number", hardwaretypes.Cabinet),
 			)
 	}
@@ -71,6 +71,7 @@ func (d *Domain) AddCabinet(ctx context.Context, deviceTypeSlug string, cabinetO
 		)
 	}
 
+	deviceTypeSlug := args[0]
 	// Verify the provided device type slug is a cabinet
 	deviceType, err := d.hardwareTypeLibrary.GetDeviceType(deviceTypeSlug)
 	if err != nil {
@@ -81,7 +82,7 @@ func (d *Domain) AddCabinet(ctx context.Context, deviceTypeSlug string, cabinetO
 	}
 
 	// Generate a hardware build out using the system as a parent
-	hardwareBuildOutItems, err := inventory.GenerateDefaultHardwareBuildOut(d.hardwareTypeLibrary, deviceTypeSlug, cabinetOrdinal, system)
+	hardwareBuildOutItems, err := inventory.GenerateDefaultHardwareBuildOut(d.hardwareTypeLibrary, deviceTypeSlug, recommendations.CabinetOrdinal, system)
 	if err != nil {
 		return AddHardwareResult{}, errors.Join(
 			fmt.Errorf("unable to build default hardware build out for %s", deviceTypeSlug),
@@ -96,17 +97,14 @@ func (d *Domain) AddCabinet(ctx context.Context, deviceTypeSlug string, cabinetO
 		hardware := inventory.NewHardwareFromBuildOut(hardwareBuildOut, inventory.HardwareStatusStaged)
 
 		// Ask the inventory provider to craft a metadata object for this information
-		if err := d.externalInventoryProvider.BuildHardwareMetadata(&hardware, metadata); err != nil {
+		if err := d.externalInventoryProvider.BuildHardwareMetadata(&hardware, cmd, args, recommendations); err != nil {
 			return AddHardwareResult{}, err
 		}
 
 		log.Debug().Any("id", hardware.ID).Msg("Hardware")
 		log.Debug().Str("path", hardwareBuildOut.LocationPath.String()).Msg("Hardware Build out")
 
-		// TODO need a check to see if all the needed information exists,
-		// Things like role/subrole/nid/alias could be injected at a later time.
-		// Not sure how hard it would be to specify at this point in time.
-		// This command creates the physical information for a node, have another command for the logical part of the data
+		// Metadata is now set by the BuildHardwareMetadata so it can be added to the datastore
 		if err := d.datastore.Add(&hardware); err != nil {
 			return AddHardwareResult{}, errors.Join(
 				fmt.Errorf("unable to add hardware to inventory datastore"),
@@ -129,7 +127,7 @@ func (d *Domain) AddCabinet(ctx context.Context, deviceTypeSlug string, cabinetO
 
 	// Validate the current state of CANI's inventory data against the provider plugin
 	// for provider specific data.
-	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(ctx, d.datastore, false); len(failedValidations) > 0 {
+	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(cmd.Context(), d.datastore, false); len(failedValidations) > 0 {
 		result.ProviderValidationErrors = failedValidations
 		return result, provider.ErrDataValidationFailure
 	} else if err != nil {
@@ -154,14 +152,14 @@ func (d *Domain) RemoveCabinet(u uuid.UUID, recursion bool) error {
 	return d.datastore.Flush()
 }
 
-func (d *Domain) Recommend(deviceTypeSlug string) (recommendations provider.HardwareRecommendations, err error) {
+func (d *Domain) Recommend(cmd *cobra.Command, args []string, auto bool) (recommendations provider.HardwareRecommendations, err error) {
 	// Get the existing inventory
 	inv, err := d.List()
 	if err != nil {
 		return recommendations, err
 	}
 	// Get recommendations from the CSM provider for the cabinet
-	recommendations, err = d.externalInventoryProvider.RecommendHardware(inv, deviceTypeSlug)
+	recommendations, err = d.externalInventoryProvider.RecommendHardware(inv, cmd, args, auto)
 	if err != nil {
 		return recommendations, err
 	}

--- a/internal/provider/csm/csv.go
+++ b/internal/provider/csm/csv.go
@@ -134,7 +134,8 @@ func (csm *CSM) SetFields(hw *inventory.Hardware, values map[string]string) (res
 			}
 			hw.SetProviderMetadata(inventory.CSMProvider, metadataRaw)
 		}
-	} else if csmMetadata.Cabinet != nil {
+	}
+	if csmMetadata.Cabinet != nil {
 		for key, value := range values {
 			switch key {
 			case "Vlan":

--- a/internal/provider/csm/metadata_test.go
+++ b/internal/provider/csm/metadata_test.go
@@ -32,9 +32,11 @@ import (
 	"testing"
 
 	"github.com/Cray-HPE/cani/internal/inventory"
+	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/Cray-HPE/cani/pkg/pointers"
 	"github.com/google/uuid"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -145,9 +147,13 @@ func (suite *BuildHardwareMetadataTestSuite) SetupSuite() {
 }
 
 func (suite *BuildHardwareMetadataTestSuite) TestCabinet() {
-	rawProperties := map[string]interface{}{
-		ProviderMetadataVlanId: 1234,
+	recommendations := provider.HardwareRecommendations{
+		ProviderMetadata: map[string]interface{}{
+			ProviderMetadataVlanId: 1234,
+		},
 	}
+	cmd := &cobra.Command{}
+	args := []string{}
 
 	hardware := inventory.Hardware{
 		ID:             uuid.New(),
@@ -158,7 +164,7 @@ func (suite *BuildHardwareMetadataTestSuite) TestCabinet() {
 		Status:         inventory.HardwareStatusStaged,
 	}
 
-	err := suite.csm.BuildHardwareMetadata(&hardware, rawProperties)
+	err := suite.csm.BuildHardwareMetadata(&hardware, cmd, args, recommendations)
 	suite.NoError(err)
 
 	suite.NotNil(hardware.ProviderMetadata)


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- adds a `MergeProviderCommand()` function, which can be re-used by each subcommand.  This allows the CANI cobra command to be merged with the provider-specific command
- `MergeProviderCommand()` is used with the `add cabinet` and `add blade` workflows
- CSM-specific things are removed from `add_cabinet.go` and moved down `internal/provider/csm` package.  This generalizes the command and opens the door for other providers to use the command and adding their customizations on top
- As part of this change, metadata is no longer passed to `AddCabinet()` and is instead generated in the CSM package using the cobra command.  This required some domino-effect changes throughout the package
- `RecommendHardware()` and `BuildHardwareMetadata()`interface modified to accept the cobra command and args
- A method for `func (r HardwareRecommendations) Print()` printing is used instead of printing provider-specific things instead of baking this currently-csm-specific info into the cmd layer
- logic in `internal/provider/csm/csv.go` was slightly adjusted to account for the new metadata changes

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Medium to low. 

- only one test was changed, `metadata_test.go`, which was required since the function needed new arguments.  The change is relatively minor, still proving the code remains as stable as is was in main
- new code/logic is introduced so it can introduce new issues but is necessary to support multiple providers