### PR TITLE
run provider command as a sub command to init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -131,7 +131,6 @@ func initConfig() {
 func setupDomain(cmd *cobra.Command, args []string) (err error) {
 	log.Debug().Msgf("Setting %s provider", cmd.Name())
 	log.Debug().Msgf("Setting up domain for command: %s", cmd.Name())
-	// if cmd.Name() != "init" || cmd.Name() != "status" {
 	log.Debug().Msgf("Checking for active domains")
 	// Find an active session
 	activeDomains := []*domain.Domain{}
@@ -146,7 +145,7 @@ func setupDomain(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
-	if cmd.Name() != "init" {
+	if cmd.Parent().Name() != "init" {
 		// Error if no sessions are active
 		if len(activeProviders) == 0 {
 			// These commands are special because they validate hardware in the args

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,7 +86,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 
 // WriteSession writes the session configuration back to the config file
 func WriteSession(cmd *cobra.Command, args []string) error {
-	if cmd.Name() == "init" {
+	if cmd.Parent().Name() == "init" {
 		// Write the configuration back to the file
 		cfgFile := cmd.Root().PersistentFlags().Lookup("config").Value.String()
 		log.Debug().Msgf("Writing session to config %s", cfgFile)

--- a/cmd/session/session_init.go
+++ b/cmd/session/session_init.go
@@ -43,19 +43,13 @@ import (
 )
 
 func initSessionWithProviderCmd(cmd *cobra.Command, args []string) (err error) {
-	for _, p := range domain.GetProviders() {
-		// if the provider matches the arg requested, a session can begin
-		if p.Slug() == args[0] {
-			providerInitCmd, exists := ProviderInitCmds[p.Slug()]
-			if exists {
-				// Create a domain object to interact with the datastore and the provider
-				root.D, err = domain.New(providerInitCmd, args)
-				if err != nil {
-					return err
-				}
-			}
-		}
+	// Create a domain object to interact with the datastore and the provider
+	root.D, err = domain.New(cmd, args)
+	if err != nil {
+		return err
 	}
+
+	root.D.Provider = cmd.Use
 
 	// Set the datastore
 	log.Debug().Msgf("checking provider %s", root.D.Provider)
@@ -69,7 +63,7 @@ func initSessionWithProviderCmd(cmd *cobra.Command, args []string) (err error) {
 	root.D.CustomHardwareTypesDir = config.CustomDir
 	root.D.LogFilePath = filepath.Join(config.ConfigDir, taxonomy.LogFile)
 
-	log.Debug().Msgf("creating domain object for provider %s", args[0])
+	log.Debug().Msgf("creating domain object for provider %s", root.D.Provider)
 	// Setup the domain now that the minimum required options are set
 	// This allows the provider to define their own logic and keeps it out
 	// of the 'cmd' package
@@ -135,7 +129,7 @@ func initSessionWithProviderCmd(cmd *cobra.Command, args []string) (err error) {
 	root.D.Active = true
 
 	// add this provider to the config with the assembled domain object
-	root.Conf.Session.Domains[args[0]] = root.D
+	root.Conf.Session.Domains[root.D.Provider] = root.D
 
 	// write the config to the file
 	err = root.WriteSession(cmd, args)

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -60,7 +60,6 @@ var SessionInitCmd *cobra.Command
 // New returns a new Domain
 func New(cmd *cobra.Command, args []string) (d *Domain, err error) {
 	d = &Domain{}
-	d.Provider = args[0]
 	return d, nil
 }
 

--- a/internal/provider/csm/csm.go
+++ b/internal/provider/csm/csm.go
@@ -66,7 +66,7 @@ func New(cmd *cobra.Command, args []string, hwlib *hardwaretypes.Library, opts i
 		Options:         &CsmOpts{},
 	}
 
-	if cmd.Name() == "init" {
+	if cmd.Parent().Name() == "init" {
 		useSimulation := cmd.Flags().Changed("use-simulator")
 		slsUrl, _ := cmd.Flags().GetString("csm-url-sls")
 		hsmUrl, _ := cmd.Flags().GetString("csm-url-hsm")

--- a/spec/functional/cani_session_spec.sh
+++ b/spec/functional/cani_session_spec.sh
@@ -62,9 +62,9 @@ It "--config $CANI_CONF init"
 End
 
 # Starting a session without passing a provider should fail
-It "--config $CANI_CONF init fake -S --csm-api-host localhost:8443"
+It "--config $CANI_CONF init fake"
   BeforeCall remove_config
-  When call bin/cani alpha session --config "$CANI_CONF" init fake -S --csm-api-host localhost:8443
+  When call bin/cani alpha session --config "$CANI_CONF" init fake
   The status should equal 1
   The line 1 of stderr should equal 'Error: fake is not a valid provider.  Valid providers: [csm]'
 End


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- Merging a provider command with the cani `init` command works ok for one provider, but when adding more, clashes can occur if two providers set the same flags.   This change makes a new provider command for each provider, and merges CANI's flags with it.  This results in each provider having CANI's flags and their own, without clashing with another provider.  To accomplish this, the command name is the same as the provider via the `Slug()` method, and then when an argument to `session init` is a valid provider, it executes the providers init command
- Changes `if cmd.Name() == "init"`s to `if cmd.Parent().Name() == "init"` since `init` calls subcommands
- this requires one change to a test, which checks csm-specific flags on a fake provider

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

