### PR TITLE
add functions for getting domains earlier

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -144,3 +144,17 @@ func WriteConfig(path string, cfg *Config) error {
 
 	return nil
 }
+
+// AvailableDomains returns a slice of available domains read from the config
+func (c *Config) AvailableDomains() (map[string]*domain.Domain, error) {
+	domains := make(map[string]*domain.Domain, 0)
+
+	for p, d := range c.Session.Domains {
+		log.Info().Msgf("Found an available domain: %+v", p)
+		_, exists := domains[p]
+		if !exists {
+			domains[p] = d
+		}
+	}
+	return domains, nil
+}

--- a/cmd/session/init.go
+++ b/cmd/session/init.go
@@ -79,7 +79,7 @@ func init() {
 
 	// all flags should be set in init().  you can set flags after the fact, but it is much easier to work with everything up front
 	// this will set existing variables for each provider
-	err = mergeProviderFlags(BootstrapCmd, ProviderCmd)
+	err = root.MergeProviderFlags(BootstrapCmd, ProviderCmd)
 	if err != nil {
 		log.Error().Msgf("unable to get flags from provider: %v", err)
 		os.Exit(1)

--- a/cmd/session/session_init.go
+++ b/cmd/session/session_init.go
@@ -40,28 +40,7 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
-
-// mergeProviderFlags creates a new init command
-// Initilizing a session is where all the information needed to interact with the inventory system(s) is gathered
-// Plugin authors can call this to create their own flags based on their custom business logic
-// A few common flags are set here, but the rest is up to the plugin author
-func mergeProviderFlags(bootstrapCmd *cobra.Command, providerCmd *cobra.Command) (err error) {
-	providerFlagset := &pflag.FlagSet{}
-
-	// get the appropriate flagset from the provider's crafted command
-	providerFlagset = providerCmd.Flags()
-
-	if err != nil {
-		return err
-	}
-
-	// add the provider flags to the command
-	bootstrapCmd.Flags().AddFlagSet(providerFlagset)
-
-	return nil
-}
 
 func initSessionWithProviderCmd(cmd *cobra.Command, args []string) (err error) {
 	// Create a domain object to interact with the datastore and the provider

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -39,7 +39,7 @@ import (
 // Initilizing a session is where all the information needed to interact with the inventory system(s) is gathered
 // Plugin authors can call this to create their own flags based on their custom business logic
 // A few common flags are set here, but the rest is up to the plugin author
-func mergeProviderFlags(bootstrapCmd *cobra.Command, providerCmd *cobra.Command) (err error) {
+func MergeProviderFlags(bootstrapCmd *cobra.Command, providerCmd *cobra.Command) (err error) {
 	providerFlagset := &pflag.FlagSet{}
 
 	// get the appropriate flagset from the provider's crafted command
@@ -97,7 +97,7 @@ func MergeProviderCommand(bootstrapCmd *cobra.Command, providerCmd *cobra.Comman
 	// all flags should be set in init().
 	// You can set flags after the fact, but it is much easier to work with everything up front
 	// this will set existing variables for each provider
-	err = mergeProviderFlags(bootstrapCmd, providerCmd)
+	err = MergeProviderFlags(bootstrapCmd, providerCmd)
 	if err != nil {
 		log.Error().Msgf("unable to get flags from provider: %v", err)
 		os.Exit(1)

--- a/internal/domain/init.go
+++ b/internal/domain/init.go
@@ -1,0 +1,62 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package domain
+
+import (
+	"github.com/Cray-HPE/cani/cmd/taxonomy"
+	"github.com/Cray-HPE/cani/internal/provider/csm"
+	"github.com/spf13/cobra"
+)
+
+// NewProviderCmd returns the appropriate command to the cmd layer
+func NewProviderCmd(bootstrapCmd *cobra.Command, availableDomains map[string]*Domain) (providerCmd *cobra.Command, err error) {
+	providerCmd = &cobra.Command{}
+	for _, d := range availableDomains {
+		switch d.Provider {
+		case taxonomy.CSM:
+			providerCmd, err = csm.NewProviderCmd(bootstrapCmd)
+		}
+		if err != nil {
+			return providerCmd, nil
+		}
+	}
+
+	return providerCmd, nil
+}
+
+// UpdateProviderCmd allows the provider to make updates to the command after cani defines its settings
+func UpdateProviderCmd(bootstrapCmd *cobra.Command, availableDomains map[string]*Domain) (err error) {
+	for _, d := range availableDomains {
+		switch d.Provider {
+		case taxonomy.CSM:
+			err = csm.UpdateProviderCmd(bootstrapCmd)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/provider/csm/init.go
+++ b/internal/provider/csm/init.go
@@ -25,7 +25,12 @@
  */
 package csm
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
 
 var (
 	k8sPodsCidr     string
@@ -59,6 +64,96 @@ var (
 	nid     int
 	alias   string
 )
+
+// NewProviderCmd returns the appropriate command to the cmd layer
+func NewProviderCmd(bootstrapCmd *cobra.Command) (providerCmd *cobra.Command, err error) {
+	// first, choose the right command
+	switch bootstrapCmd.Name() {
+	case "init":
+		providerCmd, err = NewSessionInitCommand()
+	case "cabinet":
+		switch bootstrapCmd.Parent().Name() {
+		case "add":
+			providerCmd, err = NewAddCabinetCommand()
+		case "update":
+			providerCmd, err = NewUpdateCabinetCommand()
+		case "list":
+			providerCmd, err = NewListCabinetCommand()
+		}
+	case "blade":
+		switch bootstrapCmd.Parent().Name() {
+		case "add":
+			providerCmd, err = NewAddBladeCommand()
+		case "update":
+			providerCmd, err = NewUpdateBladeCommand()
+		case "list":
+			providerCmd, err = NewListBladeCommand()
+		}
+	case "node":
+		// check for add/update variants
+		switch bootstrapCmd.Parent().Name() {
+		case "add":
+			providerCmd, err = NewAddNodeCommand()
+		case "update":
+			providerCmd, err = NewUpdateNodeCommand()
+		case "list":
+			providerCmd, err = NewListNodeCommand()
+		}
+	case "export":
+		providerCmd, err = NewExportCommand()
+	case "import":
+		providerCmd, err = NewImportCommand()
+	default:
+		log.Debug().Msgf("Command not implemented by provider: %s %s", bootstrapCmd.Parent().Name(), bootstrapCmd.Name())
+	}
+	if err != nil {
+		return providerCmd, err
+	}
+
+	return providerCmd, nil
+}
+
+func UpdateProviderCmd(bootstrapCmd *cobra.Command) (err error) {
+	// first, choose the right command
+	switch bootstrapCmd.Name() {
+	case "init":
+		err = UpdateSessionInitCommand(bootstrapCmd)
+	case "cabinet":
+		// check for add/update variants
+		switch bootstrapCmd.Parent().Name() {
+		case "add":
+			err = UpdateAddCabinetCommand(bootstrapCmd)
+		case "update":
+			err = UpdateUpdateCabinetCommand(bootstrapCmd)
+		case "list":
+			err = UpdateListCabinetCommand(bootstrapCmd)
+		}
+	case "blade":
+		// check for add/update variants
+		switch bootstrapCmd.Parent().Name() {
+		case "add":
+			err = UpdateAddBladeCommand(bootstrapCmd)
+		case "update":
+			err = UpdateUpdateBladeCommand(bootstrapCmd)
+		case "list":
+			err = UpdateListBladeCommand(bootstrapCmd)
+		}
+	case "node":
+		// check for add/update variants
+		switch bootstrapCmd.Parent().Name() {
+		case "add":
+			err = UpdateAddNodeCommand(bootstrapCmd)
+		case "update":
+			err = UpdateUpdateNodeCommand(bootstrapCmd)
+		case "list":
+			err = UpdateUpdateNodeCommand(bootstrapCmd)
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("unable to update cmd from provider: %v", err)
+	}
+	return nil
+}
 
 func NewSessionInitCommand() (cmd *cobra.Command, err error) {
 	// cmd represents the session init command
@@ -100,6 +195,10 @@ func NewSessionInitCommand() (cmd *cobra.Command, err error) {
 	return cmd, nil
 }
 
+func UpdateSessionInitCommand(caniCmd *cobra.Command) error {
+	return nil
+}
+
 func NewAddCabinetCommand() (cmd *cobra.Command, err error) {
 	// cmd represents the session init command
 	cmd = &cobra.Command{}
@@ -116,6 +215,24 @@ func UpdateAddCabinetCommand(caniCmd *cobra.Command) error {
 	return nil
 }
 
+func NewUpdateCabinetCommand() (cmd *cobra.Command, err error) {
+	cmd = &cobra.Command{}
+	return cmd, nil
+}
+
+func UpdateUpdateCabinetCommand(caniCmd *cobra.Command) error {
+	return nil
+}
+
+func NewListCabinetCommand() (cmd *cobra.Command, err error) {
+	cmd = &cobra.Command{}
+	return cmd, nil
+}
+
+func UpdateListCabinetCommand(caniCmd *cobra.Command) error {
+	return nil
+}
+
 func NewAddNodeCommand() (cmd *cobra.Command, err error) {
 	// cmd represents for cani alpha add node
 	cmd = &cobra.Command{}
@@ -127,6 +244,10 @@ func NewAddNodeCommand() (cmd *cobra.Command, err error) {
 	return cmd, nil
 }
 
+func UpdateAddNodeCommand(caniCmd *cobra.Command) error {
+	return nil
+}
+
 func NewUpdateNodeCommand() (cmd *cobra.Command, err error) {
 	// cmd represents for cani alpha update node
 	cmd = &cobra.Command{}
@@ -136,6 +257,20 @@ func NewUpdateNodeCommand() (cmd *cobra.Command, err error) {
 	cmd.Flags().StringSlice("alias", []string{}, "Comma-separated aliases of the node")
 
 	return cmd, nil
+}
+
+// NewListNodeCommand implements the NewListNodeCommand method of the InventoryProvider interface
+func NewListNodeCommand() (cmd *cobra.Command, err error) {
+	// TODO: Implement
+	cmd = &cobra.Command{}
+
+	return cmd, nil
+}
+
+// UpdateListNodeCommand implements the UpdateListNodeCommand method of the InventoryProvider interface
+func UpdateListNodeCommand(caniCmd *cobra.Command) error {
+	// TODO: Implement
+	return nil
 }
 
 // UpdateUpdateNodeCommand
@@ -164,4 +299,37 @@ func NewImportCommand() (cmd *cobra.Command, err error) {
 	cmd = &cobra.Command{}
 
 	return cmd, nil
+}
+
+func NewAddBladeCommand() (cmd *cobra.Command, err error) {
+	// cmd represents cani alpha import
+	cmd = &cobra.Command{}
+
+	return cmd, nil
+}
+
+func UpdateAddBladeCommand(caniCmd *cobra.Command) error {
+	return nil
+}
+
+func NewUpdateBladeCommand() (cmd *cobra.Command, err error) {
+	// cmd represents cani alpha import
+	cmd = &cobra.Command{}
+
+	return cmd, nil
+}
+
+func UpdateUpdateBladeCommand(caniCmd *cobra.Command) error {
+	return nil
+}
+
+func NewListBladeCommand() (cmd *cobra.Command, err error) {
+	// cmd represents cani alpha import
+	cmd = &cobra.Command{}
+
+	return cmd, nil
+}
+
+func UpdateListBladeCommand(caniCmd *cobra.Command) error {
+	return nil
 }


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- adds an `AvailablerDomains()` method to `Conf`
- makes `mergeProviderFlags` public so `session_init.go` is not duplicating code (removed code here)
- adds `NewProviderCmd` and `UpdateProviderCmd` methods to the domain layer, to further move provider-specific code out of the cmd package
- moves this logic to the provider by adding a `csm.NewProviderCmd()` method

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

