### PR TITLE
revamp PrintHardware 

### DIFF
--- a/cmd/blade/add_blade.go
+++ b/cmd/blade/add_blade.go
@@ -31,6 +31,7 @@ import (
 	"sort"
 
 	root "github.com/Cray-HPE/cani/cmd"
+	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/Cray-HPE/cani/internal/tui"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
@@ -119,6 +120,7 @@ func addBlade(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
+	var filtered = make(map[uuid.UUID]inventory.Hardware, 0)
 	for _, result := range result.AddedHardware {
 		// If the type is a Node
 		if result.Hardware.Type == hardwaretypes.NodeBlade {
@@ -134,9 +136,10 @@ func addBlade(cmd *cobra.Command, args []string) (err error) {
 				result.Location)
 
 			log.Info().Str("status", "SUCCESS").Msgf("%s was successfully staged to be added to the system", hardwaretypes.NodeBlade)
-			root.D.PrintHardware(&result.Hardware)
+			filtered[result.Hardware.ID] = result.Hardware
 		}
 	}
+	root.D.PrintHardware(cmd, args, filtered)
 
 	return nil
 }

--- a/cmd/blade/list_blade.go
+++ b/cmd/blade/list_blade.go
@@ -26,18 +26,10 @@
 package blade
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"os"
-	"sort"
-	"text/tabwriter"
-
 	root "github.com/Cray-HPE/cani/cmd"
 	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/google/uuid"
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
@@ -60,91 +52,16 @@ func listBlade(cmd *cobra.Command, args []string) error {
 
 	// Filter the inventory to only blades
 	filtered := make(map[uuid.UUID]inventory.Hardware, 0)
-
-	// If no args are provided, list all blades
-	if len(args) == 0 {
-		for key, hw := range inv.Hardware {
-			if hw.Type == hardwaretypes.NodeBlade {
-				filtered[key] = hw
-			}
-		}
-	} else {
-		// List each blade specified in the args
-		for _, arg := range args {
-			// Convert the argument to a UUID
-			u, err := uuid.Parse(arg)
-			if err != nil {
-				return fmt.Errorf("Need a UUID: %s", err.Error())
-			}
-			// if blade does not exist, error
-			if _, exists := inv.Hardware[u]; !exists {
-				return fmt.Errorf("%s %s not found in inventory.", hardwaretypes.NodeBlade, u)
-			}
-			// If the hardware is a blade
-			if inv.Hardware[u].Type == hardwaretypes.NodeBlade {
-				// add it to the filtered inventory
-				filtered[u] = inv.Hardware[u]
-			} else {
-				log.Debug().Msgf("%s is not a %s.  It is a %s", u, hardwaretypes.NodeBlade, inv.Hardware[u].Type)
-			}
+	for key, hw := range inv.Hardware {
+		if hw.Type == hardwaretypes.NodeBlade {
+			filtered[key] = hw
 		}
 	}
-	switch format {
-	case "json":
-		// Convert the filtered inventory into a formatted JSON string
-		inventoryJSON, err := json.MarshalIndent(filtered, "", "  ")
-		if err != nil {
-			return errors.New(fmt.Sprintf("Error marshaling inventory to JSON: %v", err))
-		}
 
-		// Print the inventory
-		fmt.Println(string(inventoryJSON))
-	case "pretty":
-		minwidth := 0         // minimal cell width including any padding
-		tabwidth := 8         // width of tab characters (equivalent number of spaces)
-		padding := 1          // padding added to a cell before computing its width
-		padchar := byte('\t') // ASCII char used for padding
-
-		w := tabwriter.NewWriter(os.Stdout, minwidth, tabwidth, padding, padchar, tabwriter.AlignRight)
-		defer w.Flush()
-
-		fmt.Fprintf(w, "%s\t%s\t%s\t%v\n",
-			"UUID",
-			"Status",
-			"Type",
-			"Location")
-
-		// make keys slice to sort by values in the map
-		keys := make([]uuid.UUID, 0, len(filtered))
-		for key := range filtered {
-			keys = append(keys, key)
-		}
-
-		// sort by what the user wants
-		sort.Slice(keys, func(i, j int) bool {
-			switch sortBy {
-			case "location":
-				return filtered[keys[i]].LocationPath.String() < filtered[keys[j]].LocationPath.String()
-
-			case "type":
-				return string(filtered[keys[i]].DeviceTypeSlug) < string(filtered[keys[j]].DeviceTypeSlug)
-
-			case "uuid":
-				return filtered[keys[i]].ID.String() < filtered[keys[j]].ID.String()
-
-			}
-
-			// default is sorted by loc
-			return filtered[keys[i]].LocationPath.String() < filtered[keys[j]].LocationPath.String()
-		})
-
-		for _, hw := range keys {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%v\n",
-				filtered[hw].ID.String(),
-				filtered[hw].Status,
-				filtered[hw].DeviceTypeSlug,
-				filtered[hw].LocationPath.String())
-		}
+	err = root.D.PrintHardware(cmd, args, filtered)
+	if err != nil {
+		return err
 	}
+
 	return nil
 }

--- a/cmd/cabinet/add_cabinet.go
+++ b/cmd/cabinet/add_cabinet.go
@@ -31,9 +31,11 @@ import (
 	"sort"
 
 	root "github.com/Cray-HPE/cani/cmd"
+	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/Cray-HPE/cani/internal/tui"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
+	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -93,13 +95,15 @@ func addCabinet(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
+	var filtered = make(map[uuid.UUID]inventory.Hardware, 0)
 	for _, result := range result.AddedHardware {
 		if result.Hardware.Type == hardwaretypes.Cabinet {
 			log.Debug().Msgf("%s added at %s with parent %s (%s)", result.Hardware.Type, result.Location.String(), hardwaretypes.System, result.Hardware.Parent)
 			log.Info().Str("status", "SUCCESS").Msgf("%s %d was successfully staged to be added to the system", hardwaretypes.Cabinet, recommendations.CabinetOrdinal)
-			root.D.PrintHardware(&result.Hardware)
+			filtered[result.Hardware.ID] = result.Hardware
 		}
 	}
 
+	root.D.PrintHardware(cmd, args, filtered)
 	return nil
 }

--- a/cmd/cabinet/list_cabinet.go
+++ b/cmd/cabinet/list_cabinet.go
@@ -26,19 +26,10 @@
 package cabinet
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"os"
-	"sort"
-	"strings"
-	"text/tabwriter"
-
 	root "github.com/Cray-HPE/cani/cmd"
 	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/google/uuid"
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
@@ -58,6 +49,7 @@ func listCabinet(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
 	// Filter the inventory to only cabinets
 	filtered := make(map[uuid.UUID]inventory.Hardware, 0)
 	for key, hw := range inv.Hardware {
@@ -66,106 +58,10 @@ func listCabinet(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	switch format {
-	case "json":
-		// Convert the filtered inventory into a formatted JSON string
-		inventoryJSON, err := json.MarshalIndent(filtered, "", "  ")
-		if err != nil {
-			return errors.New(fmt.Sprintf("Error marshaling inventory to JSON: %v", err))
-		}
-		// Print the inventory
-		fmt.Println(string(inventoryJSON))
-
-	case "pretty":
-		// 		tpl := `{{ printf "%.25s" CABINET }}
-		//{{- range . }}
-		// |{{ .ID }} | {{ .DeviceTypeSlug }} | {{ .DeviceTypeSlug }}  | {{ .LocationPath }} | {{ end }}
-		// 		`
-
-		minwidth := 0         // minimal cell width including any padding
-		tabwidth := 8         // width of tab characters (equivalent number of spaces)
-		padding := 1          // padding added to a cell before computing its width
-		padchar := byte('\t') // ASCII char used for padding
-
-		w := tabwriter.NewWriter(os.Stdout, minwidth, tabwidth, padding, padchar, tabwriter.AlignRight)
-		defer w.Flush()
-
-		// set the CANI columns
-		caniColumns := []string{
-			"UUID",
-			"Status",
-			"Type",
-			"Location",
-		}
-		// Get columns set by the provider
-		providerColumns := root.D.ListCabinetMetadataColumns()
-
-		// combine CANI and provider columns
-		columns := []string{}
-		for _, col := range [][]string{caniColumns, providerColumns} {
-			columns = append(columns, col...)
-		}
-
-		fmt.Fprint(
-			w,
-			fmt.Sprintf("%v%s", strings.Join(columns, "\t"), "\n"),
-		)
-
-		// make keys slice to sort by values in the map
-		keys := make([]uuid.UUID, 0, len(filtered))
-		for key := range filtered {
-			keys = append(keys, key)
-		}
-
-		// sort by what the user wants
-		sort.Slice(keys, func(i, j int) bool {
-			switch sortBy {
-			case "location":
-				return filtered[keys[i]].LocationPath.String() < filtered[keys[j]].LocationPath.String()
-
-			case "type":
-				return string(filtered[keys[i]].DeviceTypeSlug) < string(filtered[keys[j]].DeviceTypeSlug)
-
-			case "uuid":
-				return filtered[keys[i]].ID.String() < filtered[keys[j]].ID.String()
-			}
-
-			// default is sorted by loc
-			return filtered[keys[i]].LocationPath.String() < filtered[keys[j]].LocationPath.String()
-		})
-
-		for _, u := range keys {
-			hw, exists := filtered[u]
-			if !exists {
-				return err
-			}
-			// get the provider-specific fields
-			providerValues, err := root.D.ListCabinetMetadataRow(hw)
-			if err != nil {
-				return err
-			}
-
-			// Set the fields CANI uses
-			fields := []string{"%s", "%s", "%s"}
-			// append any provider-specified ones, using a %+v to display them to avoid any typing issues at the cost of something ugly printing
-			for _, n := range providerColumns {
-				log.Debug().Msgf("Using provider-defined column: %+v", n)
-				fields = append(fields, "%+v")
-			}
-			// print the table with CANI and provider columns/rows
-			fmt.Fprint(
-				w,
-				fmt.Sprintf(strings.Join(fields, "\t"),
-					filtered[u].ID.String(),
-					filtered[u].Status,
-					filtered[u].DeviceTypeSlug,
-					filtered[u].LocationPath.String()),
-				"\t",
-				fmt.Sprintf(strings.Join(providerValues, "\t")),
-				"\n",
-			)
-		}
-
+	err = root.D.PrintHardware(cmd, args, filtered)
+	if err != nil {
+		return err
 	}
+
 	return nil
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -26,10 +26,6 @@
 package cmd
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -49,13 +45,10 @@ func listInventory(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Convert the inventory into a formatted JSON string
-	inventoryJSON, err := json.MarshalIndent(inv.Hardware, "", "  ")
+	err = D.PrintHardware(cmd, args, inv.Hardware)
 	if err != nil {
-		return errors.New(fmt.Sprintf("Error marshaling inventory to JSON: %v", err))
+		return err
 	}
 
-	// Print the inventory
-	fmt.Println(string(inventoryJSON))
 	return nil
 }

--- a/cmd/node/init.go
+++ b/cmd/node/init.go
@@ -43,6 +43,7 @@ var (
 	format                string
 	sortBy                string
 	ProviderAddNodeCmd    = &cobra.Command{}
+	ProviderListNodeCmd   = &cobra.Command{}
 	ProviderUpdateNodeCmd = &cobra.Command{}
 )
 
@@ -81,6 +82,11 @@ func init() {
 	// Merge CANI's command with the provider-specified command
 	// this allows for CANI's operations to remain consistent, while adding provider config on top
 	err = root.MergeProviderCommand(UpdateNodeCmd, ProviderUpdateNodeCmd)
+	if err != nil {
+		log.Error().Msgf("%+v", err)
+		os.Exit(1)
+	}
+	err = root.MergeProviderCommand(ListNodeCmd, ProviderListNodeCmd)
 	if err != nil {
 		log.Error().Msgf("%+v", err)
 		os.Exit(1)

--- a/cmd/node/list_node.go
+++ b/cmd/node/list_node.go
@@ -26,16 +26,8 @@
 package node
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"os"
-	"sort"
-	"text/tabwriter"
-
 	root "github.com/Cray-HPE/cani/cmd"
 	"github.com/Cray-HPE/cani/internal/inventory"
-	"github.com/Cray-HPE/cani/internal/provider/csm"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
@@ -57,6 +49,7 @@ func listNode(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
 	// Filter the inventory to only nodes
 	filtered := make(map[uuid.UUID]inventory.Hardware, 0)
 	for key, hw := range inv.Hardware {
@@ -65,91 +58,10 @@ func listNode(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	switch format {
-	case "json":
-		// Convert the filtered inventory into a formatted JSON string
-		inventoryJSON, err := json.MarshalIndent(filtered, "", "  ")
-		if err != nil {
-			return errors.New(fmt.Sprintf("Error marshaling inventory to JSON: %v", err))
-		}
-		// Print the inventory
-		fmt.Println(string(inventoryJSON))
-
-	case "pretty":
-
-		minwidth := 0         // minimal cell width including any padding
-		tabwidth := 8         // width of tab characters (equivalent number of spaces)
-		padding := 1          // padding added to a cell before computing its width
-		padchar := byte('\t') // ASCII char used for padding
-
-		w := tabwriter.NewWriter(os.Stdout, minwidth, tabwidth, padding, padchar, tabwriter.AlignRight)
-		defer w.Flush()
-
-		fmt.Fprintf(w, "%s\t%s\t%s\t%v\t%s\t%s\t%s\t%s\n",
-			"UUID",
-			"Status",
-			"Type",
-			"Role",
-			"SubRole",
-			"Alias",
-			"NID",
-			"Location")
-
-		// make keys slice to sort by values in the map
-		keys := make([]uuid.UUID, 0, len(filtered))
-		for key := range filtered {
-			keys = append(keys, key)
-		}
-
-		// sort by what the user wants
-		sort.Slice(keys, func(i, j int) bool {
-			switch sortBy {
-			case "location":
-				return filtered[keys[i]].LocationPath.String() < filtered[keys[j]].LocationPath.String()
-
-			case "type":
-				return string(filtered[keys[i]].DeviceTypeSlug) < string(filtered[keys[j]].DeviceTypeSlug)
-
-			case "uuid":
-				return filtered[keys[i]].ID.String() < filtered[keys[j]].ID.String()
-
-			}
-
-			// default is sorted by loc
-			return filtered[keys[i]].LocationPath.String() < filtered[keys[j]].LocationPath.String()
-		})
-
-		for _, hw := range keys {
-			// Start with an empty Node metadata struct, just in case if this node doesn't have any
-			// metadata set
-			var nodeMetadata csm.NodeMetadata
-
-			// If metadata exists decode it
-			if _, exists := filtered[hw].ProviderMetadata[inventory.CSMProvider]; exists {
-				csmMetadata, err := csm.DecodeProviderMetadata(filtered[hw])
-				if err != nil {
-					return err
-				}
-
-				if csmMetadata.Node != nil {
-					nodeMetadata = *csmMetadata.Node
-				}
-			}
-
-			// convert properties to strings and set nil values for easy printing
-			pp := nodeMetadata.Pretty()
-
-			fmt.Fprintf(w, "%s\t%s\t%s\t%v\t%v\t%v\t%v\t%v\n",
-				filtered[hw].ID.String(),
-				filtered[hw].Status,
-				filtered[hw].DeviceTypeSlug,
-				pp.Role,
-				pp.SubRole,
-				pp.Alias,
-				pp.Nid,
-				filtered[hw].LocationPath.String())
-		}
-
+	err = root.D.PrintHardware(cmd, args, filtered)
+	if err != nil {
+		return err
 	}
+
 	return nil
 }

--- a/internal/domain/cabinet.go
+++ b/internal/domain/cabinet.go
@@ -165,16 +165,3 @@ func (d *Domain) Recommend(cmd *cobra.Command, args []string, auto bool) (recomm
 	}
 	return recommendations, nil
 }
-
-func (d *Domain) ListCabinetMetadataColumns() (columns []string) {
-	columns = d.externalInventoryProvider.ListCabinetMetadataColumns()
-	return columns
-}
-
-func (d *Domain) ListCabinetMetadataRow(hw inventory.Hardware) (row []string, err error) {
-	row, err = d.externalInventoryProvider.ListCabinetMetadataRow(hw)
-	if err != nil {
-		return row, err
-	}
-	return row, nil
-}

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -136,7 +136,6 @@ func (d *Domain) SetupDomain(cmd *cobra.Command, args []string, configDomains ma
 		}
 	}
 
-	log.Debug().Msgf("setting provider-specific options %+v", d.Options)
 	if d.Options == nil {
 		opts, err := d.externalInventoryProvider.GetProviderOptions()
 		if err != nil {

--- a/internal/domain/print.go
+++ b/internal/domain/print.go
@@ -25,8 +25,16 @@
  */
 package domain
 
-import "github.com/Cray-HPE/cani/internal/inventory"
+import (
+	"github.com/Cray-HPE/cani/internal/inventory"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+)
 
-func (d *Domain) PrintHardware(hardware *inventory.Hardware) {
-	d.externalInventoryProvider.PrintHardware(hardware)
+func (d *Domain) PrintHardware(cmd *cobra.Command, args []string, filtered map[uuid.UUID]inventory.Hardware) error {
+	err := d.externalInventoryProvider.PrintHardware(cmd, args, filtered)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/provider/csm/csm.go
+++ b/internal/provider/csm/csm.go
@@ -201,13 +201,13 @@ func (csm *CSM) setupClients() (err error) {
 	return nil
 }
 
-// ListCabinetMetadataColumns returns a slice of strings, which are columns names of CSM-specific metadata to be shown when listing cabinets
-func (csm *CSM) ListCabinetMetadataColumns() (columns []string) {
+// listCabinetMetadataColumns returns a slice of strings, which are columns names of CSM-specific metadata to be shown when listing cabinets
+func listCabinetMetadataColumns() (columns []string) {
 	return []string{"HMN VLAN"}
 }
 
-// ListCabinetMetadataRow returns a slice of strings, which are values from the hardware that correlate to the columns they will be shown in
-func (csm *CSM) ListCabinetMetadataRow(hw inventory.Hardware) (values []string, err error) {
+// listCabinetMetadataRow returns a slice of strings, which are values from the hardware that correlate to the columns they will be shown in
+func listCabinetMetadataRow(hw inventory.Hardware) (values []string, err error) {
 	md, err := DecodeProviderMetadata(hw)
 	if err != nil {
 		return values, err

--- a/internal/provider/csm/print.go
+++ b/internal/provider/csm/print.go
@@ -26,32 +26,417 @@
 package csm
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
 	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
+	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
 )
 
-func (csm *CSM) PrintHardware(hw *inventory.Hardware) {
-	switch hw.Type {
-	case hardwaretypes.NodeBlade:
-		log.Info().Msgf("UUID: %s", hw.ID)
-
-		cabinet, _ := hw.LocationPath.GetOrdinal(hardwaretypes.Cabinet)
-		log.Info().Msgf("Cabinet: %d", cabinet)
-
-		chassis, _ := hw.LocationPath.GetOrdinal(hardwaretypes.Chassis)
-		log.Info().Msgf("Chassis: %d", chassis)
-
-		blade, _ := hw.LocationPath.GetOrdinal(hardwaretypes.NodeBlade)
-		log.Info().Msgf("Blade: %d", blade)
-
-	case hardwaretypes.Cabinet:
-		log.Info().Msgf("UUID: %s", hw.ID)
-		log.Info().Msgf("Cabinet Number: %d", *hw.LocationOrdinal)
-		log.Info().Msgf("VLAN ID: %d", hw.ProviderMetadata["csm"]["Cabinet"].(map[string]interface{})["HMNVlan"])
-
+// PrintHardware implements the InventoryProvider interface
+// it prints the hardware to stdout based on the command
+func (csm *CSM) PrintHardware(cmd *cobra.Command, args []string, filtered map[uuid.UUID]inventory.Hardware) (err error) {
+	switch cmd.Parent().Name() {
+	case "add":
+		err = csm.printHardwareForAddCommand(cmd, args, filtered)
+	case "list":
+		err = csm.printHardwareForListCommand(cmd, args, filtered)
+	case "update":
+		err = csm.printHardwareForUpdateCommand(cmd, args, filtered)
+	case "remove":
+		err = csm.printHardwareForRemoveCommand(cmd, args, filtered)
 	default:
-		log.Info().Msgf("UUID: %s", hw.ID)
-		log.Info().Msgf("Type: %s", hw.Type)
+		log.Warn().Msgf("No print function for command %+v", cmd.Name())
 	}
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// printHardwareForAddCommand prints the hardware for the add command
+// based on the type of hardware
+func (csm *CSM) printHardwareForAddCommand(cmd *cobra.Command, args []string, filtered map[uuid.UUID]inventory.Hardware) (err error) {
+	for _, hw := range filtered {
+		switch hw.Type {
+		case hardwaretypes.Cabinet:
+			err = printForAddCabinetCommand(cmd, args, hw)
+		// case hardwaretypes.Chassis:
+		// 	err = printForAddChassisCommand(cmd, args, hw)
+		case hardwaretypes.NodeBlade:
+			err = printForAddBladeCommand(cmd, args, hw)
+		case hardwaretypes.Node:
+			err = printForAddNodeCommand(cmd, args, hw)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// printHardwareForListCommand prints the hardware for the list command
+func (csm *CSM) printHardwareForListCommand(cmd *cobra.Command, args []string, filtered map[uuid.UUID]inventory.Hardware) (err error) {
+	err = printForListCommand(cmd, args, filtered)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// printHardwareForUpdateCommand
+func (csm *CSM) printHardwareForUpdateCommand(cmd *cobra.Command, args []string, filtered map[uuid.UUID]inventory.Hardware) (err error) {
+
+	return nil
+}
+
+// printHardwareForRemoveCommand
+func (csm *CSM) printHardwareForRemoveCommand(cmd *cobra.Command, args []string, filtered map[uuid.UUID]inventory.Hardware) (err error) {
+
+	return nil
+}
+
+// printForAddCabinetCommand prints the hardware for the add cabinet command
+func printForAddCabinetCommand(cmd *cobra.Command, args []string, hw inventory.Hardware) error {
+	log.Info().Msgf("UUID: %s", hw.ID)
+	log.Info().Msgf("Cabinet Number: %d", *hw.LocationOrdinal)
+	log.Info().Msgf("VLAN ID: %d", hw.ProviderMetadata["csm"]["Cabinet"].(map[string]interface{})["HMNVlan"])
+
+	return nil
+}
+
+// printForAddBladeCommand prints the hardware for the add blade command
+func printForAddBladeCommand(cmd *cobra.Command, args []string, hw inventory.Hardware) error {
+	log.Info().Msgf("UUID: %s", hw.ID)
+
+	cabinet, _ := hw.LocationPath.GetOrdinal(hardwaretypes.Cabinet)
+	log.Info().Msgf("Cabinet: %d", cabinet)
+
+	chassis, _ := hw.LocationPath.GetOrdinal(hardwaretypes.Chassis)
+	log.Info().Msgf("Chassis: %d", chassis)
+
+	blade, _ := hw.LocationPath.GetOrdinal(hardwaretypes.NodeBlade)
+	log.Info().Msgf("Blade: %d", blade)
+
+	return nil
+}
+
+// printForAddNodeCommand prints the hardware for the add node command
+func printForAddNodeCommand(cmd *cobra.Command, args []string, hw inventory.Hardware) error {
+	log.Info().Msgf("UUID: %s", hw.ID)
+
+	cabinet, _ := hw.LocationPath.GetOrdinal(hardwaretypes.Cabinet)
+	log.Info().Msgf("Cabinet: %d", cabinet)
+
+	chassis, _ := hw.LocationPath.GetOrdinal(hardwaretypes.Chassis)
+	log.Info().Msgf("Chassis: %d", chassis)
+
+	blade, _ := hw.LocationPath.GetOrdinal(hardwaretypes.NodeBlade)
+	log.Info().Msgf("Blade: %d", blade)
+
+	node, _ := hw.LocationPath.GetOrdinal(hardwaretypes.Node)
+	log.Info().Msgf("Node: %d", node)
+
+	return nil
+}
+
+// printForListCommand prints the hardware for the list command
+func printForListCommand(cmd *cobra.Command, args []string, filtered map[uuid.UUID]inventory.Hardware) (err error) {
+	format, _ := cmd.Flags().GetString("format")
+
+	switch format {
+	case "json":
+		log.Info().Msgf("list print json")
+		// Convert the filtered inventory into a formatted JSON string
+		inventoryJSON, err := json.MarshalIndent(filtered, "", "  ")
+		if err != nil {
+			return errors.New(fmt.Sprintf("Error marshaling inventory to JSON: %v", err))
+		}
+		// Print the inventory
+		fmt.Println(string(inventoryJSON))
+
+	case "pretty":
+		err = prettyPrintForListCommand(cmd, args, filtered)
+	}
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// prettyPrintForListCommand prints the hardware for the list command
+// in a pretty, human-readable format and based on the type of hardware
+func prettyPrintForListCommand(cmd *cobra.Command, args []string, filtered map[uuid.UUID]inventory.Hardware) (err error) {
+	switch cmd.Name() {
+	case "cabinet":
+		err = prettyPrintForListCabinet(cmd, args, filtered)
+	case "chassis":
+		err = prettyPrintForListChassis(cmd, args, filtered)
+	case "blade":
+		err = prettyPrintForListBlade(cmd, args, filtered)
+	case "node":
+		err = prettyPrintForListNode(cmd, args, filtered)
+	default:
+	}
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// prettyPrintForListCabinet pretty prints cabinets for the list command
+func prettyPrintForListCabinet(cmd *cobra.Command, args []string, filtered map[uuid.UUID]inventory.Hardware) (err error) {
+	format, _ := cmd.Flags().GetString("format")
+	sortBy, _ := cmd.Flags().GetString("sort")
+
+	switch format {
+	case "json":
+		// Convert the filtered inventory into a formatted JSON string
+		inventoryJSON, err := json.MarshalIndent(filtered, "", "  ")
+		if err != nil {
+			return errors.New(fmt.Sprintf("Error marshaling inventory to JSON: %v", err))
+		}
+		// Print the inventory
+		fmt.Println(string(inventoryJSON))
+
+	case "pretty":
+		// 		tpl := `{{ printf "%.25s" CABINET }}
+		//{{- range . }}
+		// |{{ .ID }} | {{ .DeviceTypeSlug }} | {{ .DeviceTypeSlug }}  | {{ .LocationPath }} | {{ end }}
+		// 		`
+
+		minwidth := 0         // minimal cell width including any padding
+		tabwidth := 8         // width of tab characters (equivalent number of spaces)
+		padding := 1          // padding added to a cell before computing its width
+		padchar := byte('\t') // ASCII char used for padding
+
+		w := tabwriter.NewWriter(os.Stdout, minwidth, tabwidth, padding, padchar, tabwriter.AlignRight)
+		defer w.Flush()
+
+		// set the CANI columns
+		caniColumns := []string{
+			"UUID",
+			"Status",
+			"Type",
+			"Location",
+		}
+		// Get columns set by the provider
+		providerColumns := listCabinetMetadataColumns()
+
+		// combine CANI and provider columns
+		columns := []string{}
+		for _, col := range [][]string{caniColumns, providerColumns} {
+			columns = append(columns, col...)
+		}
+
+		fmt.Fprint(
+			w,
+			fmt.Sprintf("%v%s", strings.Join(columns, "\t"), "\n"),
+		)
+
+		// make keys slice to sort by values in the map
+		keys := make([]uuid.UUID, 0, len(filtered))
+		for key := range filtered {
+			keys = append(keys, key)
+		}
+
+		// sort by what the user wants
+		sort.Slice(keys, func(i, j int) bool {
+			switch sortBy {
+			case "location":
+				return filtered[keys[i]].LocationPath.String() < filtered[keys[j]].LocationPath.String()
+
+			case "type":
+				return string(filtered[keys[i]].DeviceTypeSlug) < string(filtered[keys[j]].DeviceTypeSlug)
+
+			case "uuid":
+				return filtered[keys[i]].ID.String() < filtered[keys[j]].ID.String()
+			}
+
+			// default is sorted by loc
+			return filtered[keys[i]].LocationPath.String() < filtered[keys[j]].LocationPath.String()
+		})
+
+		for _, u := range keys {
+			hw, exists := filtered[u]
+			if !exists {
+				return err
+			}
+			// get the provider-specific fields
+			providerValues, err := listCabinetMetadataRow(hw)
+			if err != nil {
+				return err
+			}
+
+			// Set the fields CANI uses
+			fields := []string{"%s", "%s", "%s"}
+			// append any provider-specified ones, using a %+v to display them to avoid any typing issues at the cost of something ugly printing
+			for _, n := range providerColumns {
+				log.Debug().Msgf("Using provider-defined column: %+v", n)
+				fields = append(fields, "%+v")
+			}
+			// print the table with CANI and provider columns/rows
+			fmt.Fprint(
+				w,
+				fmt.Sprintf(strings.Join(fields, "\t"),
+					filtered[u].ID.String(),
+					filtered[u].Status,
+					filtered[u].DeviceTypeSlug,
+					filtered[u].LocationPath.String()),
+				"\t",
+				fmt.Sprintf(strings.Join(providerValues, "\t")),
+				"\n",
+			)
+		}
+
+	}
+	return nil
+}
+
+// prettyPrintForListChassis pretty prints chassis for the list command
+func prettyPrintForListChassis(cmd *cobra.Command, args []string, filtered map[uuid.UUID]inventory.Hardware) (err error) {
+	log.Warn().Msgf("not yet implemented")
+	return nil
+}
+
+// prettyPrintForListBlade pretty prints blades for the list command
+func prettyPrintForListBlade(cmd *cobra.Command, args []string, filtered map[uuid.UUID]inventory.Hardware) (err error) {
+	sortBy, _ := cmd.Flags().GetString("sort")
+	minwidth := 0         // minimal cell width including any padding
+	tabwidth := 8         // width of tab characters (equivalent number of spaces)
+	padding := 1          // padding added to a cell before computing its width
+	padchar := byte('\t') // ASCII char used for padding
+
+	w := tabwriter.NewWriter(os.Stdout, minwidth, tabwidth, padding, padchar, tabwriter.AlignRight)
+	defer w.Flush()
+
+	fmt.Fprintf(w, "%s\t%s\t%s\t%v\n",
+		"UUID",
+		"Status",
+		"Type",
+		"Location")
+
+	// make keys slice to sort by values in the map
+	keys := make([]uuid.UUID, 0, len(filtered))
+	for key := range filtered {
+		keys = append(keys, key)
+	}
+
+	// sort by what the user wants
+	sort.Slice(keys, func(i, j int) bool {
+		switch sortBy {
+		case "location":
+			return filtered[keys[i]].LocationPath.String() < filtered[keys[j]].LocationPath.String()
+
+		case "type":
+			return string(filtered[keys[i]].DeviceTypeSlug) < string(filtered[keys[j]].DeviceTypeSlug)
+
+		case "uuid":
+			return filtered[keys[i]].ID.String() < filtered[keys[j]].ID.String()
+
+		}
+
+		// default is sorted by loc
+		return filtered[keys[i]].LocationPath.String() < filtered[keys[j]].LocationPath.String()
+	})
+
+	for _, hw := range keys {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%v\n",
+			filtered[hw].ID.String(),
+			filtered[hw].Status,
+			filtered[hw].DeviceTypeSlug,
+			filtered[hw].LocationPath.String())
+	}
+	return nil
+}
+
+// prettyPrintForListNode pretty prints nodes for the list command
+func prettyPrintForListNode(cmd *cobra.Command, args []string, filtered map[uuid.UUID]inventory.Hardware) (err error) {
+	// format, _ := cmd.Flags().GetString("format")
+	sortBy, _ := cmd.Flags().GetString("sort")
+
+	minwidth := 0         // minimal cell width including any padding
+	tabwidth := 8         // width of tab characters (equivalent number of spaces)
+	padding := 1          // padding added to a cell before computing its width
+	padchar := byte('\t') // ASCII char used for padding
+
+	w := tabwriter.NewWriter(os.Stdout, minwidth, tabwidth, padding, padchar, tabwriter.AlignRight)
+	defer w.Flush()
+
+	fmt.Fprintf(w, "%s\t%s\t%s\t%v\t%s\t%s\t%s\t%s\n",
+		"UUID",
+		"Status",
+		"Type",
+		"Role",
+		"SubRole",
+		"Alias",
+		"NID",
+		"Location")
+
+	// make keys slice to sort by values in the map
+	keys := make([]uuid.UUID, 0, len(filtered))
+	for key := range filtered {
+		keys = append(keys, key)
+	}
+
+	// sort by what the user wants
+	sort.Slice(keys, func(i, j int) bool {
+		switch sortBy {
+		case "location":
+			return filtered[keys[i]].LocationPath.String() < filtered[keys[j]].LocationPath.String()
+
+		case "type":
+			return string(filtered[keys[i]].DeviceTypeSlug) < string(filtered[keys[j]].DeviceTypeSlug)
+
+		case "uuid":
+			return filtered[keys[i]].ID.String() < filtered[keys[j]].ID.String()
+
+		}
+
+		// default is sorted by loc
+		return filtered[keys[i]].LocationPath.String() < filtered[keys[j]].LocationPath.String()
+	})
+
+	for _, hw := range keys {
+		// Start with an empty Node metadata struct, just in case if this node doesn't have any
+		// metadata set
+		var nodeMetadata NodeMetadata
+
+		// If metadata exists decode it
+		if _, exists := filtered[hw].ProviderMetadata[inventory.CSMProvider]; exists {
+			csmMetadata, err := DecodeProviderMetadata(filtered[hw])
+			if err != nil {
+				return err
+			}
+
+			if csmMetadata.Node != nil {
+				nodeMetadata = *csmMetadata.Node
+			}
+		}
+
+		// convert properties to strings and set nil values for easy printing
+		pp := nodeMetadata.Pretty()
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%v\t%v\t%v\t%v\t%v\n",
+			filtered[hw].ID.String(),
+			filtered[hw].Status,
+			filtered[hw].DeviceTypeSlug,
+			pp.Role,
+			pp.SubRole,
+			pp.Alias,
+			pp.Nid,
+			filtered[hw].LocationPath.String())
+	}
+	return nil
 }

--- a/internal/provider/hpcm/init.go
+++ b/internal/provider/hpcm/init.go
@@ -66,6 +66,13 @@ func NewUpdateNodeCommand() (cmd *cobra.Command, err error) {
 	return cmd, nil
 }
 
+func NewListNodeCommand() (cmd *cobra.Command, err error) {
+	// cmd represents for cani alpha add node
+	cmd = &cobra.Command{}
+
+	return cmd, nil
+}
+
 // UpdateUpdateNodeCommand
 func UpdateUpdateNodeCommand(caniCmd *cobra.Command) error {
 

--- a/internal/provider/hpcm/metadata.go
+++ b/internal/provider/hpcm/metadata.go
@@ -51,13 +51,3 @@ func (hpcm *Hpcm) GetFields(hw *inventory.Hardware, fieldNames []string) (values
 	log.Warn().Msgf("not yet implemented")
 	return []string{}, nil
 }
-
-func (hpcm *Hpcm) ListCabinetMetadataColumns() (columns []string) {
-	log.Warn().Msgf("not yet implemented")
-	return columns
-}
-
-func (hpcm *Hpcm) ListCabinetMetadataRow(hw inventory.Hardware) (values []string, err error) {
-	log.Warn().Msgf("not yet implemented")
-	return values, nil
-}

--- a/internal/provider/hpcm/print.go
+++ b/internal/provider/hpcm/print.go
@@ -28,8 +28,9 @@ package hpcm
 import (
 	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
 )
 
-func (hpcm *Hpcm) PrintHardware(hw *inventory.Hardware) {
+func (hpcm *Hpcm) PrintHardware(cmd *cobra.Command, args []string, hw *inventory.Hardware) {
 	log.Warn().Msgf("not yet implemented")
 }

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -88,12 +88,8 @@ type InventoryProvider interface {
 	// Return metadata about each field
 	GetFieldMetadata() ([]FieldMetadata, error)
 
-	// Workflows
-	ListCabinetMetadataColumns() (columns []string)
-	ListCabinetMetadataRow(inventory.Hardware) (values []string, err error)
-
 	// Print
-	PrintHardware(hw *inventory.Hardware)
+	PrintHardware(cmd *cobra.Command, args []string, filtered map[uuid.UUID]inventory.Hardware) error
 }
 
 type HardwareValidationResult struct {

--- a/spec/functional/cani_add_spec.sh
+++ b/spec/functional/cani_add_spec.sh
@@ -32,7 +32,7 @@ End
 
 It 'no args'
   BeforeCall remove_config
-  When call bin/cani alpha add
+  When call bin/cani --config "$CANI_CONF" alpha add
   The status should equal 0
   The stdout should satisfy fixture 'cani/add/help'
   The stderr should include 'No active session.'

--- a/spec/functional/cani_remove_spec.sh
+++ b/spec/functional/cani_remove_spec.sh
@@ -32,7 +32,7 @@ End
 
 It 'no args'
   BeforeCall remove_config
-  When call bin/cani alpha remove
+  When call bin/cani --config "$CANI_CONF" alpha remove
   The status should equal 0
   The stdout should satisfy fixture 'cani/remove/help'
   The stderr should include 'No active session.'

--- a/spec/functional/cani_update_spec.sh
+++ b/spec/functional/cani_update_spec.sh
@@ -32,7 +32,7 @@ End
 
 It 'no args'
   BeforeCall remove_config
-  When call bin/cani alpha update
+  When call bin/cani --config "$CANI_CONF" alpha update
   The status should equal 0
   The stdout should satisfy fixture 'cani/update/help'
   The stderr should include 'No active session.'


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- changes all `list` commands to call `root.D.PrintHardware()`
- changed `PrintHardware()` to have arguments of `cmd *cobra.Command, args []string, inv map[uuid.UUID]inventory.Hardware` to give the provider full control over print statements.  this was discovered as a need while adding two other providers (hpcm, cani)
- adjust the hpcm provider pkg to conform to the new method
- fixes a small issue with a shellspec test that does not use the deployed config file 

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Low.  Tests remain unchanged, print statements are the same, they just live somewhere else now