### PR TITLE
remove more cray-sauce, adjust switch statements for better readability

### DIFF
--- a/cmd/cabinet/add_cabinet.go
+++ b/cmd/cabinet/add_cabinet.go
@@ -57,7 +57,7 @@ func addCabinet(cmd *cobra.Command, args []string) (err error) {
 
 	if auto {
 		// get hardware recommendations from the provider
-		log.Info().Msgf("Querying inventory to suggest cabinet number and VLAN ID")
+		log.Info().Msgf("Querying inventory to suggest %s", hardwaretypes.Cabinet)
 		// Prompt the user to confirm the suggestions
 		if !accept {
 			accept, err = tui.CustomConfirmation(fmt.Sprintf("Would you like to accept the recommendations and add the %s", hardwaretypes.Cabinet))

--- a/cmd/session/init.go
+++ b/cmd/session/init.go
@@ -40,7 +40,6 @@ var (
 	commit                   bool
 	ignoreExternalValidation bool
 	ignoreValidationMessage  = "Ignore validation failures. Use this to allow unconventional configurations."
-	csmInitCmd               = &cobra.Command{}
 
 	ProviderCmd = &cobra.Command{}
 	// BootstapCmd is used to start a session with a specific provider and allows the provider to define
@@ -62,9 +61,7 @@ func init() {
 	for _, provider := range taxonomy.SupportedProviders {
 		switch provider {
 		case taxonomy.CSM:
-			csmInitCmd, err = csm.NewSessionInitCommand()
-			csmInitCmd.Use = "init"
-			ProviderCmd = csmInitCmd
+			ProviderCmd, err = csm.NewSessionInitCommand()
 		default:
 			log.Debug().Msgf("skipping provider: %s", provider)
 		}
@@ -72,6 +69,7 @@ func init() {
 			log.Error().Msgf("unable to get cmd from provider: %v", err)
 			os.Exit(1)
 		}
+		ProviderCmd.Use = "init"
 	}
 
 	// Define the bare minimum needed to determine who the provider for the session will be
@@ -87,7 +85,7 @@ func init() {
 
 	// Add session commands to root commands
 	root.SessionCmd.AddCommand(BootstrapCmd)
-	BootstrapCmd.AddCommand(csmInitCmd)
+	BootstrapCmd.AddCommand(ProviderCmd)
 	root.SessionCmd.AddCommand(SessionApplyCmd)
 	root.SessionCmd.AddCommand(SessionStatusCmd)
 	root.SessionCmd.AddCommand(SessionSummaryCmd)

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -109,33 +109,34 @@ func (d *Domain) SetupDomain(cmd *cobra.Command, args []string) (err error) {
 	// Instantiate the provider interface object
 	switch d.Provider {
 	case taxonomy.CSM:
-		// Create a new provider object
 		d.externalInventoryProvider, err = csm.New(cmd, args, d.hardwareTypeLibrary, d.Options)
-		if err != nil {
-			return errors.Join(
-				fmt.Errorf("failed to initialize CSM external inventory provider"),
-				err,
-			)
-		}
 
-		if cmd.Name() == "init" {
-			err := d.externalInventoryProvider.SetProviderOptions(cmd, args)
-			if err != nil {
-				return err
-			}
-		}
-		log.Debug().Msgf("setting provider-specific options %+v", d.Options)
-		if d.Options == nil {
-			opts, err := d.externalInventoryProvider.GetProviderOptions()
-			if err != nil {
-				return err
-			}
-
-			d.Options = opts.(interface{})
-		}
-		// }
 	default:
 		return fmt.Errorf("unknown external inventory provider provided (%s)", d.Provider)
+	}
+
+	if err != nil {
+		return errors.Join(
+			fmt.Errorf("failed to initialize %s external inventory provider", d.Provider),
+			err,
+		)
+	}
+
+	if cmd.Name() == "init" {
+		err := d.externalInventoryProvider.SetProviderOptions(cmd, args)
+		if err != nil {
+			return err
+		}
+	}
+
+	log.Debug().Msgf("setting provider-specific options %+v", d.Options)
+	if d.Options == nil {
+		opts, err := d.externalInventoryProvider.GetProviderOptions()
+		if err != nil {
+			return err
+		}
+
+		d.Options = opts
 	}
 
 	return nil

--- a/internal/provider/csm/config_options.go
+++ b/internal/provider/csm/config_options.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/Cray-HPE/cani/cmd/taxonomy"
 	"github.com/Cray-HPE/cani/internal/provider/csm/validate"
-	"github.com/mitchellh/mapstructure"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
@@ -167,12 +166,4 @@ func (csm *CSM) GetProviderOptions() (interface{}, error) {
 		return nil, fmt.Errorf("options from CSM are nil")
 	}
 	return csm.Options, nil
-}
-
-func (csm *CSM) SetProviderOptionsInterface(opts interface{}) error {
-	err := mapstructure.Decode(opts, &csm.Options)
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/internal/provider/hpcm/options.go
+++ b/internal/provider/hpcm/options.go
@@ -35,10 +35,6 @@ func (hpcm *Hpcm) SetProviderOptions(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (hpcm *Hpcm) SetProviderOptionsInterface(cmd *cobra.Command, args []string) error {
-	return nil
-}
-
 func (hpcm *Hpcm) GetProviderOptions() (interface{}, error) {
 	return nil, nil
 }

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -66,10 +66,6 @@ type InventoryProvider interface {
 	// SetProviderOptions are specific to the Provider. For example, supported Roles and SubRoles
 	SetProviderOptions(cmd *cobra.Command, args []string) error
 
-	// SetProviderOptionsInterface passes the options down to the provider as an interface
-	// It must be type-asserted at that layer and then set
-	SetProviderOptionsInterface(interface{}) error
-
 	// GetProviderOptions gets the options from the provider as an interface
 	// It must be type-asserted and then set at the domain layer
 	GetProviderOptions() (interface{}, error)

--- a/spec/edge/add_cabinet_ex2000_subnet_limit_spec.sh
+++ b/spec/edge/add_cabinet_ex2000_subnet_limit_spec.sh
@@ -63,7 +63,7 @@ End
 It 'Add ex2000 cabinet to reach subnet limit'
   When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2000 --auto --accept
   The status should equal 0
-  The line 1 of stderr should include 'Querying inventory to suggest cabinet number and VLAN ID'
+  The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include "Suggested cabinet number: $1"
   The line 3 of stderr should include "Suggested VLAN ID: $2"
   The line 4 of stderr should include "Cabinet $1 was successfully staged to be added to the system"

--- a/spec/edge/add_cabinet_ex2000_vlan_limit_spec.sh
+++ b/spec/edge/add_cabinet_ex2000_vlan_limit_spec.sh
@@ -63,7 +63,7 @@ End
 It 'Add ex2000 cabinet to reach the vlan limit'
   When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2000 --auto --accept
   The status should equal 0
-  The line 1 of stderr should include 'Querying inventory to suggest cabinet number and VLAN ID'
+  The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include "Suggested cabinet number: $1"
   The line 3 of stderr should include "Suggested VLAN ID: $2"
   The line 4 of stderr should include "Cabinet $1 was successfully staged to be added to the system"
@@ -76,7 +76,7 @@ Describe 'EDGE:'
 It 'Add ex2000 cabinet to exceed the vlan limit'
   When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2000 --auto --accept
   The status should equal 1
-  The line 1 of stderr should include 'Querying inventory to suggest cabinet number and VLAN ID'
+  The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include "Suggested cabinet number: 10000"
   The line 3 of stderr should include "Suggested VLAN ID: 4000"
   The line 4 of stderr should equal "Error: VLAN exceeds the provider's maximum range (3999).  Please choose a valid VLAN"

--- a/spec/functional/cani_add_cabinet_spec.sh
+++ b/spec/functional/cani_add_cabinet_spec.sh
@@ -218,7 +218,7 @@ It "--config $CANI_CONF hpe-ex2000 --auto --accept"
   BeforeCall use_active_session # session is active
   When call bin/cani alpha add cabinet --config "$CANI_CONF" hpe-ex2000 --auto --accept 
   The status should equal 0
-  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 1 of stderr should include " Querying inventory to suggest Cabinet"
   The line 2 of stderr should include " Suggested cabinet number: "
   The line 3 of stderr should include " Suggested VLAN ID: "
   The line 4 of stderr should include " was successfully staged to be added to the system"
@@ -252,7 +252,7 @@ End
 
 It "--config $CANI_CONF $1 --auto --accept"
   When call bin/cani alpha add cabinet --config "$CANI_CONF" "$1" --auto --accept
-  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 1 of stderr should include " Querying inventory to suggest Cabinet"
   The line 2 of stderr should include " Suggested cabinet number: "
   The line 3 of stderr should include " Suggested VLAN ID: "
   The line 4 of stderr should include " was successfully staged to be added to the system"
@@ -344,7 +344,7 @@ End
 # setup a bunch of cabinets with incongruent cabinet numbers
 It "--config $CANI_CONF $1 --auto --accept"
   When call bin/cani alpha add cabinet --config "$CANI_CONF" "$1" --auto --accept
-  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 1 of stderr should include " Querying inventory to suggest Cabinet"
   The line 2 of stderr should include " Suggested cabinet number: "
   The line 3 of stderr should include " Suggested VLAN ID: "
   The line 4 of stderr should include " was successfully staged to be added to the system"
@@ -436,7 +436,7 @@ End
 # setup a bunch of cabinets with incongruent cabinet numbers
 It "--config $CANI_CONF $1 --auto --accept"
   When call bin/cani alpha add cabinet --config "$CANI_CONF" "$1" --auto --accept
-  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 1 of stderr should include " Querying inventory to suggest Cabinet"
   The line 2 of stderr should include " Suggested cabinet number: "
   The line 3 of stderr should include " Suggested VLAN ID: "
   The line 4 of stderr should include " was successfully staged to be added to the system"
@@ -460,7 +460,7 @@ It "--config $CANI_CONF my-custom-cabinet --auto --accept"
   BeforeCall use_valid_datastore_system_only
   When call bin/cani alpha add cabinet --config "$CANI_CONF" my-custom-cabinet --auto --accept
   The status should equal 0
-  The line 1 of stderr should include " Querying inventory to suggest cabinet number and VLAN ID"
+  The line 1 of stderr should include " Querying inventory to suggest Cabinet"
   The line 2 of stderr should include " Suggested cabinet number: 4321"
   The line 3 of stderr should include " Suggested VLAN ID: 1111"
   The line 4 of stderr should include " was successfully staged to be added to the system"

--- a/spec/integration/add_cabinet_ex2000_dryrun_spec.sh
+++ b/spec/integration/add_cabinet_ex2000_dryrun_spec.sh
@@ -52,7 +52,7 @@ End
 It 'add ex2000 cabinet'
   When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2000 --auto --accept
   The status should equal 0
-  The line 1 of stderr should include 'Querying inventory to suggest cabinet number and VLAN ID'
+  The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 9001'
   The line 3 of stderr should include 'Suggested VLAN ID: 3001'
   The line 4 of stderr should include 'Cabinet 9001 was successfully staged to be added to the system'

--- a/spec/integration/add_cabinet_ex2000_spec.sh
+++ b/spec/integration/add_cabinet_ex2000_spec.sh
@@ -52,7 +52,7 @@ End
 It 'add ex2000 cabinet'
   When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2000 --auto --accept
   The status should equal 0
-  The line 1 of stderr should include 'Querying inventory to suggest cabinet number and VLAN ID'
+  The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 9001'
   The line 3 of stderr should include 'Suggested VLAN ID: 3001'
   The line 4 of stderr should include 'Cabinet 9001 was successfully staged to be added to the system'

--- a/spec/integration/add_cabinet_ex2500_spec.sh
+++ b/spec/integration/add_cabinet_ex2500_spec.sh
@@ -52,7 +52,7 @@ End
 It 'add hpe-ex2500-1-liquid-cooled-chassis cabinet'
   When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2500-1-liquid-cooled-chassis --auto --accept
   The status should equal 0
-  The line 1 of stderr should include 'Querying inventory to suggest cabinet number and VLAN ID'
+  The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 8000'
   The line 3 of stderr should include 'Suggested VLAN ID: 3001'
   The line 4 of stderr should include 'Cabinet 8000 was successfully staged to be added to the system'
@@ -61,7 +61,7 @@ End
 It 'add hpe-ex2500-2-liquid-cooled-chassis cabinet'
   When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2500-2-liquid-cooled-chassis --auto --accept
   The status should equal 0
-  The line 1 of stderr should include 'Querying inventory to suggest cabinet number and VLAN ID'
+  The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 8001'
   The line 3 of stderr should include 'Suggested VLAN ID: 3002'
   The line 4 of stderr should include 'Cabinet 8001 was successfully staged to be added to the system'
@@ -70,7 +70,7 @@ End
 It 'add hpe-ex2500-3-liquid-cooled-chassis cabinet'
   When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2500-3-liquid-cooled-chassis --auto --accept
   The status should equal 0
-  The line 1 of stderr should include 'Querying inventory to suggest cabinet number and VLAN ID'
+  The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 8002'
   The line 3 of stderr should include 'Suggested VLAN ID: 3003'
   The line 4 of stderr should include 'Cabinet 8002 was successfully staged to be added to the system'

--- a/spec/integration/add_cabinet_ex3000_spec.sh
+++ b/spec/integration/add_cabinet_ex3000_spec.sh
@@ -52,7 +52,7 @@ End
 It 'add ex3000 cabinet'
   When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex3000 --auto --accept
   The status should equal 0
-  The line 1 of stderr should include 'Querying inventory to suggest cabinet number and VLAN ID'
+  The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 1000'
   The line 3 of stderr should include 'Suggested VLAN ID: 3001'
   The line 4 of stderr should include 'Cabinet 1000 was successfully staged to be added to the system'

--- a/spec/integration/add_cabinet_ex4000_spec.sh
+++ b/spec/integration/add_cabinet_ex4000_spec.sh
@@ -52,7 +52,7 @@ End
 It 'add ex4000 cabinet'
   When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex4000 --auto --accept
   The status should equal 0
-  The line 1 of stderr should include 'Querying inventory to suggest cabinet number and VLAN ID'
+  The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 1000'
   The line 3 of stderr should include 'Suggested VLAN ID: 3001'
   The line 4 of stderr should include 'Cabinet 1000 was successfully staged to be added to the system'

--- a/spec/integration/export_import_spec.sh
+++ b/spec/integration/export_import_spec.sh
@@ -36,7 +36,7 @@ End
 It 'add cabinet hpe-ex2500-1-liquid-cooled-chassis'
   When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2500-1-liquid-cooled-chassis --auto --accept
   The status should equal 0
-  The line 1 of stderr should include 'Querying inventory to suggest cabinet number and VLAN ID'
+  The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 8000'
   The line 3 of stderr should include 'Suggested VLAN ID: 3001'
   The line 4 of stderr should include 'Cabinet 8000 was successfully staged to be added to the system'

--- a/spec/integration/export_sls_json_spec.sh
+++ b/spec/integration/export_sls_json_spec.sh
@@ -36,7 +36,7 @@ End
 It 'add cabinet hpe-ex2500-1-liquid-cooled-chassis'
   When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2500-1-liquid-cooled-chassis --auto --accept
   The status should equal 0
-  The line 1 of stderr should include 'Querying inventory to suggest cabinet number and VLAN ID'
+  The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 8000'
   The line 3 of stderr should include 'Suggested VLAN ID: 3001'
   The line 4 of stderr should include 'Cabinet 8000 was successfully staged to be added to the system'


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- removes more csm specific things I found
- moves repetitive error and var assignments to the end of the switch statement for better readability of different cases

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

