### PR TITLE
migrate single-provider config to multi

### DIFF
--- a/cmd/config/debt.go
+++ b/cmd/config/debt.go
@@ -1,0 +1,158 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package config
+
+import (
+	"os"
+
+	"github.com/Cray-HPE/cani/cmd/taxonomy"
+	"github.com/Cray-HPE/cani/internal/inventory"
+	"github.com/Cray-HPE/cani/internal/provider"
+	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
+	"gopkg.in/yaml.v3"
+)
+
+// DeprecatedConfig is the single-provider Config object and is left here for migration purposes
+type DeprecatedConfig struct {
+	Session *DeprecatedSession `yaml:"session"`
+}
+
+// DeprecatedSession is the single-provider Session object and is left here for migration purposes
+type DeprecatedSession struct {
+	DomainOptions *DeprecatedDomainOpts `yaml:"domain_options"`
+	Domain        *DeprecatedDomain     `yaml:"domain"`
+	Active        bool                  `yaml:"active"`
+}
+
+// DeprecatedDomain is the single-provider Domain object and is left here for migration purposes
+type DeprecatedDomain struct {
+	hardwareTypeLibrary       *hardwaretypes.Library
+	datastore                 inventory.Datastore
+	externalInventoryProvider provider.InventoryProvider
+	configOptions             DeprecatedConfigOptions
+}
+
+// DeprecatedDomainOpts is the single-provider Domain object and is left here for migration purposes
+type DeprecatedDomainOpts struct {
+	DatastorePath          string                 `yaml:"datastore_path"`
+	LogFilePath            string                 `yaml:"log_file_path"`
+	Provider               string                 `yaml:"provider"`
+	CsmOptions             DeprecatedProviderOpts `yaml:"csm_options"`
+	CustomHardwareTypesDir string                 `yaml:"custom_hardware_types_dir"`
+}
+
+// DeprecatedProviderOpts are the single-provider options and is now handled within each provider's package
+type DeprecatedProviderOpts struct {
+	UseSimulation      bool
+	InsecureSkipVerify bool
+	APIGatewayToken    string
+	BaseUrlSLS         string
+	BaseUrlHSM         string
+	SecretName         string
+	K8sPodsCidr        string
+	K8sServicesCidr    string
+	KubeConfig         string
+	ClientID           string `json:"-" yaml:"-"` // omit credentials from cani.yml
+	ClientSecret       string `json:"-" yaml:"-"` // omit credentials from cani.yml
+	ProviderHost       string
+	TokenUsername      string `json:"-" yaml:"-"` // omit credentials from cani.yml
+	TokenPassword      string `json:"-" yaml:"-"` // omit credentials from cani.yml
+	CaCertPath         string
+	ValidRoles         []string
+	ValidSubRoles      []string
+}
+
+// DeprecatedConfigOptions is the single-provider ConfigOptions and is now handled within each provider's package
+type DeprecatedConfigOptions struct {
+	ValidRoles      []string
+	ValidSubRoles   []string
+	K8sPodsCidr     string
+	K8sServicesCidr string
+}
+
+// migrateConfig converts an older single-provider config into a multi-provider formatted one
+func migrateConfig(path string, old []byte) (migrated *Config, err error) {
+	// unmarshal the old config style to a struct
+	dc := &DeprecatedConfig{}
+	err = yaml.Unmarshal(old, &dc)
+	if err != nil {
+		return migrated, err
+	}
+
+	// get just the options
+	csmOpts, err := yaml.Marshal(dc.Session.DomainOptions.CsmOptions)
+	if err != nil {
+		return migrated, err
+	}
+
+	// rename the old config
+	err = os.Rename(path, path+".single")
+	if err != nil {
+		return migrated, err
+	}
+
+	// Generate a new one in its place
+	err = InitConfig(path)
+	if err != nil {
+		return migrated, err
+	}
+
+	// load the new config
+	new, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// unmarshal the new config to a struct
+	err = yaml.Unmarshal(new, &migrated)
+	if err != nil {
+		return nil, err
+	}
+
+	providerOpts := map[string]interface{}{}
+
+	// convert deprecated csm_options to new generic options
+	err = yaml.Unmarshal(csmOpts, &providerOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	// the multi-provider structure is slightly different, so map appropriately
+	migrated.Session.Domains[taxonomy.CSM].CustomHardwareTypesDir = dc.Session.DomainOptions.CustomHardwareTypesDir
+	migrated.Session.Domains[taxonomy.CSM].DatastorePath = dc.Session.DomainOptions.DatastorePath
+	migrated.Session.Domains[taxonomy.CSM].LogFilePath = dc.Session.DomainOptions.LogFilePath
+	migrated.Session.Domains[taxonomy.CSM].Active = dc.Session.Active
+	migrated.Session.Domains[taxonomy.CSM].Provider = dc.Session.DomainOptions.Provider
+	// also set the csm_options to the now-generic options
+	migrated.Session.Domains[taxonomy.CSM].Options = providerOpts
+
+	err = WriteConfig(path, migrated)
+	if err != nil {
+		return migrated, err
+	}
+
+	return migrated, nil
+}

--- a/internal/provider/csm/config_options.go
+++ b/internal/provider/csm/config_options.go
@@ -40,23 +40,23 @@ import (
 )
 
 type CsmOpts struct {
-	UseSimulation      bool     `json:"UseSimulation" yaml:"use_simulation"`
-	InsecureSkipVerify bool     `json:"InsecureSkipVerify" yaml:"insecure_skip_verify"`
-	APIGatewayToken    string   `json:"APIGatewayToken" yaml:"api_gateway_token"`
-	BaseUrlSLS         string   `json:"BaseUrlSLS" yaml:"base_url_sls"`
-	BaseUrlHSM         string   `json:"BaseUrlHSM" yaml:"base_url_hsm"`
-	SecretName         string   `json:"SecretName" yaml:"secret_name"`
-	K8sPodsCidr        string   `json:"K8sPodsCidr" yaml:"k8s_pods_cidr"`
-	K8sServicesCidr    string   `json:"K8sServicesCidr" yaml:"k8s_services_cidr"`
-	KubeConfig         string   `json:"KubeConfig" yaml:"kubeconfig"`
-	ClientID           string   `json:"-" yaml:"-"` // omit credentials from cani.yml
-	ClientSecret       string   `json:"-" yaml:"-"` // omit credentials from cani.yml
-	ProviderHost       string   `json:"ProviderHost" yaml:"provider_host"`
-	TokenUsername      string   `json:"-" yaml:"-"` // omit credentials from cani.yml
-	TokenPassword      string   `json:"-" yaml:"-"` // omit credentials from cani.yml
-	CaCertPath         string   `json:"CaCertPath" yaml:"ca_cert_path"`
-	ValidRoles         []string `json:"ValidRoles" yaml:"valid_roles"`
-	ValidSubRoles      []string `json:"ValidSubRoles" yaml:"valid_sub_roles"`
+	UseSimulation      bool
+	InsecureSkipVerify bool
+	APIGatewayToken    string
+	BaseUrlSLS         string
+	BaseUrlHSM         string
+	SecretName         string
+	K8sPodsCidr        string
+	K8sServicesCidr    string
+	KubeConfig         string
+	ClientID           string `json:"-" yaml:"-"` // omit credentials from cani.yml
+	ClientSecret       string `json:"-" yaml:"-"` // omit credentials from cani.yml
+	ProviderHost       string
+	TokenUsername      string `json:"-" yaml:"-"` // omit credentials from cani.yml
+	TokenPassword      string `json:"-" yaml:"-"` // omit credentials from cani.yml
+	CaCertPath         string
+	ValidRoles         []string
+	ValidSubRoles      []string
 }
 
 func (csm *CSM) SetProviderOptions(cmd *cobra.Command, args []string) error {

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -40,6 +40,7 @@ spec_helper_precheck() {
   # also helpful for cani config fixtures if this is a static, abs path
   setenv CANI_DIR="/tmp/.cani"
   setenv CANI_CONF="${CANI_DIR:=/tmp/.cani}/cani.yml"
+  setenv CANI_CONF_SINGLE="${CANI_DIR:=/tmp/.cani}/cani.yml.single"
   setenv CANI_DS="${CANI_DIR:=/tmp/.cani}/canidb.json"
   setenv CANI_LOG="${CANI_DIR:=/tmp/.cani}/canidb.log"
   setenv CANI_CUSTOM_HW_DIR="${CANI_DIR:=/tmp/.cani}/hardware-types"
@@ -86,6 +87,13 @@ use_inactive_session(){
   #shellcheck disable=SC2317
   cp "$FIXTURES"/cani/configs/canitest_valid_inactive.yml "$CANI_CONF"
 } 
+
+# deploys an older single-provider config
+use_single_provider_session(){
+  #shellcheck disable=SC2317
+  mkdir -p "$(dirname "$CANI_CONF")"
+  cp "$FIXTURES"/cani/configs/valid_single_provider_deprecated.yml "$CANI_CONF"
+}
 
 use_custom_hw_type(){ 
   mkdir -p "$(dirname "$CANI_CUSTOM_HW_CONF")"

--- a/testdata/fixtures/cani/configs/canitest_valid_active.yml
+++ b/testdata/fixtures/cani/configs/canitest_valid_active.yml
@@ -30,25 +30,25 @@ session:
             custom_hardware_types_dir: /tmp/.cani/hardware-types
             provider: csm
             options:
-                use_simulation: true
-                insecure_skip_verify: true
-                api_gateway_token: ""
-                base_url_sls: https://localhost:8443/apis/sls/v1
-                base_url_hsm: https://localhost:8443/apis/smd/hsm/v2
-                secret_name: admin-client-auth
-                k8s_pods_cidr: 10.32.0.0/12
-                k8s_services_cidr: 10.16.0.0/12
+                usesimulation: true
+                insecureskipverify: true
+                apigatewaytoken: ""
+                baseurlsls: https://localhost:8443/apis/sls/v1
+                baseurlhsm: https://localhost:8443/apis/smd/hsm/v2
+                secretname: admin-client-auth
+                k8spodscidr: 10.32.0.0/12
+                k8sservicescidr: 10.16.0.0/12
                 kubeconfig: ""
-                provider_host: localhost:8443
-                ca_cert_path: ""
-                valid_roles:
+                providerhost: localhost:8443
+                cacertpath: ""
+                validroles:
                     - Management
                     - Compute
                     - Service
                     - System
                     - Application
                     - Storage
-                valid_sub_roles:
+                validsubroles:
                     - Storage
                     - UAN
                     - Gateway

--- a/testdata/fixtures/cani/configs/valid_single_provider_deprecated.yml
+++ b/testdata/fixtures/cani/configs/valid_single_provider_deprecated.yml
@@ -1,0 +1,59 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+session:
+    domain_options:
+        datastore_path: /tmp/.cani/canidb.json
+        log_file_path: /tmp/.cani/canidb.log
+        provider: csm
+        csm_options:
+            usesimulation: true
+            insecureskipverify: true
+            apigatewaytoken: "migrated"
+            baseurlsls: https://localhost:8443/apis/sls/v1
+            baseurlhsm: https://localhost:8443/apis/smd/hsm/v2
+            secretname: admin-client-auth
+            k8spodscidr: 10.32.0.0/12
+            k8sservicescidr: 10.16.0.0/12
+            kubeconfig: ""
+            providerhost: localhost:8443
+            cacertpath: ""
+            validroles:
+                - Management
+                - Compute
+                - Service
+                - System
+                - Application
+                - Storage
+            validsubroles:
+                - Worker
+                - Storage
+                - UAN
+                - Gateway
+                - LNETRouter
+                - Visualization
+                - UserDefined
+                - Master
+        custom_hardware_types_dir: /tmp/.cani/hardware-types
+    domain: {}
+    active: true

--- a/testdata/fixtures/cani/configs/valid_single_provider_migrated.yml
+++ b/testdata/fixtures/cani/configs/valid_single_provider_migrated.yml
@@ -24,7 +24,7 @@
 session:
     domains:
         csm:
-            active: false
+            active: true
             datastore_path: /tmp/.cani/canidb.json
             log_file_path: /tmp/.cani/canidb.log
             custom_hardware_types_dir: /tmp/.cani/hardware-types
@@ -32,7 +32,7 @@ session:
             options:
                 usesimulation: true
                 insecureskipverify: true
-                apigatewaytoken: ""
+                apigatewaytoken: migrated
                 baseurlsls: https://localhost:8443/apis/sls/v1
                 baseurlhsm: https://localhost:8443/apis/smd/hsm/v2
                 secretname: admin-client-auth


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- adds steps to create a multi-provider config if a single-provider config (now deprecated) is detected
- adds a `debt.go` file, which contains all the previous csm-sauce, needed for the conversion (rather than spreading the sauce all over their previous locations)
- reverts the `CsmOpts` struct tags since I mistakenly added underscores to them at the start of this development branch (adjusted test fixtures as appropriate)

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Low, this aids in transitioning existing versions of cani to new ones
