### PR TITLE
generate provider code more better

### DIFF
--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -129,3 +129,16 @@ func (r HardwareRecommendations) Print() {
 	log.Info().Msgf("Suggested cabinet number: %d", r.CabinetOrdinal)
 	log.Info().Msgf("Suggested VLAN ID: %d", r.ProviderMetadata["HMNVlan"])
 }
+
+// ProviderCommands is an interface for the commands that are specific to a provider
+// this isn't usually used directly, but is used to generate the commands with 'makeprovdier'
+type ProviderCommands interface {
+	NewSessionInitCommand() (cmd *cobra.Command, err error)
+	NewAddCabinetCommand() (cmd *cobra.Command, err error)
+	UpdateAddCabinetCommand(caniCmd *cobra.Command) error
+	NewAddNodeCommand() (cmd *cobra.Command, err error)
+	NewUpdateNodeCommand() (cmd *cobra.Command, err error)
+	UpdateUpdateNodeCommand(caniCmd *cobra.Command) error
+	NewExportCommand() (cmd *cobra.Command, err error)
+	NewImportCommand() (cmd *cobra.Command, err error)
+}


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- adds an interface for `ProviderCommands`, so providers know which cobra commands to make
- changes a var name `provider` to `pkg` that clashed with the `provider` import
- loops through interface for all methods (future proofing it) thanks to the above
- formats and adds imports to generated files

![Screen Shot 2023-12-18 at 7 44 15 AM](https://github.com/Cray-HPE/cani/assets/3843505/f5deb1bf-40af-45dc-a4f7-27af43ab377a)

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Low.