### PR TITLE
Add init force

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -174,7 +174,7 @@ func setupDomain(cmd *cobra.Command, args []string) (err error) {
 
 		log.Debug().Msgf("Active provider is: %s", activeDomain.Provider)
 		D = activeDomain
-		err = D.SetupDomain(cmd, args)
+		err = D.SetupDomain(cmd, args, Conf.Session.Domains)
 		if err != nil {
 			return err
 		}

--- a/cmd/session/init.go
+++ b/cmd/session/init.go
@@ -40,6 +40,7 @@ var (
 	commit                   bool
 	ignoreExternalValidation bool
 	ignoreValidationMessage  = "Ignore validation failures. Use this to allow unconventional configurations."
+	forceInit                bool
 
 	ProviderCmd = &cobra.Command{}
 	// BootstapCmd is used to start a session with a specific provider and allows the provider to define
@@ -74,6 +75,7 @@ func init() {
 
 	// Define the bare minimum needed to determine who the provider for the session will be
 	BootstrapCmd.Flags().BoolVar(&ignoreExternalValidation, "ignore-validation", false, ignoreValidationMessage)
+	BootstrapCmd.Flags().BoolVarP(&forceInit, "force", "f", false, "Overwrite the existing session with a new session")
 
 	// all flags should be set in init().  you can set flags after the fact, but it is much easier to work with everything up front
 	// this will set existing variables for each provider

--- a/cmd/session/session_init.go
+++ b/cmd/session/session_init.go
@@ -86,7 +86,7 @@ func initSessionWithProviderCmd(cmd *cobra.Command, args []string) (err error) {
 	// Setup the domain now that the minimum required options are set
 	// This allows the provider to define their own logic and keeps it out
 	// of the 'cmd' package
-	err = root.D.SetupDomain(cmd, args)
+	err = root.D.SetupDomain(cmd, args, root.Conf.Session.Domains)
 	if err != nil {
 		return err
 	}
@@ -98,10 +98,15 @@ func initSessionWithProviderCmd(cmd *cobra.Command, args []string) (err error) {
 		ds := root.D.DatastorePath
 		// Check if the json file exists
 		if _, err := os.Stat(ds); err == nil {
-			// If the json file exists, prompt user for overwrite
-			overwrite, err := promptForOverwrite(ds)
-			if err != nil {
-				return err
+			overwrite := false
+			if forceInit {
+				overwrite = true
+			} else {
+				// If the json file exists, prompt user for overwrite
+				overwrite, err = promptForOverwrite(ds)
+				if err != nil {
+					return err
+				}
 			}
 			if !overwrite {
 				// User chose not to overwrite the file

--- a/cmd/session/summary.go
+++ b/cmd/session/summary.go
@@ -47,7 +47,7 @@ var SessionSummaryCmd = &cobra.Command{
 
 func showSummary(cmd *cobra.Command, args []string) error {
 	// resetup the domain to get fresh info
-	err := root.D.SetupDomain(cmd, args)
+	err := root.D.SetupDomain(cmd, args, root.Conf.Session.Domains)
 	if err != nil {
 		return err
 	}

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -65,11 +65,18 @@ func New(cmd *cobra.Command, args []string) (d *Domain, err error) {
 }
 
 // SetupDomain sets the provider options for the domain
-func (d *Domain) SetupDomain(cmd *cobra.Command, args []string) (err error) {
+func (d *Domain) SetupDomain(cmd *cobra.Command, args []string, configDomains map[string]*Domain) (err error) {
 	// The domain needs a minimum of three things to start:
 	//   1. a datastore to save the inventory to
 	//   2. a hardware type library to know compatible hardware
 	//   3. a provider interface object
+
+	for _, sessionDomain := range configDomains {
+		if sessionDomain.Active {
+			d.Active = true
+			log.Debug().Msgf("Setting top level Domain to Active=true")
+		}
+	}
 
 	// active sessions should have a datastore
 	if _, err := os.Stat(d.DatastorePath); os.IsNotExist(err) {


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->
Test output:
```
+ shellspec ./spec/functional/cani_session_spec.sh -f tap --no-banner
1..17
ok 1 - cani session --help
ok 2 - cani session --config /tmp/.cani/cani.yml status
ok 3 - cani session --config /tmp/.cani/cani.yml status
ok 4 - cani session --config /tmp/.cani/cani.yml init
ok 5 - cani session --config /tmp/.cani/cani.yml init fake -S --csm-api-host localhost:8443
ok 6 - cani session (timeout, no connection to provider) --config /tmp/.cani/cani.yml init csm
ok 7 - cani session initialize a session without a config file or datastore
ok 8 - cani session initialize a session and validate a custom hardware type
ok 9 - cani session initialize a session and validate a custom hardware type
ok 10 - cani session initialize a session with a CIDR that overlaps k8s values
ok 11 - session migration: add a cabinet with a single-provider config
ok 12 - session migration: check config for migrated field
ok 13 - recreate session: setup for test by initializing the session
ok 14 - recreate session: session init with N answer
ok 15 - recreate session: session init with Y answer
ok 16 - recreate session: session init with force option
ok 17 - recreate session: session init with f option
```

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

