### PR TITLE
Merge CANI command with provider command

### DIFF
--- a/cmd/cabinet/init.go
+++ b/cmd/cabinet/init.go
@@ -26,16 +26,21 @@
 package cabinet
 
 import (
+	"os"
+
 	root "github.com/Cray-HPE/cani/cmd"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
 )
 
 var (
-	cabinetNumber int
-	vlanId        int
-	auto          bool
-	accept        bool
-	format        string
-	sortBy        string
+	cabinetNumber         int
+	vlanId                int
+	auto                  bool
+	accept                bool
+	format                string
+	sortBy                string
+	ProviderAddCabinetCmd = &cobra.Command{}
 )
 
 func init() {
@@ -59,4 +64,12 @@ func init() {
 
 	ListCabinetCmd.Flags().StringVarP(&format, "format", "f", "pretty", "Format out output")
 	ListCabinetCmd.Flags().StringVarP(&sortBy, "sort", "s", "location", "Sort by a specific key")
+
+	// Merge CANI's command with the provider-specified command
+	// this allows for CANI's operations to remain consistent, while adding provider config on top
+	err := root.MergeProviderCommand(AddCabinetCmd, ProviderAddCabinetCmd)
+	if err != nil {
+		log.Error().Msgf("%+v", err)
+		os.Exit(1)
+	}
 }

--- a/cmd/node/init.go
+++ b/cmd/node/init.go
@@ -26,22 +26,27 @@
 package node
 
 import (
+	"os"
+
 	root "github.com/Cray-HPE/cani/cmd"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
 )
 
 var (
-	cabinet  int
-	chassis  int
-	blade    int
-	nodecard int
-	node     int
-	role     string
-	subrole  string
-	nid      int
-	alias    string
-	nodeUuid string
-	format   string
-	sortBy   string
+	cabinet               int
+	chassis               int
+	blade                 int
+	nodecard              int
+	node                  int
+	role                  string
+	subrole               string
+	nid                   int
+	alias                 string
+	nodeUuid              string
+	format                string
+	sortBy                string
+	ProviderUpdateNodeCmd = &cobra.Command{}
 )
 
 func init() {
@@ -78,4 +83,12 @@ func init() {
 	UpdateNodeCmd.MarkFlagsMutuallyExclusive("uuid")
 	ListNodeCmd.Flags().StringVarP(&format, "format", "f", "pretty", "Format output")
 	ListNodeCmd.Flags().StringVarP(&sortBy, "sort", "s", "location", "Sort by a specific key")
+
+	// Merge CANI's command with the provider-specified command
+	// this allows for CANI's operations to remain consistent, while adding provider config on top
+	err := root.MergeProviderCommand(UpdateNodeCmd, ProviderUpdateNodeCmd)
+	if err != nil {
+		log.Error().Msgf("%+v", err)
+		os.Exit(1)
+	}
 }

--- a/internal/provider/csm/csm.go
+++ b/internal/provider/csm/csm.go
@@ -49,46 +49,6 @@ type CSM struct {
 	Options         *CsmOpts
 }
 
-func NewSessionInitCommand() (cmd *cobra.Command, err error) {
-	// cmd represents the session init command
-	cmd = &cobra.Command{}
-	cmd.Long = `Query SLS and HSM.  Validate the data against a schema before allowing an import into CANI.`
-	// ValidArgs:    DO NOT CONFIGURE.  This is set by cani's cmd pkg
-	// Args:         DO NOT CONFIGURE.  This is set by cani's cmd pkg
-	// RunE:         DO NOT CONFIGURE.  This is set by cani's cmd pkg
-	// Session init flags
-	cmd.Flags().String("csm-url-sls", "", "(CSM Provider) Base URL for the System Layout Service (SLS)")
-	cmd.Flags().String("csm-url-hsm", "", "(CSM Provider) Base URL for the Hardware State Manager (HSM)")
-	cmd.Flags().BoolVarP(&insecure, "csm-insecure-https", "k", false, "(CSM Provider) Allow insecure connections when using HTTPS to CSM services")
-	cmd.Flags().BoolVarP(&useSimulation, "csm-simulator", "S", false, "(CSM Provider) Use simulation environment URLs")
-
-	// These three pieces are needed for the CSM provider to get a token
-	cmd.Flags().StringVar(&providerHost, "csm-api-host", "api-gw-service.local", "(CSM Provider) Host or FQDN for authentation and APIs")
-	// cmd.MarkFlagRequired("csm-api-host")
-	cmd.Flags().StringVar(&tokenUsername, "csm-keycloak-username", "", "(CSM Provider) Keycloak username")
-	// cmd.MarkFlagRequired("csm-keycloak-username")
-	cmd.Flags().StringVar(&tokenPassword, "csm-keycloak-password", "", "(CSM Provider) Keycloak password")
-	// cmd.MarkFlagRequired("csm-keycloak-password")
-	cmd.MarkFlagsRequiredTogether("csm-api-host", "csm-keycloak-username", "csm-keycloak-password")
-	// TODO the API token, do we save ito the file?
-
-	cmd.Flags().StringVar(&k8sPodsCidr, "csm-k8s-pods-cidr", "10.32.0.0/12", "(CSM Provider) CIDR used by kubernetes for pods")
-	cmd.Flags().StringVar(&k8sServicesCidr, "csm-k8s-services-cidr", "10.16.0.0/12", "(CSM Provider) CIDR used by kubernetes for services")
-	// Less secure auth methods for CSM that follow existing patterns, but to discourage use, mark them hidden
-	cmd.Flags().StringVar(&kubeconfig, "csm-kube-config", "", "(CSM Provider) Path to the kube config file") // /etc/kubernetes/admin.conf
-	cmd.Flags().MarkHidden("kube-config")
-	cmd.Flags().StringVar(&caCertPath, "csm-ca-cert", "", "Path to the CA certificate file") // /etc/pki/trust/anchors/platform-ca-certs.crt"
-	cmd.Flags().MarkHidden("csm-ca-cert")
-	cmd.Flags().StringVar(&secretName, "csm-secret-name", "admin-client-auth", "(CSM Provider) secret name")
-	cmd.Flags().MarkHidden("csm-secret-name")
-	cmd.Flags().StringVar(&clientId, "csm-client-id", "", "(CSM Provider) Client ID")
-	cmd.Flags().MarkHidden("csm-client-id")
-	cmd.Flags().StringVar(&clientSecret, "csm-client-secret", "", "(CSM Provider) Client Secret")
-	cmd.Flags().MarkHidden("csm-client-secret")
-
-	return cmd, nil
-}
-
 // Need to load from existing if not init
 func New(cmd *cobra.Command, args []string, hwlib *hardwaretypes.Library, opts interface{}) (csm *CSM, err error) {
 	// create a starting object

--- a/internal/provider/csm/init.go
+++ b/internal/provider/csm/init.go
@@ -25,6 +25,8 @@
  */
 package csm
 
+import "github.com/spf13/cobra"
+
 var (
 	k8sPodsCidr     string
 	k8sServicesCidr string
@@ -38,4 +40,78 @@ var (
 	tokenUsername   string
 	tokenPassword   string
 	useSimulation   bool
+	vlanId          int
 )
+
+func NewSessionInitCommand() (cmd *cobra.Command, err error) {
+	// cmd represents the session init command
+	cmd = &cobra.Command{}
+	cmd.Long = `Query SLS and HSM.  Validate the data against a schema before allowing an import into CANI.`
+	// ValidArgs:    DO NOT CONFIGURE.  This is set by cani's cmd pkg
+	// Args:         DO NOT CONFIGURE.  This is set by cani's cmd pkg
+	// RunE:         DO NOT CONFIGURE.  This is set by cani's cmd pkg
+	// Session init flags
+	cmd.Flags().String("csm-url-sls", "", "(CSM Provider) Base URL for the System Layout Service (SLS)")
+	cmd.Flags().String("csm-url-hsm", "", "(CSM Provider) Base URL for the Hardware State Manager (HSM)")
+	cmd.Flags().BoolVarP(&insecure, "csm-insecure-https", "k", false, "(CSM Provider) Allow insecure connections when using HTTPS to CSM services")
+	cmd.Flags().BoolVarP(&useSimulation, "csm-simulator", "S", false, "(CSM Provider) Use simulation environment URLs")
+
+	// These three pieces are needed for the CSM provider to get a token
+	cmd.Flags().StringVar(&providerHost, "csm-api-host", "api-gw-service.local", "(CSM Provider) Host or FQDN for authentation and APIs")
+	// cmd.MarkFlagRequired("csm-api-host")
+	cmd.Flags().StringVar(&tokenUsername, "csm-keycloak-username", "", "(CSM Provider) Keycloak username")
+	// cmd.MarkFlagRequired("csm-keycloak-username")
+	cmd.Flags().StringVar(&tokenPassword, "csm-keycloak-password", "", "(CSM Provider) Keycloak password")
+	// cmd.MarkFlagRequired("csm-keycloak-password")
+	cmd.MarkFlagsRequiredTogether("csm-api-host", "csm-keycloak-username", "csm-keycloak-password")
+	// TODO the API token, do we save ito the file?
+
+	cmd.Flags().StringVar(&k8sPodsCidr, "csm-k8s-pods-cidr", "10.32.0.0/12", "(CSM Provider) CIDR used by kubernetes for pods")
+	cmd.Flags().StringVar(&k8sServicesCidr, "csm-k8s-services-cidr", "10.16.0.0/12", "(CSM Provider) CIDR used by kubernetes for services")
+	// Less secure auth methods for CSM that follow existing patterns, but to discourage use, mark them hidden
+	cmd.Flags().StringVar(&kubeconfig, "csm-kube-config", "", "(CSM Provider) Path to the kube config file") // /etc/kubernetes/admin.conf
+	cmd.Flags().MarkHidden("kube-config")
+	cmd.Flags().StringVar(&caCertPath, "csm-ca-cert", "", "Path to the CA certificate file") // /etc/pki/trust/anchors/platform-ca-certs.crt"
+	cmd.Flags().MarkHidden("csm-ca-cert")
+	cmd.Flags().StringVar(&secretName, "csm-secret-name", "admin-client-auth", "(CSM Provider) secret name")
+	cmd.Flags().MarkHidden("csm-secret-name")
+	cmd.Flags().StringVar(&clientId, "csm-client-id", "", "(CSM Provider) Client ID")
+	cmd.Flags().MarkHidden("csm-client-id")
+	cmd.Flags().StringVar(&clientSecret, "csm-client-secret", "", "(CSM Provider) Client Secret")
+	cmd.Flags().MarkHidden("csm-client-secret")
+
+	return cmd, nil
+}
+
+func NewAddCabinetCommand() (cmd *cobra.Command, err error) {
+	// cmd represents the session init command
+	cmd = &cobra.Command{}
+	cmd.Flags().Int("vlan-id", -1, "Vlan ID for the cabinet.")
+
+	return cmd, nil
+}
+
+// UpdateAddCabinetCommand is run during init and allows the provider to set additional options for CANI flags
+// such as marking certain options mutually exclusive with the auto flag
+func UpdateAddCabinetCommand(caniCmd *cobra.Command) error {
+	caniCmd.MarkFlagsRequiredTogether("cabinet", "vlan-id")
+	caniCmd.MarkFlagsMutuallyExclusive("auto")
+	return nil
+}
+
+func NewUpdateNodeCommand() (cmd *cobra.Command, err error) {
+	// cmd represents the session init command
+	cmd = &cobra.Command{}
+	cmd.Flags().String("role", "", "Role of the node")
+	cmd.Flags().String("subrole", "", "Subrole of the node")
+	cmd.Flags().Int("nid", 0, "NID of the node")
+	cmd.Flags().StringSlice("alias", []string{}, "Comma-separated aliases of the node")
+
+	return cmd, nil
+}
+
+// UpdateUpdateNodeCommand
+func UpdateUpdateNodeCommand(caniCmd *cobra.Command) error {
+
+	return nil
+}


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- Moves `New*Command()` functions into `init.go` since they get called during `init()`
- Add a `MergeProviderCommand()` function to merge the CANI command with the command defined by the provider

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Low
