### PR TITLE
check all providers, create a map of init commands

### DIFF
--- a/cmd/session/session_init.go
+++ b/cmd/session/session_init.go
@@ -43,10 +43,18 @@ import (
 )
 
 func initSessionWithProviderCmd(cmd *cobra.Command, args []string) (err error) {
-	// Create a domain object to interact with the datastore and the provider
-	root.D, err = domain.New(cmd, args)
-	if err != nil {
-		return err
+	for _, p := range domain.GetProviders() {
+		// if the provider matches the arg requested, a session can begin
+		if p.Slug() == args[0] {
+			providerInitCmd, exists := ProviderInitCmds[p.Slug()]
+			if exists {
+				// Create a domain object to interact with the datastore and the provider
+				root.D, err = domain.New(providerInitCmd, args)
+				if err != nil {
+					return err
+				}
+			}
+		}
 	}
 
 	// Set the datastore

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -164,3 +164,10 @@ type UpdatedHardwareResult struct {
 	DatastoreValidationErrors map[uuid.UUID]inventory.ValidateResult // TODO
 	ProviderValidationErrors  map[uuid.UUID]provider.HardwareValidationResult
 }
+
+func GetProviders() []provider.InventoryProvider {
+	supportedProviders := []provider.InventoryProvider{
+		&csm.CSM{},
+	}
+	return supportedProviders
+}

--- a/internal/domain/init.go
+++ b/internal/domain/init.go
@@ -31,6 +31,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func NewSessionInitCommand(p string) (providerCmd *cobra.Command, err error) {
+	switch p {
+	case "csm":
+		providerCmd, err = csm.NewSessionInitCommand()
+	}
+	if err != nil {
+		return providerCmd, err
+	}
+	return providerCmd, nil
+}
+
 // NewProviderCmd returns the appropriate command to the cmd layer
 func NewProviderCmd(bootstrapCmd *cobra.Command, availableDomains map[string]*Domain) (providerCmd *cobra.Command, err error) {
 	providerCmd = &cobra.Command{}

--- a/internal/provider/csm/csm.go
+++ b/internal/provider/csm/csm.go
@@ -42,6 +42,10 @@ import (
 	sls_client "github.com/Cray-HPE/cani/pkg/sls-client"
 )
 
+const (
+	CsmSlug = "csm"
+)
+
 type CSM struct {
 	// Clients
 	slsClient       *sls_client.APIClient
@@ -161,6 +165,10 @@ func New(cmd *cobra.Command, args []string, hwlib *hardwaretypes.Library, opts i
 	}
 
 	// return csm, nil
+}
+
+func (csm *CSM) Slug() string {
+	return CsmSlug
 }
 
 func (csm *CSM) setupClients() (err error) {

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -90,6 +90,9 @@ type InventoryProvider interface {
 
 	// Print
 	PrintHardware(cmd *cobra.Command, args []string, filtered map[uuid.UUID]inventory.Hardware) error
+
+	// Provider's name
+	Slug() string
 }
 
 type HardwareValidationResult struct {


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- adds a `GetProviders()` function to the domain layer
- adds a `NewSessionInitCommand()` function to the domain layer
- implements these two functions in the `session/session_init.go` and `session/init.go`.  The `init()` function is where all the cobra commands needs to be initialized, so this creates a map of them all during in init for all providers, and then the appropriate one is chosen during `session init`
- adds a `Slug()` constraint to the provider interface, which helps detect the provider earlier during init

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

