### PR TITLE
pass cmd and args to ValidateExternal to better support multiple prov…

### DIFF
--- a/cmd/session/session_apply.go
+++ b/cmd/session/session_apply.go
@@ -74,7 +74,7 @@ func stopSession(cmd *cobra.Command, args []string) (err error) {
 		log.Info().Msgf("Committing changes to session")
 
 		// Commit the external inventory
-		result, err := root.D.Commit(cmd.Context(), dryrun, ignoreExternalValidation)
+		result, err := root.D.Commit(cmd, args, dryrun, ignoreExternalValidation)
 		if errors.Is(err, provider.ErrDataValidationFailure) {
 			// TODO the following should probably suggest commands to fix the issue?
 			log.Error().Msgf("Inventory data validation errors encountered")

--- a/cmd/session/session_init.go
+++ b/cmd/session/session_init.go
@@ -116,7 +116,7 @@ func initSessionWithProviderCmd(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// Validate the external inventory before attempting an import
-	result, err := root.D.Validate(cmd.Context(), false, ignoreExternalValidation)
+	result, err := root.D.Validate(cmd, args, false, ignoreExternalValidation)
 	if errors.Is(err, provider.ErrDataValidationFailure) {
 		// TODO the following should probably suggest commands to fix the issue?
 		log.Error().Msgf("Inventory data validation errors encountered")

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -48,7 +48,7 @@ func validateInventory(cmd *cobra.Command, args []string) error {
 	if D.Active {
 
 		// Validate the external inventory
-		result, err := D.Validate(cmd.Context(), true, false)
+		result, err := D.Validate(cmd, args, true, false)
 		if errors.Is(err, provider.ErrDataValidationFailure) {
 			// TODO the following should probably suggest commands to fix the issue?
 			log.Error().Msgf("Inventory data validation errors encountered")

--- a/internal/provider/csm/validation.go
+++ b/internal/provider/csm/validation.go
@@ -37,13 +37,14 @@ import (
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
 )
 
 // Validate the external services of the inventory provider are correct
-func (csm *CSM) ValidateExternal(ctx context.Context) error {
+func (csm *CSM) ValidateExternal(cmd *cobra.Command, args []string) error {
 
 	// Get the dumpate from SLS
-	slsState, reps, err := csm.slsClient.DumpstateApi.DumpstateGet(context.Background())
+	slsState, reps, err := csm.slsClient.DumpstateApi.DumpstateGet(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("SLS dumpstate failed. %v\n", err)
 	}

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -40,7 +40,7 @@ var ErrDataValidationFailure = fmt.Errorf("data validation failure")
 // TODO Need to think about how internal data structures should be supplied to the Inventory Provider
 type InventoryProvider interface {
 	// Validate the external services of the inventory provider are correct
-	ValidateExternal(ctx context.Context) error
+	ValidateExternal(cmd *cobra.Command, args []string) error
 
 	// Validate the representation of the inventory data into the destination inventory system
 	// is consistent. The default set of checks will verify all currently provided data is valid.


### PR DESCRIPTION
…iders

# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- passes the cobra command to the provider, specifically for the `ValidateExternal()` interface function 
- this allows more control by the provider to set flags and determine what happens during validation

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Low.  All existing tests pass.