### PR TITLE
pass cobra command to all viable interface functions to give control …

### DIFF
--- a/cmd/blade/add_blade.go
+++ b/cmd/blade/add_blade.go
@@ -87,7 +87,7 @@ func addBlade(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// Add the blade from the inventory using domain methods
-	result, err := root.D.AddBlade(cmd.Context(), args[0], cabinet, chassis, blade)
+	result, err := root.D.AddBlade(cmd, args, cabinet, chassis, blade)
 	if errors.Is(err, provider.ErrDataValidationFailure) {
 		// TODO this validation error print logic could be shared
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -117,7 +117,7 @@ func exportJson(cmd *cobra.Command, args []string, d *domain.Domain, ignoreValid
 	f := os.Stdout
 	writer := bufio.NewWriter(f)
 	defer writer.Flush()
-	err := d.ExportJson(cmd.Context(), writer, ignoreValidation)
+	err := d.ExportJson(cmd, args, writer, ignoreValidation)
 	if err != nil {
 		return err
 	}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -81,7 +81,7 @@ func importAssets(cmd *cobra.Command, args []string) (err error) {
 		return nil
 	}
 
-	result, err := D.ImportCsv(cmd.Context(), r)
+	result, err := D.ImportCsv(cmd, args, r)
 	if errors.Is(err, provider.ErrDataValidationFailure) {
 		log.Error().Msgf("The changes are invalid.")
 		for id, failedValidation := range result.ValidationResults {

--- a/cmd/session/session_init.go
+++ b/cmd/session/session_init.go
@@ -135,7 +135,7 @@ func initSessionWithProviderCmd(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// Import the external inventory
-	if err := root.D.Import(cmd.Context()); err != nil {
+	if err := root.D.Import(cmd, args); err != nil {
 		return err
 	}
 

--- a/internal/domain/blade.go
+++ b/internal/domain/blade.go
@@ -26,7 +26,6 @@
 package domain
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -35,10 +34,13 @@ import (
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
 )
 
 // AddBlade adds a blade to the inventory by crafting location paths from the given ordinals and generating a hardware buildout
-func (d *Domain) AddBlade(ctx context.Context, deviceTypeSlug string, cabinetOrdinal, chassisOrdinal, bladeOrdinal int) (AddHardwareResult, error) {
+func (d *Domain) AddBlade(cmd *cobra.Command, args []string, cabinetOrdinal, chassisOrdinal, bladeOrdinal int) (AddHardwareResult, error) {
+	deviceTypeSlug := args[0]
+
 	// Check if the cabinet exists
 	cabinetPath := inventory.LocationPath{
 		{HardwareType: hardwaretypes.System, Ordinal: 0},
@@ -235,7 +237,7 @@ func (d *Domain) AddBlade(ctx context.Context, deviceTypeSlug string, cabinetOrd
 
 	// Validate the current state of CANI's inventory data against the provider plugin
 	// for provider specific data.
-	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(ctx, d.datastore, false); len(failedValidations) > 0 {
+	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(cmd, args, d.datastore, false); len(failedValidations) > 0 {
 		result.ProviderValidationErrors = failedValidations
 	} else if err != nil {
 		return AddHardwareResult{}, errors.Join(

--- a/internal/domain/cabinet.go
+++ b/internal/domain/cabinet.go
@@ -127,7 +127,7 @@ func (d *Domain) AddCabinet(cmd *cobra.Command, args []string, recommendations p
 
 	// Validate the current state of CANI's inventory data against the provider plugin
 	// for provider specific data.
-	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(cmd.Context(), d.datastore, false); len(failedValidations) > 0 {
+	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(cmd, args, d.datastore, false); len(failedValidations) > 0 {
 		result.ProviderValidationErrors = failedValidations
 		return result, provider.ErrDataValidationFailure
 	} else if err != nil {

--- a/internal/domain/commit.go
+++ b/internal/domain/commit.go
@@ -52,7 +52,7 @@ func (d *Domain) Commit(cmd *cobra.Command, args []string, dryrun bool, ignoreEx
 
 	// Validate the current state of CANI's inventory data against the provider plugin
 	// for provider specific data
-	if failedValidations, err := inventoryProvider.ValidateInternal(cmd.Context(), d.datastore, true); len(failedValidations) > 0 {
+	if failedValidations, err := inventoryProvider.ValidateInternal(cmd, args, d.datastore, true); len(failedValidations) > 0 {
 		return CommitResult{
 			ProviderValidationErrors: failedValidations,
 		}, err
@@ -75,5 +75,5 @@ func (d *Domain) Commit(cmd *cobra.Command, args []string, dryrun bool, ignoreEx
 	}
 
 	// Reconcile our inventory with the external inventory system
-	return CommitResult{}, inventoryProvider.Reconcile(cmd.Context(), d.datastore, dryrun, ignoreExternalValidation)
+	return CommitResult{}, inventoryProvider.Reconcile(cmd, args, d.datastore, dryrun, ignoreExternalValidation)
 }

--- a/internal/domain/csv.go
+++ b/internal/domain/csv.go
@@ -41,6 +41,7 @@ import (
 	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -129,8 +130,8 @@ func (d *Domain) ExportCsv(ctx context.Context, writer *csv.Writer, headers []st
 	return nil
 }
 
-func (d *Domain) ExportJson(ctx context.Context, writer io.Writer, skipValidation bool) error {
-	exportedJson, err := d.externalInventoryProvider.ExportJson(ctx, d.datastore, skipValidation)
+func (d *Domain) ExportJson(cmd *cobra.Command, args []string, writer io.Writer, skipValidation bool) error {
+	exportedJson, err := d.externalInventoryProvider.Export(cmd, args, d.datastore, skipValidation)
 	if err != nil {
 		return err
 	}
@@ -140,7 +141,7 @@ func (d *Domain) ExportJson(ctx context.Context, writer io.Writer, skipValidatio
 	return nil
 }
 
-func (d *Domain) ImportCsv(ctx context.Context, reader *csv.Reader) (result provider.CsvImportResult, err error) {
+func (d *Domain) ImportCsv(cmd *cobra.Command, args []string, reader *csv.Reader) (result provider.CsvImportResult, err error) {
 	tempDatastore, err := d.datastore.Clone()
 	if err != nil {
 		return result, err
@@ -207,7 +208,7 @@ func (d *Domain) ImportCsv(ctx context.Context, reader *csv.Reader) (result prov
 	}
 
 	if result.Modified > 0 {
-		results, err := d.externalInventoryProvider.ValidateInternal(ctx, tempDatastore, false)
+		results, err := d.externalInventoryProvider.ValidateInternal(cmd, args, tempDatastore, false)
 		if err != nil {
 			result.ValidationResults = results
 			return result, err

--- a/internal/domain/import.go
+++ b/internal/domain/import.go
@@ -25,10 +25,8 @@
  */
 package domain
 
-import (
-	"context"
-)
+import "github.com/spf13/cobra"
 
-func (d *Domain) Import(ctx context.Context) error {
-	return d.externalInventoryProvider.Import(ctx, d.datastore)
+func (d *Domain) Import(cmd *cobra.Command, args []string) error {
+	return d.externalInventoryProvider.Import(cmd, args, d.datastore)
 }

--- a/internal/domain/misc.go
+++ b/internal/domain/misc.go
@@ -66,7 +66,7 @@ func (d *Domain) Validate(cmd *cobra.Command, args []string, checkRequiredData b
 
 	// Validate the current state of CANI's inventory data against the provider plugin
 	// for provider specific data.
-	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(cmd.Context(), d.datastore, checkRequiredData); len(failedValidations) > 0 {
+	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(cmd, args, d.datastore, checkRequiredData); len(failedValidations) > 0 {
 		result.ProviderValidationErrors = failedValidations
 	} else if err != nil {
 		return ValidateResult{}, errors.Join(

--- a/internal/domain/node.go
+++ b/internal/domain/node.go
@@ -67,7 +67,7 @@ func (d *Domain) UpdateNode(cmd *cobra.Command, args []string, cabinet, chassis,
 	// Validate the current state of CANI's inventory data against the provider plugin
 	// for provider specific data.
 	var result AddHardwareResult
-	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(cmd.Context(), d.datastore, false); len(failedValidations) > 0 {
+	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(cmd, args, d.datastore, false); len(failedValidations) > 0 {
 		result.ProviderValidationErrors = failedValidations
 		return result, provider.ErrDataValidationFailure
 	} else if err != nil {

--- a/internal/provider/csm/export_sls.go
+++ b/internal/provider/csm/export_sls.go
@@ -26,16 +26,16 @@
 package csm
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 
 	"github.com/Cray-HPE/cani/internal/inventory"
+	"github.com/spf13/cobra"
 )
 
-func (csm *CSM) ExportJson(ctx context.Context, datastore inventory.Datastore, skipValidation bool) ([]byte, error) {
-	currentSLSState, _, err := csm.slsClient.DumpstateApi.DumpstateGet(ctx)
+func (csm *CSM) Export(cmd *cobra.Command, args []string, datastore inventory.Datastore, skipValidation bool) ([]byte, error) {
+	currentSLSState, _, err := csm.slsClient.DumpstateApi.DumpstateGet(cmd.Context())
 	if err != nil {
 		return nil, errors.Join(
 			fmt.Errorf("failed to get the current SLS state"),

--- a/internal/provider/csm/import.go
+++ b/internal/provider/csm/import.go
@@ -26,7 +26,6 @@
 package csm
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -46,6 +45,7 @@ import (
 	"github.com/Cray-HPE/hms-xname/xnames"
 	"github.com/Cray-HPE/hms-xname/xnametypes"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
 )
 
 //
@@ -71,7 +71,7 @@ func loadJSON(path string, dest interface{}) error {
 	return json.Unmarshal(raw, dest)
 }
 
-func (csm *CSM) Import(ctx context.Context, datastore inventory.Datastore) error {
+func (csm *CSM) Import(cmd *cobra.Command, args []string, datastore inventory.Datastore) error {
 	// Check the schema version defined in the datastore
 	datastoreSchema, err := datastore.GetSchemaVersion()
 	if err != nil {
@@ -82,17 +82,17 @@ func (csm *CSM) Import(ctx context.Context, datastore inventory.Datastore) error
 	//
 	// Retrieve current state from the system
 	//
-	slsDumpstate, _, err := csm.slsClient.DumpstateApi.DumpstateGet(ctx)
+	slsDumpstate, _, err := csm.slsClient.DumpstateApi.DumpstateGet(cmd.Context())
 	if err != nil {
 		return errors.Join(fmt.Errorf("failed to perform SLS dumpstate"), err)
 	}
 
-	hsmStateComponents, _, err := csm.hsmClient.ComponentApi.DoComponentsGet(ctx, nil)
+	hsmStateComponents, _, err := csm.hsmClient.ComponentApi.DoComponentsGet(cmd.Context(), nil)
 	if err != nil {
 		return errors.Join(fmt.Errorf("failed to retrieve HSM State Components"), err)
 	}
 
-	hsmHardwareInventory, _, err := csm.hsmClient.HWInventoryByLocationApi.DoHWInvByLocationGetAll(ctx, nil)
+	hsmHardwareInventory, _, err := csm.hsmClient.HWInventoryByLocationApi.DoHWInvByLocationGetAll(cmd.Context(), nil)
 	if err != nil {
 		return errors.Join(fmt.Errorf("failed to retrieve HSM State Components"), err)
 	}
@@ -768,7 +768,7 @@ func (csm *CSM) Import(ctx context.Context, datastore inventory.Datastore) error
 	//
 	// Push updates to SLS
 	//
-	if err := sls.HardwareUpdate(csm.slsClient, ctx, slsHardwareToModify, 10); err != nil {
+	if err := sls.HardwareUpdate(csm.slsClient, cmd.Context(), slsHardwareToModify, 10); err != nil {
 		return errors.Join(fmt.Errorf("failed to update hardware in SLS"), err)
 	}
 

--- a/internal/provider/csm/validation.go
+++ b/internal/provider/csm/validation.go
@@ -26,7 +26,6 @@
 package csm
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -60,7 +59,7 @@ func (csm *CSM) ValidateExternal(cmd *cobra.Command, args []string) error {
 // Validate the representation of the inventory data into the destination inventory system
 // is consistent. The default set of checks will verify all currently provided data is valid.
 // If enableRequiredDataChecks is set to true, additional checks focusing on missing data will be ran.
-func (csm *CSM) ValidateInternal(ctx context.Context, datastore inventory.Datastore, enableRequiredDataChecks bool) (map[uuid.UUID]provider.HardwareValidationResult, error) {
+func (csm *CSM) ValidateInternal(cmd *cobra.Command, args []string, datastore inventory.Datastore, enableRequiredDataChecks bool) (map[uuid.UUID]provider.HardwareValidationResult, error) {
 	log.Debug().Msg("Validating datastore contents against the CSM Provider")
 
 	allHardware, err := datastore.List()

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -26,7 +26,6 @@
 package provider
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/Cray-HPE/cani/internal/inventory"
@@ -45,15 +44,15 @@ type InventoryProvider interface {
 	// Validate the representation of the inventory data into the destination inventory system
 	// is consistent. The default set of checks will verify all currently provided data is valid.
 	// If enableRequiredDataChecks is set to true, additional checks focusing on missing data will be ran.
-	ValidateInternal(ctx context.Context, datastore inventory.Datastore, enableRequiredDataChecks bool) (map[uuid.UUID]HardwareValidationResult, error)
+	ValidateInternal(cmd *cobra.Command, args []string, datastore inventory.Datastore, enableRequiredDataChecks bool) (map[uuid.UUID]HardwareValidationResult, error)
 
 	// Import external inventory data into CANI's inventory format
-	Import(ctx context.Context, datastore inventory.Datastore) error
+	Import(cmd *cobra.Command, args []string, datastore inventory.Datastore) error
 
-	ExportJson(ctx context.Context, datastore inventory.Datastore, skipValidation bool) ([]byte, error)
+	Export(cmd *cobra.Command, args []string, datastore inventory.Datastore, skipValidation bool) ([]byte, error)
 
 	// Reconcile CANI's inventory state with the external inventory state and apply required changes
-	Reconcile(ctx context.Context, datastore inventory.Datastore, dryrun bool, ignoreExternalValidation bool) error
+	Reconcile(cmd *cobra.Command, args []string, datastore inventory.Datastore, dryrun bool, ignoreExternalValidation bool) error
 
 	// RecommendHardware returns recommended settings for adding hardware based on the deviceTypeSlug
 	RecommendHardware(inv inventory.Inventory, cmd *cobra.Command, args []string, auto bool) (recommended HardwareRecommendations, err error)


### PR DESCRIPTION
…to provider.  this leaves the domain and cmd logic relatively untouched when changes are made.

# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- passes the cobra command to other provider interface functions
- this further gives the control to the provider and keeps the cmd and domain layers more for logic
- this change is also needed for upcoming changes where (most) every command has a counterpart in the provider package

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Low.  Existing tests all pass
