### PR TITLE
generalize list cabinet workflow for multiple providers

### DIFF
--- a/cmd/cabinet/init.go
+++ b/cmd/cabinet/init.go
@@ -34,37 +34,39 @@ import (
 )
 
 var (
-	cabinetNumber         int
-	auto                  bool
-	accept                bool
-	format                string
-	sortBy                string
-	ProviderAddCabinetCmd = &cobra.Command{}
+	cabinetNumber          int
+	auto                   bool
+	accept                 bool
+	format                 string
+	sortBy                 string
+	ProviderAddCabinetCmd  = &cobra.Command{}
+	ProviderListCabinetCmd = &cobra.Command{}
 )
 
 func init() {
 	var err error
 
-	// Add variants to root commands
+	// Add subcommands to root commands
 	root.AddCmd.AddCommand(AddCabinetCmd)
 	root.ListCmd.AddCommand(ListCabinetCmd)
 	root.RemoveCmd.AddCommand(RemoveCabinetCmd)
 
-	// Add a flag to show supported types
+	// Common 'add cabinet' flags and then merge with provider-specified command
 	AddCabinetCmd.Flags().BoolP("list-supported-types", "L", false, "List supported hardware types.")
-
-	// Cabinets
 	AddCabinetCmd.Flags().IntVar(&cabinetNumber, "cabinet", 1001, "Cabinet number.")
 	AddCabinetCmd.Flags().BoolVar(&auto, "auto", false, "Automatically recommend and assign required flags.")
 	AddCabinetCmd.MarkFlagsMutuallyExclusive("auto")
 	AddCabinetCmd.Flags().BoolVarP(&accept, "accept", "y", false, "Automatically accept recommended values.")
+	err = root.MergeProviderCommand(AddCabinetCmd, ProviderAddCabinetCmd)
+	if err != nil {
+		log.Error().Msgf("%+v", err)
+		os.Exit(1)
+	}
 
+	// Common 'list cabinet' flags and then merge with provider-specified command
 	ListCabinetCmd.Flags().StringVarP(&format, "format", "f", "pretty", "Format out output")
 	ListCabinetCmd.Flags().StringVarP(&sortBy, "sort", "s", "location", "Sort by a specific key")
-
-	// Merge CANI's command with the provider-specified command
-	// this allows for CANI's operations to remain consistent, while adding provider config on top
-	err = root.MergeProviderCommand(AddCabinetCmd, ProviderAddCabinetCmd)
+	err = root.MergeProviderCommand(ListCabinetCmd, ProviderListCabinetCmd)
 	if err != nil {
 		log.Error().Msgf("%+v", err)
 		os.Exit(1)

--- a/internal/domain/cabinet.go
+++ b/internal/domain/cabinet.go
@@ -165,3 +165,16 @@ func (d *Domain) Recommend(cmd *cobra.Command, args []string, auto bool) (recomm
 	}
 	return recommendations, nil
 }
+
+func (d *Domain) ListCabinetMetadataColumns() (columns []string) {
+	columns = d.externalInventoryProvider.ListCabinetMetadataColumns()
+	return columns
+}
+
+func (d *Domain) ListCabinetMetadataRow(hw inventory.Hardware) (row []string, err error) {
+	row, err = d.externalInventoryProvider.ListCabinetMetadataRow(hw)
+	if err != nil {
+		return row, err
+	}
+	return row, nil
+}

--- a/internal/provider/csm/csm.go
+++ b/internal/provider/csm/csm.go
@@ -27,9 +27,11 @@ package csm
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/Cray-HPE/cani/cmd/taxonomy"
+	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/internal/provider/csm/validate"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/rs/zerolog/log"
@@ -197,4 +199,20 @@ func (csm *CSM) setupClients() (err error) {
 	csm.hsmClient = hsm_client.NewAPIClient(hsmClientConfiguration)
 
 	return nil
+}
+
+// ListCabinetMetadataColumns returns a slice of strings, which are columns names of CSM-specific metadata to be shown when listing cabinets
+func (csm *CSM) ListCabinetMetadataColumns() (columns []string) {
+	return []string{"HMN VLAN"}
+}
+
+// ListCabinetMetadataRow returns a slice of strings, which are values from the hardware that correlate to the columns they will be shown in
+func (csm *CSM) ListCabinetMetadataRow(hw inventory.Hardware) (values []string, err error) {
+	md, err := DecodeProviderMetadata(hw)
+	if err != nil {
+		return values, err
+	}
+	vlan := strconv.Itoa(*md.Cabinet.HMNVlan)
+	values = append(values, vlan)
+	return values, nil
 }

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -86,6 +86,10 @@ type InventoryProvider interface {
 
 	// Return metadata about each field
 	GetFieldMetadata() ([]FieldMetadata, error)
+
+	// Workflows
+	ListCabinetMetadataColumns() (columns []string)
+	ListCabinetMetadataRow(inventory.Hardware) (values []string, err error)
 }
 
 type HardwareValidationResult struct {


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- uses the `MergeProviderCommand` to remove cray-sauce from the `list cabinet` workflow and moves it into the `provider/csm` package
- updates the provider interface and domain package accordingly


# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Low. All existing tests still pass