### PR TITLE
adjustments in for preparation for hpcm/ngi providers

### DIFF
--- a/cmd/blade/add_blade.go
+++ b/cmd/blade/add_blade.go
@@ -42,11 +42,12 @@ import (
 
 // AddBladeCmd represents the blade add command
 var AddBladeCmd = &cobra.Command{
-	Use:     "blade",
+	Use:     "blade PROVIDER",
 	Short:   "Add blades to the inventory.",
 	Long:    `Add blades to the inventory.`,
 	PreRunE: validHardware, // Hardware can only be valid if defined in the hardware library
-	RunE:    addBlade,      // Add a blade when this sub-command is called
+	Args:    cobra.ExactArgs(1),
+	RunE:    addBlade, // Add a blade when this sub-command is called
 }
 
 // addBlade adds a blade to the inventory

--- a/cmd/blade/add_blade.go
+++ b/cmd/blade/add_blade.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/blade/init.go
+++ b/cmd/blade/init.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/blade/list_blade.go
+++ b/cmd/blade/list_blade.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/blade/list_blade.go
+++ b/cmd/blade/list_blade.go
@@ -35,10 +35,10 @@ import (
 
 // ListBladeCmd represents the blade list command
 var ListBladeCmd = &cobra.Command{
-	Use:   "blade",
+	Use:   "blade PROVIDER",
 	Short: "List blades in the inventory.",
 	Long:  `List blades in the inventory.`,
-	Args:  cobra.ArbitraryArgs,
+	Args:  cobra.ExactArgs(1),
 	RunE:  listBlade,
 }
 

--- a/cmd/blade/validate.go
+++ b/cmd/blade/validate.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/blade/validate.go
+++ b/cmd/blade/validate.go
@@ -31,13 +31,11 @@ import (
 	"os"
 
 	root "github.com/Cray-HPE/cani/cmd"
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
 // validHardware checks that the hardware type is valid by comparing it against the list of hardware types
 func validHardware(cmd *cobra.Command, args []string) (err error) {
-	log.Debug().Msgf("Validating hardware %+v", root.D)
 	if cmd.Flags().Changed("list-supported-types") {
 		cmd.SetOut(os.Stdout)
 		for _, hw := range root.BladeTypes {

--- a/cmd/cabinet/add_cabinet.go
+++ b/cmd/cabinet/add_cabinet.go
@@ -42,11 +42,12 @@ import (
 
 // AddCabinetCmd represents the cabinet add command
 var AddCabinetCmd = &cobra.Command{
-	Use:     "cabinet",
+	Use:     "cabinet PROVIDER",
 	Short:   "Add cabinets to the inventory.",
 	Long:    `Add cabinets to the inventory.`,
 	PreRunE: validHardware, // Hardware can only be valid if defined in the hardware library
-	RunE:    addCabinet,    // Add a cabinet when this sub-command is called
+	Args:    cobra.ExactArgs(1),
+	RunE:    addCabinet,
 }
 
 // addCabinet adds a cabinet to the inventory
@@ -75,7 +76,7 @@ func addCabinet(cmd *cobra.Command, args []string) (err error) {
 		}
 
 		// log the provider recommendations to the screen
-		recommendations.Print()
+		root.D.PrintRecommendations(cmd, args, recommendations)
 	}
 
 	// Add the cabinet to the inventory using domain methods
@@ -98,8 +99,6 @@ func addCabinet(cmd *cobra.Command, args []string) (err error) {
 	var filtered = make(map[uuid.UUID]inventory.Hardware, 0)
 	for _, result := range result.AddedHardware {
 		if result.Hardware.Type == hardwaretypes.Cabinet {
-			log.Debug().Msgf("%s added at %s with parent %s (%s)", result.Hardware.Type, result.Location.String(), hardwaretypes.System, result.Hardware.Parent)
-			log.Info().Str("status", "SUCCESS").Msgf("%s %d was successfully staged to be added to the system", hardwaretypes.Cabinet, recommendations.CabinetOrdinal)
 			filtered[result.Hardware.ID] = result.Hardware
 		}
 	}

--- a/cmd/cabinet/add_cabinet.go
+++ b/cmd/cabinet/add_cabinet.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/cabinet/init.go
+++ b/cmd/cabinet/init.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/cabinet/init.go
+++ b/cmd/cabinet/init.go
@@ -29,22 +29,20 @@ import (
 	"os"
 
 	root "github.com/Cray-HPE/cani/cmd"
+	"github.com/Cray-HPE/cani/internal/domain"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
 var (
-	cabinetNumber          int
-	auto                   bool
-	accept                 bool
-	format                 string
-	sortBy                 string
-	ProviderAddCabinetCmd  = &cobra.Command{}
-	ProviderListCabinetCmd = &cobra.Command{}
+	auto   bool
+	accept bool
+	format string
+	sortBy string
 )
 
-func init() {
-	var err error
+func Init() {
+	log.Trace().Msgf("%+v", "github.com/Cray-HPE/cani/cmd/cabinet.init")
 
 	// Add subcommands to root commands
 	root.AddCmd.AddCommand(AddCabinetCmd)
@@ -53,22 +51,22 @@ func init() {
 
 	// Common 'add cabinet' flags and then merge with provider-specified command
 	AddCabinetCmd.Flags().BoolP("list-supported-types", "L", false, "List supported hardware types.")
-	AddCabinetCmd.Flags().IntVar(&cabinetNumber, "cabinet", 1001, "Cabinet number.")
 	AddCabinetCmd.Flags().BoolVar(&auto, "auto", false, "Automatically recommend and assign required flags.")
 	AddCabinetCmd.MarkFlagsMutuallyExclusive("auto")
 	AddCabinetCmd.Flags().BoolVarP(&accept, "accept", "y", false, "Automatically accept recommended values.")
-	err = root.MergeProviderCommand(AddCabinetCmd)
-	if err != nil {
-		log.Error().Msgf("%+v", err)
-		os.Exit(1)
-	}
 
 	// Common 'list cabinet' flags and then merge with provider-specified command
 	ListCabinetCmd.Flags().StringVarP(&format, "format", "f", "pretty", "Format out output")
 	ListCabinetCmd.Flags().StringVarP(&sortBy, "sort", "s", "location", "Sort by a specific key")
-	err = root.MergeProviderCommand(ListCabinetCmd)
-	if err != nil {
-		log.Error().Msgf("%+v", err)
-		os.Exit(1)
+
+	// Register all provider commands during init()
+	for _, p := range domain.GetProviders() {
+		for _, c := range []*cobra.Command{AddCabinetCmd, ListCabinetCmd} {
+			err := root.RegisterProviderCommand(p, c)
+			if err != nil {
+				log.Error().Msgf("Unable to get command '%s %s' from provider %s ", c.Parent().Name(), c.Name(), p.Slug())
+				os.Exit(1)
+			}
+		}
 	}
 }

--- a/cmd/cabinet/list_cabinet.go
+++ b/cmd/cabinet/list_cabinet.go
@@ -35,10 +35,10 @@ import (
 
 // ListCabinetCmd represents the cabinet list command
 var ListCabinetCmd = &cobra.Command{
-	Use:   "cabinet",
+	Use:   "cabinet PROVIDER",
 	Short: "List cabinets in the inventory.",
 	Long:  `List cabinets in the inventory.`,
-	Args:  cobra.ArbitraryArgs,
+	Args:  cobra.ExactArgs(1),
 	RunE:  listCabinet,
 }
 

--- a/cmd/cabinet/list_cabinet.go
+++ b/cmd/cabinet/list_cabinet.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/cabinet/validate.go
+++ b/cmd/cabinet/validate.go
@@ -72,33 +72,5 @@ func validHardware(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
-	err = validFlagCombos(cmd, args)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// validFlagCombos has additional flag logic to account for overiding required flags with the --auto flag
-func validFlagCombos(cmd *cobra.Command, args []string) error {
-	cabinetSet := cmd.Flags().Changed("cabinet")
-	vlanIdSet := cmd.Flags().Changed("vlan-id")
-	autoSet := cmd.Flags().Changed("auto")
-	// if auto is set, the values are recommended and the required flags are bypassed
-	if autoSet {
-		return nil
-	} else {
-		if !cabinetSet && !vlanIdSet {
-			return errors.New("required flag(s) \"cabinet\", \"vlan-id\" not set")
-		}
-		if cabinetSet && !vlanIdSet {
-			return errors.New("required flag(s) \"vlan-id\" not set")
-		}
-		if !cabinetSet && vlanIdSet {
-			return errors.New("required flag(s) \"cabinet\" not set")
-		}
-	}
-
 	return nil
 }

--- a/cmd/cabinet/validate.go
+++ b/cmd/cabinet/validate.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/cdu/init.go
+++ b/cmd/cdu/init.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/cdu/init.go
+++ b/cmd/cdu/init.go
@@ -27,6 +27,7 @@ package cdu
 
 import (
 	root "github.com/Cray-HPE/cani/cmd"
+	"github.com/rs/zerolog/log"
 )
 
 var (
@@ -34,7 +35,8 @@ var (
 	supportedHw []string
 )
 
-func init() {
+func Init() {
+	log.Trace().Msgf("%+v", "github.com/Cray-HPE/cani/cmd/cdu.init")
 	// Add variants to root commands
 	root.AddCmd.AddCommand(AddCduCmd)
 	root.ListCmd.AddCommand(ListCduCmd)

--- a/cmd/chassis/init.go
+++ b/cmd/chassis/init.go
@@ -27,6 +27,7 @@ package chassis
 
 import (
 	root "github.com/Cray-HPE/cani/cmd"
+	"github.com/rs/zerolog/log"
 )
 
 var (
@@ -36,7 +37,8 @@ var (
 	sortBy      string
 )
 
-func init() {
+func Init() {
+	log.Trace().Msgf("%+v", "github.com/Cray-HPE/cani/cmd/chassis.init")
 	// Add variants to root commands
 	root.AddCmd.AddCommand(AddChassisCmd)
 	root.ListCmd.AddCommand(ListChassisCmd)

--- a/cmd/chassis/init.go
+++ b/cmd/chassis/init.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -35,9 +35,10 @@ var (
 
 // ExportCmd represents the export command
 var ExportCmd = &cobra.Command{
-	Use:   "export",
+	Use:   "export PROVIDER",
 	Short: "Export assets from the inventory.",
 	Long:  `Export assets from the inventory.`,
+	Args:  cobra.ExactArgs(1),
 	RunE:  export,
 }
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -35,9 +35,10 @@ var (
 
 // ImportCmd represents the import command
 var ImportCmd = &cobra.Command{
-	Use:   "import [FILE]",
+	Use:   "import PROVIDER [FILE]",
 	Short: "Import assets into the inventory.",
 	Long:  `Import assets into the inventory.`,
+	Args:  cobra.ExactArgs(1),
 	RunE:  importCmd,
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -40,7 +40,14 @@ import (
 	"golang.org/x/term"
 )
 
-func init() {
+var (
+	ActiveDomain = &domain.Domain{}
+)
+
+// Init() is called during init() in internal/initmanager for multi-provider support
+func Init() {
+	setupLogging()
+	log.Trace().Msgf("%+v", "github.com/Cray-HPE/cani/cmd.init")
 	// Create or load a yaml config and the database
 	cobra.OnInitialize(setupLogging, initConfig)
 
@@ -55,23 +62,43 @@ func init() {
 	AlphaCmd.AddCommand(ValidateCmd)
 
 	AlphaCmd.AddCommand(ExportCmd)
-	err := MergeProviderCommand(ExportCmd)
-	if err != nil {
-		log.Error().Msgf("%+v", err)
-		os.Exit(1)
-	}
-
 	AlphaCmd.AddCommand(ImportCmd)
-	err = MergeProviderCommand(ImportCmd)
-	if err != nil {
-		log.Error().Msgf("%+v", err)
-		os.Exit(1)
-	}
 
 	// Global root command flags
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", cfgFile, "Path to the configuration file")
 	RootCmd.PersistentFlags().BoolVarP(&Debug, "debug", "D", false, "additional debug output")
 	RootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "additional verbose output")
+
+	// Register all provider commands during init()
+	for _, p := range domain.GetProviders() {
+		for _, c := range []*cobra.Command{ImportCmd, ExportCmd} {
+			err := RegisterProviderCommand(p, c)
+			if err != nil {
+				log.Error().Msgf("Unable to get command '%s %s' from provider %s ", c.Parent().Name(), c.Name(), p.Slug())
+				os.Exit(1)
+			}
+		}
+	}
+}
+
+func GetActiveDomain() (err error) {
+	log.Trace().Msgf("%+v", "github.com/Cray-HPE/cani/cmd.InitGetActiveDomain")
+	// Get the active domain, needed for selecting provider commands early during init
+	ActiveDomain, err = Conf.ActiveProvider()
+	if err != nil {
+		return err
+	}
+
+	// once loaded, we can determine early on if there is an active provider
+	// and set the appropriate commands to use
+	if ActiveDomain != nil {
+		if ActiveDomain.Active {
+			log.Debug().Msgf("Active domain provider: %+v", ActiveDomain.Provider)
+		} else {
+			log.Debug().Msgf("No active domain")
+		}
+	}
+	return nil
 }
 
 // setupLogging sets up the global logger
@@ -94,6 +121,10 @@ func setupLogging() {
 		if Verbose {
 			log.Logger = log.With().Caller().Logger()
 		}
+	}
+	if Verbose || os.Getenv("CANI_DEBUG") != "" {
+		zerolog.SetGlobalLevel(zerolog.TraceLevel)
+		log.Logger = log.With().Caller().Logger()
 	}
 }
 
@@ -145,6 +176,7 @@ func setupDomain(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
+	// FIXME: Duplicated by config.ActiveProvider
 	if cmd.Parent().Name() != "init" {
 		// Error if no sessions are active
 		if len(activeProviders) == 0 {
@@ -152,7 +184,7 @@ func setupDomain(cmd *cobra.Command, args []string) (err error) {
 			// so SetupDomain is called manually
 			// The timing of events works out such that simply returning the error
 			// will exit without the message
-			if cmd.Name() == "status" {
+			if cmd.Parent().Name() == "status" {
 				log.Info().Msgf("No active session.")
 				return nil
 			} else {

--- a/cmd/makeprovider.go
+++ b/cmd/makeprovider.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/node/add_node.go
+++ b/cmd/node/add_node.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/node/init.go
+++ b/cmd/node/init.go
@@ -29,10 +29,9 @@ import (
 	"os"
 
 	root "github.com/Cray-HPE/cani/cmd"
-	"github.com/rs/zerolog"
+	"github.com/Cray-HPE/cani/internal/domain"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 )
 
 var (
@@ -49,15 +48,9 @@ var (
 	ProviderUpdateNodeCmd = &cobra.Command{}
 )
 
-func init() {
-	log.Logger = log.Output(
-		zerolog.ConsoleWriter{
-			Out: os.Stderr,
-			// When not in a terminal disable color
-			NoColor: !term.IsTerminal(int(os.Stderr.Fd())),
-		},
-	)
-	var err error
+func Init() {
+	log.Trace().Msgf("%+v", "github.com/Cray-HPE/cani/cmd/node.init")
+
 	// Add variants to root commands
 	root.AddCmd.AddCommand(AddNodeCmd)
 	root.ListCmd.AddCommand(ListNodeCmd)
@@ -66,14 +59,6 @@ func init() {
 
 	// Add a flag to show supported types
 	AddNodeCmd.Flags().BoolP("list-supported-types", "L", false, "List supported hardware types.")
-
-	// Merge CANI's command with the provider-specified command
-	// this allows for CANI's operations to remain consistent, while adding provider config on top
-	err = root.MergeProviderCommand(AddNodeCmd)
-	if err != nil {
-		log.Error().Msgf("%+v", err)
-		os.Exit(1)
-	}
 
 	// Blades have several parents, so we need to add flags for each
 	UpdateNodeCmd.Flags().IntVar(&cabinet, "cabinet", 1001, "Parent cabinet")
@@ -88,16 +73,14 @@ func init() {
 	ListNodeCmd.Flags().StringVarP(&format, "format", "f", "pretty", "Format output")
 	ListNodeCmd.Flags().StringVarP(&sortBy, "sort", "s", "location", "Sort by a specific key")
 
-	// Merge CANI's command with the provider-specified command
-	// this allows for CANI's operations to remain consistent, while adding provider config on top
-	err = root.MergeProviderCommand(UpdateNodeCmd)
-	if err != nil {
-		log.Error().Msgf("%+v", err)
-		os.Exit(1)
-	}
-	err = root.MergeProviderCommand(ListNodeCmd)
-	if err != nil {
-		log.Error().Msgf("%+v", err)
-		os.Exit(1)
+	// Register all provider commands during init()
+	for _, p := range domain.GetProviders() {
+		for _, c := range []*cobra.Command{AddNodeCmd, ListNodeCmd, UpdateNodeCmd} {
+			err := root.RegisterProviderCommand(p, c)
+			if err != nil {
+				log.Error().Msgf("Unable to get command '%s %s' from provider %s ", c.Parent().Name(), c.Name(), p.Slug())
+				os.Exit(1)
+			}
+		}
 	}
 }

--- a/cmd/node/init.go
+++ b/cmd/node/init.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/node/list_node.go
+++ b/cmd/node/list_node.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/node/list_node.go
+++ b/cmd/node/list_node.go
@@ -35,10 +35,10 @@ import (
 
 // ListNodeCmd represents the node list command
 var ListNodeCmd = &cobra.Command{
-	Use:   "node",
+	Use:   "node PROVIDER",
 	Short: "List nodes in the inventory.",
 	Long:  `List nodes in the inventory.`,
-	Args:  cobra.ArbitraryArgs,
+	Args:  cobra.ExactArgs(1),
 	RunE:  listNode,
 }
 

--- a/cmd/node/update_node.go
+++ b/cmd/node/update_node.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/node/update_node.go
+++ b/cmd/node/update_node.go
@@ -38,9 +38,10 @@ import (
 
 // UpdateNodeCmd represents the node update command
 var UpdateNodeCmd = &cobra.Command{
-	Use:   "node",
+	Use:   "node PROVIDER",
 	Short: "Update nodes in the inventory.",
 	Long:  `Update nodes in the inventory.`,
+	Args:  cobra.ExactArgs(1),
 	RunE:  updateNode, // Update a node when this sub-command is called
 }
 

--- a/cmd/pdu/init.go
+++ b/cmd/pdu/init.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/pdu/init.go
+++ b/cmd/pdu/init.go
@@ -27,6 +27,7 @@ package pdu
 
 import (
 	root "github.com/Cray-HPE/cani/cmd"
+	"github.com/rs/zerolog/log"
 )
 
 var (
@@ -34,7 +35,8 @@ var (
 	supportedHw []string
 )
 
-func init() {
+func Init() {
+	log.Trace().Msgf("%+v", "github.com/Cray-HPE/cani/cmd/pdu.init")
 	// Add variants to root commands
 	root.AddCmd.AddCommand(AddPduCmd)
 	root.ListCmd.AddCommand(ListPduCmd)

--- a/cmd/session/init.go
+++ b/cmd/session/init.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/session/init.go
+++ b/cmd/session/init.go
@@ -42,7 +42,6 @@ var (
 	ignoreValidationMessage  = "Ignore validation failures. Use this to allow unconventional configurations."
 	forceInit                bool
 
-	ProviderInitCmds = map[string]*cobra.Command{}
 	// BootstapCmd is used to start a session with a specific provider and allows the provider to define
 	// how the real init command is defined using their custom business logic
 	SessionInitCmd = &cobra.Command{
@@ -55,37 +54,13 @@ var (
 	}
 )
 
-func init() {
+func Init() {
+	log.Trace().Msgf("%+v", "github.com/Cray-HPE/cani/cmd/session.init")
 	// Define the bare minimum needed to determine who the provider for the session will be
 	SessionInitCmd.Flags().BoolVar(&ignoreExternalValidation, "ignore-validation", false, ignoreValidationMessage)
 	SessionInitCmd.Flags().BoolVarP(&forceInit, "force", "f", false, "Overwrite the existing session with a new session")
 	SessionInitCmd.Flags().BoolP("insecure", "k", false, "Allow insecure connections when using HTTPS")
 	SessionInitCmd.Flags().BoolP("use-simulator", "S", false, "Use simulation environtment settings")
-
-	for _, p := range domain.GetProviders() {
-		// Create a provider "init" command
-		providerCmd, err := domain.NewSessionInitCommand(p.Slug())
-		if err != nil {
-			log.Error().Msgf("unable to get provider init command: %v", err)
-			os.Exit(1)
-		}
-
-		// Merge cani's default flags into the provider command
-		err = root.MergeProviderFlags(providerCmd, SessionInitCmd)
-		if err != nil {
-			log.Error().Msgf("unable to get flags from provider: %v", err)
-			os.Exit(1)
-		}
-
-		// set its use to the provider name (to be used as an arg to the "init" command)
-		providerCmd.Use = p.Slug()
-		// run cani's initialization function
-		providerCmd.RunE = initSessionWithProviderCmd
-
-		// add it as a sub-command to "init" so when an arg is passed, it will call the appropriate provider command
-		SessionInitCmd.AddCommand(providerCmd)
-
-	}
 
 	// Add session commands to root commands
 	root.SessionCmd.AddCommand(SessionInitCmd)
@@ -97,4 +72,14 @@ func init() {
 	SessionApplyCmd.Flags().BoolVarP(&commit, "commit", "c", false, "Commit changes to session")
 	SessionApplyCmd.Flags().BoolVarP(&dryrun, "dryrun", "d", false, "Perform dryrun, and do not make changes to the system")
 	SessionApplyCmd.Flags().BoolVar(&ignoreExternalValidation, "ignore-validation", false, ignoreValidationMessage)
+
+	for _, p := range domain.GetProviders() {
+		for _, c := range []*cobra.Command{SessionInitCmd} {
+			err := root.RegisterProviderCommand(p, c)
+			if err != nil {
+				log.Error().Msgf("Unable to get command '%s %s' from provider %s ", c.Parent().Name(), c.Name(), p.Slug())
+				os.Exit(1)
+			}
+		}
+	}
 }

--- a/cmd/session/session_init.go
+++ b/cmd/session/session_init.go
@@ -49,7 +49,7 @@ func initSessionWithProviderCmd(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	root.D.Provider = cmd.Use
+	root.D.Provider = cmd.Name()
 
 	// Set the datastore
 	log.Debug().Msgf("checking provider %s", root.D.Provider)
@@ -57,7 +57,7 @@ func initSessionWithProviderCmd(cmd *cobra.Command, args []string) (err error) {
 	case taxonomy.CSM:
 		root.D.DatastorePath = filepath.Join(config.ConfigDir, taxonomy.DsFileCSM)
 	default:
-		root.D.DatastorePath = filepath.Join(config.ConfigDir, taxonomy.DsFile)
+		err = fmt.Errorf("not a valid provider: %s", root.D.Provider)
 	}
 	// Set the paths needed for starting a session
 	root.D.CustomHardwareTypesDir = config.CustomDir

--- a/cmd/session/session_init.go
+++ b/cmd/session/session_init.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/switch/init.go
+++ b/cmd/switch/init.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/switch/init.go
+++ b/cmd/switch/init.go
@@ -27,6 +27,7 @@ package sw
 
 import (
 	root "github.com/Cray-HPE/cani/cmd"
+	"github.com/rs/zerolog/log"
 )
 
 var (
@@ -34,7 +35,8 @@ var (
 	supportedHw []string
 )
 
-func init() {
+func Init() {
+	log.Trace().Msgf("%+v", "github.com/Cray-HPE/cani/cmd/switch.init")
 	// Add variants to root commands
 	root.AddCmd.AddCommand(AddSwitchCmd)
 	root.ListCmd.AddCommand(ListSwitchCmd)

--- a/cmd/taxonomy/taxonomy.go
+++ b/cmd/taxonomy/taxonomy.go
@@ -28,6 +28,8 @@ package taxonomy
 import (
 	"path/filepath"
 	"sort"
+
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -50,6 +52,7 @@ var (
 	SupportedProviders = []string{CSM}
 )
 
-func init() {
+func Init() {
+	log.Trace().Msgf("%+v", "github.com/Cray-HPE/cani/cmd/taxonomy.init")
 	sort.Strings(SupportedProviders)
 }

--- a/cmd/taxonomy/taxonomy.go
+++ b/cmd/taxonomy/taxonomy.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/internal/domain/blade.go
+++ b/internal/domain/blade.go
@@ -176,7 +176,7 @@ func (d *Domain) AddBlade(cmd *cobra.Command, args []string, cabinetOrdinal, cha
 			// Generate the CANI hardware inventory version of the hardware build out data
 			hardware = inventory.NewHardwareFromBuildOut(hardwareBuildOut, inventory.HardwareStatusStaged)
 
-			log.Debug().Str("path", hardwareBuildOut.LocationPath.String()).Msg("Hardware Build out")
+			log.Trace().Str("path", hardwareBuildOut.LocationPath.String()).Msg("Hardware Build out")
 
 			// TODO need a check to see if all the needed information exists,
 			// Things like role/subrole/nid/alias could be injected at a later time.
@@ -223,7 +223,7 @@ func (d *Domain) AddBlade(cmd *cobra.Command, args []string, cabinetOrdinal, cha
 		}
 		pair.Hardware.LocationPath = hardwareLocation
 		result.AddedHardware = append(result.AddedHardware, pair)
-		log.Debug().Str("path", hardwareLocation.String()).Msg("Datastore")
+		log.Trace().Str("path", hardwareLocation.String()).Msg("Datastore")
 
 	}
 

--- a/internal/domain/blade.go
+++ b/internal/domain/blade.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/internal/domain/cabinet.go
+++ b/internal/domain/cabinet.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/internal/domain/cabinet.go
+++ b/internal/domain/cabinet.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/Cray-HPE/cani/cmd/taxonomy"
 	"github.com/Cray-HPE/cani/internal/inventory"
 	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
@@ -112,17 +113,20 @@ func (d *Domain) AddCabinet(cmd *cobra.Command, args []string, recommendations p
 			)
 		}
 
-		hardwareLocation, err := d.datastore.GetLocation(hardware)
-		if err != nil {
-			panic(err)
+		hlp := HardwareLocationPair{
+			Hardware: hardware,
 		}
 
-		result.AddedHardware = append(result.AddedHardware, HardwareLocationPair{
-			Hardware: hardware,
-			Location: hardwareLocation,
-		})
-		log.Debug().Str("path", hardwareLocation.String()).Msg("Datastore")
+		result.AddedHardware = append(result.AddedHardware, hlp)
 
+		if d.Provider == taxonomy.CSM {
+			hardwareLocation, err := d.datastore.GetLocation(hardware)
+			if err != nil {
+				panic(err)
+			}
+			hlp.Location = hardwareLocation
+			log.Debug().Str("path", hardwareLocation.String()).Msg("Datastore")
+		}
 	}
 
 	// Validate the current state of CANI's inventory data against the provider plugin

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -60,6 +60,7 @@ var SessionInitCmd *cobra.Command
 // New returns a new Domain
 func New(cmd *cobra.Command, args []string) (d *Domain, err error) {
 	d = &Domain{}
+	d.Provider = cmd.Name()
 	return d, nil
 }
 
@@ -73,7 +74,7 @@ func (d *Domain) SetupDomain(cmd *cobra.Command, args []string, configDomains ma
 	for _, sessionDomain := range configDomains {
 		if sessionDomain.Active {
 			d.Active = true
-			log.Debug().Msgf("Setting top level Domain to Active=true")
+			log.Trace().Msgf("Setting top level Domain to Active=true")
 		}
 	}
 
@@ -84,14 +85,13 @@ func (d *Domain) SetupDomain(cmd *cobra.Command, args []string, configDomains ma
 		}
 	}
 
-	log.Debug().Msgf("Setting up datastore interface: %s", d.DatastorePath)
+	log.Trace().Msgf("Setting up datastore interface: %s", d.DatastorePath)
 	// Load the datastore.  Different providers have different storage needs
 	switch d.Provider {
 	case taxonomy.CSM:
 		d.datastore, err = inventory.NewDatastoreJSONCSM(d.DatastorePath, d.LogFilePath, inventory.Provider(d.Provider))
 	default:
-		log.Warn().Msgf("using default provider datastore")
-		d.datastore, err = inventory.NewDatastoreJSON(d.DatastorePath, d.LogFilePath, inventory.Provider(d.Provider))
+		return fmt.Errorf("invalid provider: %s", d.Provider)
 	}
 	if err != nil {
 		return errors.Join(
@@ -100,7 +100,7 @@ func (d *Domain) SetupDomain(cmd *cobra.Command, args []string, configDomains ma
 		)
 	}
 
-	log.Debug().Msgf("loading embedded and custom hardwaretypes: %s", d.CustomHardwareTypesDir)
+	log.Trace().Msgf("loading embedded and custom hardwaretypes: %s", d.CustomHardwareTypesDir)
 	// Load the hardware type library.  Supported hardware is embedded
 	// this also loads any custom-deinfed hardware at the given path
 	d.hardwareTypeLibrary, err = hardwaretypes.NewEmbeddedLibrary(d.CustomHardwareTypesDir)
@@ -111,12 +111,11 @@ func (d *Domain) SetupDomain(cmd *cobra.Command, args []string, configDomains ma
 		)
 	}
 
-	log.Debug().Msgf("getting plugin settings for provider %s", d.Provider)
+	log.Trace().Msgf("getting plugin settings for provider %s", d.Provider)
 	// Instantiate the provider interface object
 	switch d.Provider {
 	case taxonomy.CSM:
 		d.externalInventoryProvider, err = csm.New(cmd, args, d.hardwareTypeLibrary, d.Options)
-
 	default:
 		return fmt.Errorf("unknown external inventory provider provided (%s)", d.Provider)
 	}
@@ -128,7 +127,7 @@ func (d *Domain) SetupDomain(cmd *cobra.Command, args []string, configDomains ma
 		)
 	}
 
-	if cmd.Name() == "init" {
+	if cmd.Parent().Name() == "init" {
 		err := d.externalInventoryProvider.SetProviderOptions(cmd, args)
 		if err != nil {
 			return err
@@ -169,4 +168,8 @@ func GetProviders() []provider.InventoryProvider {
 		&csm.CSM{},
 	}
 	return supportedProviders
+}
+
+func (d *Domain) Slug() string {
+	return d.externalInventoryProvider.Slug()
 }

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/internal/domain/init.go
+++ b/internal/domain/init.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/internal/domain/init.go
+++ b/internal/domain/init.go
@@ -26,48 +26,28 @@
 package domain
 
 import (
-	"github.com/Cray-HPE/cani/cmd/taxonomy"
+	"fmt"
+
 	"github.com/Cray-HPE/cani/internal/provider/csm"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
-func NewSessionInitCommand(p string) (providerCmd *cobra.Command, err error) {
-	switch p {
-	case "csm":
-		providerCmd, err = csm.NewSessionInitCommand()
-	}
-	if err != nil {
-		return providerCmd, err
-	}
-	return providerCmd, nil
+func init() {
+	log.Trace().Msgf("%+v", "github.com/Cray-HPE/cani/internal/domain.init")
 }
 
 // NewProviderCmd returns the appropriate command to the cmd layer
-func NewProviderCmd(bootstrapCmd *cobra.Command) (providerCmd *cobra.Command, err error) {
+func NewProviderCmd(caniCmd *cobra.Command, p string) (providerCmd *cobra.Command, err error) {
 	providerCmd = &cobra.Command{}
-	for _, p := range GetProviders() {
-		switch p.Slug() {
-		case taxonomy.CSM:
-			providerCmd, err = csm.NewProviderCmd(bootstrapCmd)
-		}
-		if err != nil {
-			return providerCmd, nil
-		}
+	switch p {
+	case "csm":
+		providerCmd, err = csm.NewProviderCmd(caniCmd)
+	default:
+		err = fmt.Errorf("no command matched for provider %s", p)
 	}
-
+	if err != nil {
+		return providerCmd, nil
+	}
 	return providerCmd, nil
-}
-
-// UpdateProviderCmd allows the provider to make updates to the command after cani defines its settings
-func UpdateProviderCmd(bootstrapCmd *cobra.Command) (err error) {
-	for _, p := range GetProviders() {
-		switch p.Slug() {
-		case taxonomy.CSM:
-			err = csm.UpdateProviderCmd(bootstrapCmd)
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/internal/domain/print.go
+++ b/internal/domain/print.go
@@ -27,9 +27,20 @@ package domain
 
 import (
 	"github.com/Cray-HPE/cani/internal/inventory"
+	"github.com/Cray-HPE/cani/internal/provider"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
+
+// PrintRecommendations implements the InventoryProvider interface
+// it prints the hardware to stdout based on the command
+func (d *Domain) PrintRecommendations(cmd *cobra.Command, args []string, recommendations provider.HardwareRecommendations) error {
+	err := d.externalInventoryProvider.PrintRecommendations(cmd, args, recommendations)
+	if err != nil {
+		return err
+	}
+	return nil
+}
 
 func (d *Domain) PrintHardware(cmd *cobra.Command, args []string, filtered map[uuid.UUID]inventory.Hardware) error {
 	err := d.externalInventoryProvider.PrintHardware(cmd, args, filtered)

--- a/internal/domain/print.go
+++ b/internal/domain/print.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/internal/inventory/buildout.go
+++ b/internal/inventory/buildout.go
@@ -103,7 +103,7 @@ func GenerateHardwareBuildOut(l *hardwaretypes.Library, opts GenerateHardwareBui
 		current := queue[0]
 		queue = queue[1:]
 
-		log.Debug().Msgf("Visiting: %s", current.DeviceTypeSlug)
+		log.Trace().Msgf("Visiting: %s", current.DeviceTypeSlug)
 		currentDeviceType, ok := l.DeviceTypes[current.DeviceTypeSlug]
 		if !ok {
 			return nil, fmt.Errorf("device type (%v) does not exist", current.DeviceTypeSlug)
@@ -125,9 +125,9 @@ func GenerateHardwareBuildOut(l *hardwaretypes.Library, opts GenerateHardwareBui
 		}
 
 		for _, deviceBay := range currentDeviceType.DeviceBays {
-			log.Debug().Msgf("  Device bay: %s", deviceBay.Name)
+			log.Trace().Msgf("  Device bay: %s", deviceBay.Name)
 			if deviceBay.Default != nil {
-				log.Debug().Msgf("    Default: %s", deviceBay.Default.Slug)
+				log.Trace().Msgf("    Default: %s", deviceBay.Default.Slug)
 
 				queue = append(queue, HardwareBuildOut{
 					// Hardware type is deferred until when it is processed

--- a/internal/inventory/buildout.go
+++ b/internal/inventory/buildout.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/internal/inventory/init.go
+++ b/internal/inventory/init.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/internal/inventory/init.go
+++ b/internal/inventory/init.go
@@ -29,6 +29,7 @@ import (
 	"os"
 
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 var (
@@ -37,7 +38,5 @@ var (
 )
 
 func init() {
-	// Default level for this example is info, unless debug flag is present
-	zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	log.Trace().Msgf("%+v", "github.com/Cray-HPE/cani/internal/inventory.init")
 }

--- a/internal/provider/csm/init.go
+++ b/internal/provider/csm/init.go
@@ -26,8 +26,10 @@
 package csm
 
 import (
+	"errors"
 	"fmt"
 
+	"github.com/Cray-HPE/cani/pkg/utils"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -64,46 +66,50 @@ var (
 	alias   string
 )
 
+func Init() {
+	log.Trace().Msgf("%+v", "github.com/Cray-HPE/cani/internal/provider/csm.init")
+}
+
 // NewProviderCmd returns the appropriate command to the cmd layer
-func NewProviderCmd(bootstrapCmd *cobra.Command) (providerCmd *cobra.Command, err error) {
+func NewProviderCmd(caniCmd *cobra.Command) (providerCmd *cobra.Command, err error) {
 	// first, choose the right command
-	switch bootstrapCmd.Name() {
+	switch caniCmd.Name() {
 	case "init":
-		providerCmd, err = NewSessionInitCommand()
+		providerCmd, err = NewSessionInitCommand(caniCmd)
 	case "cabinet":
-		switch bootstrapCmd.Parent().Name() {
+		switch caniCmd.Parent().Name() {
 		case "add":
-			providerCmd, err = NewAddCabinetCommand()
+			providerCmd, err = NewAddCabinetCommand(caniCmd)
 		case "update":
-			providerCmd, err = NewUpdateCabinetCommand()
+			providerCmd, err = NewUpdateCabinetCommand(caniCmd)
 		case "list":
-			providerCmd, err = NewListCabinetCommand()
+			providerCmd, err = NewListCabinetCommand(caniCmd)
 		}
 	case "blade":
-		switch bootstrapCmd.Parent().Name() {
+		switch caniCmd.Parent().Name() {
 		case "add":
-			providerCmd, err = NewAddBladeCommand()
+			providerCmd, err = NewAddBladeCommand(caniCmd)
 		case "update":
-			providerCmd, err = NewUpdateBladeCommand()
+			providerCmd, err = NewUpdateBladeCommand(caniCmd)
 		case "list":
-			providerCmd, err = NewListBladeCommand()
+			providerCmd, err = NewListBladeCommand(caniCmd)
 		}
 	case "node":
 		// check for add/update variants
-		switch bootstrapCmd.Parent().Name() {
+		switch caniCmd.Parent().Name() {
 		case "add":
-			providerCmd, err = NewAddNodeCommand()
+			providerCmd, err = NewAddNodeCommand(caniCmd)
 		case "update":
-			providerCmd, err = NewUpdateNodeCommand()
+			providerCmd, err = NewUpdateNodeCommand(caniCmd)
 		case "list":
-			providerCmd, err = NewListNodeCommand()
+			providerCmd, err = NewListNodeCommand(caniCmd)
 		}
 	case "export":
-		providerCmd, err = NewExportCommand()
+		providerCmd, err = NewExportCommand(caniCmd)
 	case "import":
-		providerCmd, err = NewImportCommand()
+		providerCmd, err = NewImportCommand(caniCmd)
 	default:
-		log.Debug().Msgf("Command not implemented by provider: %s %s", bootstrapCmd.Parent().Name(), bootstrapCmd.Name())
+		err = fmt.Errorf("Command not implemented by provider: %s %s", caniCmd.Parent().Name(), caniCmd.Name())
 	}
 	if err != nil {
 		return providerCmd, err
@@ -112,55 +118,9 @@ func NewProviderCmd(bootstrapCmd *cobra.Command) (providerCmd *cobra.Command, er
 	return providerCmd, nil
 }
 
-func UpdateProviderCmd(bootstrapCmd *cobra.Command) (err error) {
-	// first, choose the right command
-	switch bootstrapCmd.Name() {
-	case "init":
-		err = UpdateSessionInitCommand(bootstrapCmd)
-	case "cabinet":
-		// check for add/update variants
-		switch bootstrapCmd.Parent().Name() {
-		case "add":
-			err = UpdateAddCabinetCommand(bootstrapCmd)
-		case "update":
-			err = UpdateUpdateCabinetCommand(bootstrapCmd)
-		case "list":
-			err = UpdateListCabinetCommand(bootstrapCmd)
-		}
-	case "blade":
-		// check for add/update variants
-		switch bootstrapCmd.Parent().Name() {
-		case "add":
-			err = UpdateAddBladeCommand(bootstrapCmd)
-		case "update":
-			err = UpdateUpdateBladeCommand(bootstrapCmd)
-		case "list":
-			err = UpdateListBladeCommand(bootstrapCmd)
-		}
-	case "node":
-		// check for add/update variants
-		switch bootstrapCmd.Parent().Name() {
-		case "add":
-			err = UpdateAddNodeCommand(bootstrapCmd)
-		case "update":
-			err = UpdateUpdateNodeCommand(bootstrapCmd)
-		case "list":
-			err = UpdateUpdateNodeCommand(bootstrapCmd)
-		}
-	}
-	if err != nil {
-		return fmt.Errorf("unable to update cmd from provider: %v", err)
-	}
-	return nil
-}
-
-func NewSessionInitCommand() (cmd *cobra.Command, err error) {
-	// cmd represents the session init command
-	cmd = &cobra.Command{}
+func NewSessionInitCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error) {
+	cmd = utils.CloneCommand(caniCmd)
 	cmd.Long = `Query SLS and HSM.  Validate the data against a schema before allowing an import into CANI.`
-	// ValidArgs:    DO NOT CONFIGURE.  This is set by cani's cmd pkg
-	// Args:         DO NOT CONFIGURE.  This is set by cani's cmd pkg
-	// RunE:         DO NOT CONFIGURE.  This is set by cani's cmd pkg
 	// Session init flags
 	cmd.Flags().String("csm-url-sls", "", "(CSM Provider) Base URL for the System Layout Service (SLS)")
 	cmd.Flags().String("csm-url-hsm", "", "(CSM Provider) Base URL for the Hardware State Manager (HSM)")
@@ -192,47 +152,70 @@ func NewSessionInitCommand() (cmd *cobra.Command, err error) {
 	return cmd, nil
 }
 
-func UpdateSessionInitCommand(caniCmd *cobra.Command) error {
-	return nil
-}
-
-func NewAddCabinetCommand() (cmd *cobra.Command, err error) {
-	// cmd represents the session init command
-	cmd = &cobra.Command{}
+func NewAddCabinetCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error) {
+	cmd = utils.CloneCommand(caniCmd)
+	cmd.Flags().Int("cabinet", 1001, "Cabinet number.")
 	cmd.Flags().Int("vlan-id", -1, "Vlan ID for the cabinet.")
+	cmd.MarkFlagsRequiredTogether("cabinet", "vlan-id")
+	cmd.MarkFlagsMutuallyExclusive("auto")
 
+	// make a wrapper script if PreRunE is already set
+	if caniCmd.PreRunE != nil {
+		fn := func(c *cobra.Command, a []string) error {
+			err = caniCmd.PreRunE(c, a)
+			if err != nil {
+				return err
+			}
+
+			err = validCAddCabinetFlags(c, a)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+
+		// assign the wrapper to the PreRunE field
+		cmd.PreRunE = fn
+	}
 	return cmd, nil
 }
 
-// UpdateAddCabinetCommand is run during init and allows the provider to set additional options for CANI flags
-// such as marking certain options mutually exclusive with the auto flag
-func UpdateAddCabinetCommand(caniCmd *cobra.Command) error {
-	caniCmd.MarkFlagsRequiredTogether("cabinet", "vlan-id")
-	caniCmd.MarkFlagsMutuallyExclusive("auto")
+// validCAddCabinetFlags has additional flag logic to account for overiding required flags with the --auto flag
+func validCAddCabinetFlags(cmd *cobra.Command, args []string) error {
+	cabinetSet := cmd.Flags().Changed("cabinet")
+	vlanIdSet := cmd.Flags().Changed("vlan-id")
+	autoSet := cmd.Flags().Changed("auto")
+	// if auto is set, the values are recommended and the required flags are bypassed
+	if autoSet {
+		return nil
+	} else {
+		if !cabinetSet && !vlanIdSet {
+			return errors.New("required flag(s) \"cabinet\", \"vlan-id\" not set")
+		}
+		if cabinetSet && !vlanIdSet {
+			return errors.New("required flag(s) \"vlan-id\" not set")
+		}
+		if !cabinetSet && vlanIdSet {
+			return errors.New("required flag(s) \"cabinet\" not set")
+		}
+	}
+
 	return nil
 }
 
-func NewUpdateCabinetCommand() (cmd *cobra.Command, err error) {
-	cmd = &cobra.Command{}
+func NewUpdateCabinetCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error) {
+	cmd = utils.CloneCommand(caniCmd)
 	return cmd, nil
 }
 
-func UpdateUpdateCabinetCommand(caniCmd *cobra.Command) error {
-	return nil
-}
-
-func NewListCabinetCommand() (cmd *cobra.Command, err error) {
-	cmd = &cobra.Command{}
+func NewListCabinetCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error) {
+	cmd = utils.CloneCommand(caniCmd)
 	return cmd, nil
 }
 
-func UpdateListCabinetCommand(caniCmd *cobra.Command) error {
-	return nil
-}
-
-func NewAddNodeCommand() (cmd *cobra.Command, err error) {
+func NewAddNodeCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error) {
 	// cmd represents for cani alpha add node
-	cmd = &cobra.Command{}
+	cmd = utils.CloneCommand(caniCmd)
 	cmd.Flags().StringVar(&role, "role", "", "Role of the node")
 	cmd.Flags().StringVar(&subrole, "subrole", "", "Subrole of the node")
 	cmd.Flags().IntVar(&nid, "nid", 0, "NID of the node")
@@ -241,13 +224,9 @@ func NewAddNodeCommand() (cmd *cobra.Command, err error) {
 	return cmd, nil
 }
 
-func UpdateAddNodeCommand(caniCmd *cobra.Command) error {
-	return nil
-}
-
-func NewUpdateNodeCommand() (cmd *cobra.Command, err error) {
+func NewUpdateNodeCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error) {
 	// cmd represents for cani alpha update node
-	cmd = &cobra.Command{}
+	cmd = utils.CloneCommand(caniCmd)
 	cmd.Flags().String("role", "", "Role of the node")
 	cmd.Flags().String("subrole", "", "Subrole of the node")
 	cmd.Flags().Int("nid", 0, "NID of the node")
@@ -257,28 +236,14 @@ func NewUpdateNodeCommand() (cmd *cobra.Command, err error) {
 }
 
 // NewListNodeCommand implements the NewListNodeCommand method of the InventoryProvider interface
-func NewListNodeCommand() (cmd *cobra.Command, err error) {
-	// TODO: Implement
-	cmd = &cobra.Command{}
-
+func NewListNodeCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error) {
+	cmd = utils.CloneCommand(caniCmd)
 	return cmd, nil
 }
 
-// UpdateListNodeCommand implements the UpdateListNodeCommand method of the InventoryProvider interface
-func UpdateListNodeCommand(caniCmd *cobra.Command) error {
-	// TODO: Implement
-	return nil
-}
-
-// UpdateUpdateNodeCommand
-func UpdateUpdateNodeCommand(caniCmd *cobra.Command) error {
-
-	return nil
-}
-
-func NewExportCommand() (cmd *cobra.Command, err error) {
+func NewExportCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error) {
 	// cmd represents cani alpha export
-	cmd = &cobra.Command{}
+	cmd = utils.CloneCommand(caniCmd)
 	cmd.Flags().StringVar(
 		&csvHeaders, "headers", "Type,Vlan,Role,SubRole,Status,Nid,Alias,Name,ID,Location", "Comma separated list of fields to get")
 	cmd.Flags().StringVarP(
@@ -291,42 +256,23 @@ func NewExportCommand() (cmd *cobra.Command, err error) {
 	return cmd, nil
 }
 
-func NewImportCommand() (cmd *cobra.Command, err error) {
-	// cmd represents cani alpha import
-	cmd = &cobra.Command{}
-
+func NewImportCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error) {
+	cmd = utils.CloneCommand(caniCmd)
 	return cmd, nil
 }
 
-func NewAddBladeCommand() (cmd *cobra.Command, err error) {
-	// cmd represents cani alpha import
-	cmd = &cobra.Command{}
-
+func NewAddBladeCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error) {
+	cmd = utils.CloneCommand(caniCmd)
+	cmd.MarkFlagsMutuallyExclusive("auto")
 	return cmd, nil
 }
 
-func UpdateAddBladeCommand(caniCmd *cobra.Command) error {
-	return nil
-}
-
-func NewUpdateBladeCommand() (cmd *cobra.Command, err error) {
-	// cmd represents cani alpha import
-	cmd = &cobra.Command{}
-
+func NewUpdateBladeCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error) {
+	cmd = utils.CloneCommand(caniCmd)
 	return cmd, nil
 }
 
-func UpdateUpdateBladeCommand(caniCmd *cobra.Command) error {
-	return nil
-}
-
-func NewListBladeCommand() (cmd *cobra.Command, err error) {
-	// cmd represents cani alpha import
-	cmd = &cobra.Command{}
-
+func NewListBladeCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error) {
+	cmd = utils.CloneCommand(caniCmd)
 	return cmd, nil
-}
-
-func UpdateListBladeCommand(caniCmd *cobra.Command) error {
-	return nil
 }

--- a/internal/provider/csm/init.go
+++ b/internal/provider/csm/init.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/internal/provider/csm/print.go
+++ b/internal/provider/csm/print.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/internal/provider/csm/recommend.go
+++ b/internal/provider/csm/recommend.go
@@ -40,7 +40,7 @@ import (
 
 func (csm *CSM) RecommendHardware(inv inventory.Inventory, cmd *cobra.Command, args []string, auto bool) (recommended provider.HardwareRecommendations, err error) {
 	var deviceTypeSlug string
-	if cmd.Parent().Name() == "add" {
+	if cmd.Parent().Parent().Name() == "add" {
 		deviceTypeSlug = args[0]
 	}
 	// loop through the existing inventory to check for vlans

--- a/internal/provider/csm/recommend.go
+++ b/internal/provider/csm/recommend.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/internal/provider/csm/validation.go
+++ b/internal/provider/csm/validation.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/internal/provider/csm/validation.go
+++ b/internal/provider/csm/validation.go
@@ -120,7 +120,7 @@ func (csm *CSM) validateInternalNode(allHardware map[uuid.UUID]inventory.Hardwar
 		if cHardware.Type != hardwaretypes.Node {
 			continue
 		}
-		log.Debug().Msgf("Validating %s: %v", cHardware.ID, cHardware)
+		log.Trace().Msgf("Validating %s: %v", cHardware.ID, cHardware)
 
 		metadata, err := DecodeProviderMetadata(cHardware)
 		if err != nil {
@@ -260,7 +260,7 @@ func (csm *CSM) validateInternalCabinet(allHardware map[uuid.UUID]inventory.Hard
 			continue
 		}
 
-		log.Debug().Msgf("Validating %s: %v", cHardware.ID, cHardware)
+		log.Trace().Msgf("Validating %s: %v", cHardware.ID, cHardware)
 
 		metadata, err := DecodeProviderMetadata(cHardware)
 		if err != nil {

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -34,6 +34,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func Init() {
+	log.Info().Msgf("%+v", "github.com/Cray-HPE/cani/internal/provider.init")
+}
+
 var ErrDataValidationFailure = fmt.Errorf("data validation failure")
 
 // TODO Need to think about how internal data structures should be supplied to the Inventory Provider
@@ -90,6 +94,7 @@ type InventoryProvider interface {
 
 	// Print
 	PrintHardware(cmd *cobra.Command, args []string, filtered map[uuid.UUID]inventory.Hardware) error
+	PrintRecommendations(cmd *cobra.Command, args []string, recommendations HardwareRecommendations) error
 
 	// Provider's name
 	Slug() string
@@ -132,12 +137,17 @@ func (r HardwareRecommendations) Print() {
 // ProviderCommands is an interface for the commands that are specific to a provider
 // this isn't usually used directly, but is used to generate the commands with 'makeprovdier'
 type ProviderCommands interface {
-	NewSessionInitCommand() (cmd *cobra.Command, err error)
-	NewAddCabinetCommand() (cmd *cobra.Command, err error)
-	UpdateAddCabinetCommand(caniCmd *cobra.Command) error
-	NewAddNodeCommand() (cmd *cobra.Command, err error)
-	NewUpdateNodeCommand() (cmd *cobra.Command, err error)
-	UpdateUpdateNodeCommand(caniCmd *cobra.Command) error
-	NewExportCommand() (cmd *cobra.Command, err error)
-	NewImportCommand() (cmd *cobra.Command, err error)
+	NewProviderCmd(caniCmd *cobra.Command) (providerCmd *cobra.Command, err error)
+	NewSessionInitCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error)
+	NewAddCabinetCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error)
+	NewUpdateCabinetCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error)
+	NewListCabinetCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error)
+	NewAddBladeCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error)
+	NewUpdateBladeCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error)
+	NewListBladeCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error)
+	NewAddNodeCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error)
+	NewUpdateNodeCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error)
+	NewListNodeCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error)
+	NewExportCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error)
+	NewImportCommand(caniCmd *cobra.Command) (cmd *cobra.Command, err error)
 }

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/main.go
+++ b/main.go
@@ -25,18 +25,39 @@ package main
 
 import (
 	"github.com/Cray-HPE/cani/cmd"
-	_ "github.com/Cray-HPE/cani/cmd/blade"
-	_ "github.com/Cray-HPE/cani/cmd/cabinet"
-	_ "github.com/Cray-HPE/cani/cmd/cdu"
-	_ "github.com/Cray-HPE/cani/cmd/chassis"
-	_ "github.com/Cray-HPE/cani/cmd/config"
-	_ "github.com/Cray-HPE/cani/cmd/node"
-	_ "github.com/Cray-HPE/cani/cmd/pdu"
-	_ "github.com/Cray-HPE/cani/cmd/session"
-	_ "github.com/Cray-HPE/cani/cmd/switch"
-	_ "github.com/Cray-HPE/cani/cmd/taxonomy"
+	"github.com/Cray-HPE/cani/cmd/blade"
+	"github.com/Cray-HPE/cani/cmd/cabinet"
+	"github.com/Cray-HPE/cani/cmd/cdu"
+	"github.com/Cray-HPE/cani/cmd/chassis"
+	"github.com/Cray-HPE/cani/cmd/node"
+	"github.com/Cray-HPE/cani/cmd/pdu"
+	"github.com/Cray-HPE/cani/cmd/session"
+	sw "github.com/Cray-HPE/cani/cmd/switch"
+	_ "github.com/Cray-HPE/cani/internal/provider"
+	_ "github.com/Cray-HPE/cani/pkg/hardwaretypes"
+	"github.com/rs/zerolog/log"
 )
 
+// Run all package init functions in a specific order
+// this is mainly due to all cobra commands needing flags and other settings
+// to be set during init
+func init() {
+	// configure logging first for friendly console-logs
+	log.Trace().Msgf("%+v", "github.com/Cray-HPE/cani/main.init")
+	// load the config and generate root commands
+	cmd.Init()
+	// initialize cobra commands for each package
+	session.Init()
+	cabinet.Init()
+	cdu.Init()
+	chassis.Init()
+	blade.Init()
+	node.Init()
+	pdu.Init()
+	sw.Init()
+}
+
 func main() {
+	log.Trace().Msgf("%+v", "github.com/Cray-HPE/cani/main.main")
 	cmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -1,4 +1,29 @@
 /*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+/*
 MIT License
 
 (C) Copyright 2022 Hewlett Packard Enterprise Development LP

--- a/pkg/hardwaretypes/library.go
+++ b/pkg/hardwaretypes/library.go
@@ -88,24 +88,24 @@ func NewEmbeddedLibrary(customDir string) (*Library, error) {
 
 	// Load the embedded hardware type embedded files
 	basePath := "hardware-types"
-	log.Debug().Msgf("Looking for built-in hardware-types")
+	log.Trace().Msgf("Looking for built-in hardware-types")
 	defaultFiles, err := defaultHardwareTypesFS.ReadDir(basePath)
 	if err != nil {
 		return nil, err
 	}
 
-	log.Debug().Msgf("Looking for custom hardware-types in %s", customDir)
+	log.Trace().Msgf("Looking for custom hardware-types in %s", customDir)
 	// append user-defined hardware-type files to the default embedded ones
 	customFiles, err := os.ReadDir(customDir)
 	if err != nil {
 		// it is ok if no custom files exist
-		log.Debug().Msgf("No custom hardware-types defined in %s", customDir)
+		log.Trace().Msgf("No custom hardware-types defined in %s", customDir)
 	}
 
 	// Parse hardware type files
 	for _, file := range defaultFiles {
 		filePath := path.Join(basePath, file.Name())
-		log.Debug().Msgf("Parsing built-in hardware-type: %s", filePath)
+		log.Trace().Msgf("Parsing built-in hardware-type: %s", filePath)
 
 		fileRaw, err := defaultHardwareTypesFS.ReadFile(filePath)
 		if err != nil {
@@ -118,7 +118,7 @@ func NewEmbeddedLibrary(customDir string) (*Library, error) {
 		}
 
 		for _, deviceType := range fileDeviceTypes {
-			log.Debug().Msgf("Registering device type: %s", deviceType.Slug)
+			log.Trace().Msgf("Registering device type: %s", deviceType.Slug)
 			if err := library.RegisterDeviceType(deviceType); err != nil {
 				return nil, errors.Join(
 					fmt.Errorf("failed to register device type '%s'", deviceType.Slug),
@@ -132,7 +132,7 @@ func NewEmbeddedLibrary(customDir string) (*Library, error) {
 	if len(customFiles) != 0 {
 		for _, file := range customFiles {
 			filePath := filepath.Join(customDir, file.Name())
-			log.Debug().Msgf("Parsing custom hardware-type: %v", filePath)
+			log.Trace().Msgf("Parsing custom hardware-type: %v", filePath)
 
 			fileRaw, err := os.ReadFile(filePath)
 			if err != nil {
@@ -145,7 +145,7 @@ func NewEmbeddedLibrary(customDir string) (*Library, error) {
 			}
 
 			for _, deviceType := range fileDeviceTypes {
-				log.Debug().Msgf("Registering device type: %s", deviceType.Slug)
+				log.Trace().Msgf("Registering device type: %s", deviceType.Slug)
 				if err := library.RegisterDeviceType(deviceType); err != nil {
 					return nil, errors.Join(
 						fmt.Errorf("failed to register device type '%s'", deviceType.Slug),

--- a/pkg/hardwaretypes/library.go
+++ b/pkg/hardwaretypes/library.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -23,25 +23,32 @@
  *  OTHER DEALINGS IN THE SOFTWARE.
  *
  */
-package node
+package utils
 
-import (
-	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
-// AddNodeCmd represents the node add command
-var AddNodeCmd = &cobra.Command{
-	Use:     "node PROVIDER",
-	Short:   "Add nodes to the inventory.",
-	Long:    `Add nodes to the inventory.`,
-	Args:    cobra.ExactArgs(1),
-	PreRunE: validHardware, // Hardware can only be valid if defined in the hardware library
-	RunE:    addNode,       // Add a node when this sub-command is called
-}
+func CloneCommand(cmd *cobra.Command) (newCmd *cobra.Command) {
+	if cmd == nil {
+		return nil
+	}
 
-// addNode adds a node to the inventory
-func addNode(cmd *cobra.Command, args []string) error {
-	log.Info().Msgf("Not yet implemented")
-	return nil
+	// copy certain fields, omitting some currently not in use by cani
+	newCmd = &cobra.Command{
+		Use:       cmd.Use,
+		Short:     cmd.Short,
+		Long:      cmd.Long,
+		RunE:      cmd.RunE,
+		PreRunE:   cmd.PreRunE,
+		ValidArgs: cmd.ValidArgs,
+	}
+
+	// copy flags to the new command
+	newCmd.Flags().AddFlagSet(cmd.Flags())
+
+	// copy any subcommands recursively to the new command
+	for _, subCmd := range cmd.Commands() {
+		newCmd.AddCommand(CloneCommand(subCmd))
+	}
+
+	return newCmd
 }

--- a/spec/edge/add_cabinet_ex2000_subnet_limit_spec.sh
+++ b/spec/edge/add_cabinet_ex2000_subnet_limit_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/edge/add_cabinet_ex2000_subnet_limit_spec.sh
+++ b/spec/edge/add_cabinet_ex2000_subnet_limit_spec.sh
@@ -61,12 +61,13 @@ Parameters:dynamic
 End
 
 It 'Add ex2000 cabinet to reach subnet limit'
-  When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2000 --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add cabinet csm hpe-ex2000 --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include "Suggested cabinet number: $1"
   The line 3 of stderr should include "Suggested VLAN ID: $2"
-  The line 4 of stderr should include "Cabinet $1 was successfully staged to be added to the system"
+  The line 4 of stderr should include "Cabinet was successfully staged to be added to the system"
+  The line 6 of stderr should include "Cabinet Number: $1"
 End
 
 End

--- a/spec/edge/add_cabinet_ex2000_vlan_limit_spec.sh
+++ b/spec/edge/add_cabinet_ex2000_vlan_limit_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/edge/add_cabinet_ex2000_vlan_limit_spec.sh
+++ b/spec/edge/add_cabinet_ex2000_vlan_limit_spec.sh
@@ -61,12 +61,13 @@ Parameters:dynamic
 End
 
 It 'Add ex2000 cabinet to reach the vlan limit'
-  When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2000 --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add cabinet csm hpe-ex2000 --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include "Suggested cabinet number: $1"
   The line 3 of stderr should include "Suggested VLAN ID: $2"
-  The line 4 of stderr should include "Cabinet $1 was successfully staged to be added to the system"
+  The line 4 of stderr should include "Cabinet was successfully staged to be added to the system"
+  The line 6 of stderr should include "Cabinet Number: $1"
 End
 
 End
@@ -74,7 +75,7 @@ End
 Describe 'EDGE:'
 
 It 'Add ex2000 cabinet to exceed the vlan limit'
-  When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2000 --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add cabinet csm hpe-ex2000 --auto --accept
   The status should equal 1
   The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include "Suggested cabinet number: 10000"

--- a/spec/functional/cani_add_blade_spec.sh
+++ b/spec/functional/cani_add_blade_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/functional/cani_add_blade_spec.sh
+++ b/spec/functional/cani_add_blade_spec.sh
@@ -39,21 +39,21 @@ End
 # Adding a blade withot a hardware type should fail
 # it should list the available hardware types
 It "--config $CANI_CONF"
-  When call bin/cani alpha add blade --config "$CANI_CONF"
+  When call bin/cani alpha add blade csm --config "$CANI_CONF"
   The status should equal 1
   The line 1 of stderr should include 'Error: No hardware type provided: Choose from: [hpe-crayex-ex235a-compute-blade hpe-crayex-ex235n-compute-blade hpe-crayex-ex254n-compute-blade hpe-crayex-ex420-compute-blade hpe-crayex-ex425-compute-blade hpe-crayex-ex4252-compute-blade]'
 End
 
 # Adding a blade with an invalid hardware type should fail
 It "--config $CANI_CONF fake-hardware-type"
-  When call bin/cani alpha add blade --config "$CANI_CONF" fake-hardware-type
+  When call bin/cani alpha add blade csm --config "$CANI_CONF" fake-hardware-type
   The status should equal 1
   The line 1 of stderr should equal 'Error: Invalid hardware type: fake-hardware-type'
 End
 
 # Listing hardware types should show available hardware types
 It "--config $CANI_CONF -L"
-  When call bin/cani alpha add blade --config "$CANI_CONF" -L
+  When call bin/cani alpha add blade csm --config "$CANI_CONF" -L
   The status should equal 0
   The line 1 of stdout should equal "hpe-crayex-ex235a-compute-blade"
   The line 2 of stdout should equal "hpe-crayex-ex235n-compute-blade"
@@ -73,7 +73,7 @@ Parameters:dynamic
   mkdir -p "$CANI_DIR"
   cp "$SHELLSPEC_HELPERDIR/testdata/fixtures/cani/configs/canitest_valid_active.yml" "$CANI_CONF"
   cp "$FIXTURES"/cani/configs/canitestdb_valid_system_only.json "$CANI_DS"
-  for blade in $(bin/cani --config "$SHELLSPEC_HELPERDIR/testdata/fixtures/cani/configs/canitest_valid_active.yml" alpha add blade -L); do
+  for blade in $(bin/cani --config "$SHELLSPEC_HELPERDIR/testdata/fixtures/cani/configs/canitest_valid_active.yml" alpha add blade csm -L); do
     %data "$blade"
   done
 End
@@ -82,7 +82,7 @@ End
 It "--config $CANI_CONF $1 --cabinet 3000 --chassis 1 --blade 0 (no session)"
   BeforeCall use_inactive_session # session is inactive
   BeforeCall use_valid_datastore_system_only # deploy a valid datastore
-  When call bin/cani alpha add blade --config "$CANI_CONF" "$1" --cabinet 3000 --chassis 1 --blade 0
+  When call bin/cani alpha add blade csm --config "$CANI_CONF" "$1" --cabinet 3000 --chassis 1 --blade 0
   The status should equal 1
   The line 1 of stderr should include "No active session."
 End
@@ -93,7 +93,7 @@ End
 It "--config $CANI_CONF $1 --cabinet 3000 --chassis 1 --blade 0 (active session, no datastore)"
   BeforeCall use_active_session # session is active
   BeforeCall remove_datastore # datastore does not exist
-  When call bin/cani alpha add blade --config "$CANI_CONF" "$1" --cabinet 3000 --chassis 1 --blade 0
+  When call bin/cani alpha add blade csm --config "$CANI_CONF" "$1" --cabinet 3000 --chassis 1 --blade 0
   The status should equal 1
   The line 1 of stderr should include "Datastore '$CANI_DS' does not exist.  Run 'session init' to begin"
 End
@@ -107,7 +107,7 @@ End
 It "--config $CANI_CONF $1 (active session, datastore, no flags)"
   BeforeCall use_active_session # session is active
   BeforeCall use_valid_datastore_system_only # deploy a valid datastore
-  When call bin/cani alpha add blade --config "$CANI_CONF" "$1"
+  When call bin/cani alpha add blade csm --config "$CANI_CONF" "$1"
   The status should equal 1
   The line 1 of stderr should equal 'Error: required flag(s) "blade", "cabinet", "chassis" not set'
 End
@@ -120,7 +120,7 @@ End
 It "--config $CANI_CONF $1 --cabinet 3000 (active session, datastore, some flags)"
   BeforeCall use_active_session # session is active
   BeforeCall use_valid_datastore_system_only # deploy a valid datastore
-  When call bin/cani alpha add blade --config "$CANI_CONF" "$1" --cabinet 3000
+  When call bin/cani alpha add blade csm --config "$CANI_CONF" "$1" --cabinet 3000
   The status should equal 1
   The line 1 of stderr should equal 'Error: required flag(s) "blade", "chassis" not set'
 End
@@ -132,7 +132,7 @@ End
 It "--config $CANI_CONF $1 --cabinet 3000 --chassis 0 (active session, datastore, some flags)"
   BeforeCall use_active_session # session is active
   BeforeCall use_valid_datastore_system_only # deploy a valid datastore
-  When call bin/cani alpha add blade --config "$CANI_CONF" "$1" --cabinet 3000 --chassis 0
+  When call bin/cani alpha add blade csm --config "$CANI_CONF" "$1" --cabinet 3000 --chassis 0
   The status should equal 1
   The line 1 of stderr should equal 'Error: required flag(s) "blade", not set'
 End
@@ -147,7 +147,7 @@ End
 It "--config $CANI_CONF $1 --cabinet 3000 --chassis 1 --blade 0 (active session, datastore, all flags, no cabinet)"
   BeforeCall use_active_session # session is active
   BeforeCall use_valid_datastore_system_only # deploy a valid datastore
-  When call bin/cani alpha add blade --config "$CANI_CONF" "$1" --cabinet 3000 --chassis 1 --blade 0
+  When call bin/cani alpha add blade csm --config "$CANI_CONF" "$1" --cabinet 3000 --chassis 1 --blade 0
   The status should equal 1
   The line 1 of stderr should equal 'Error: unable to find Cabinet at System:0->Cabinet:3000'
   The line 2 of stderr should equal "try 'list cabinet'"
@@ -164,7 +164,7 @@ End
 It "--config $CANI_CONF $1 --cabinet 3000 --chassis 1234 --blade 0 (active session, datastore, all flags, no chassis)"
   BeforeCall use_active_session # session is active
   BeforeCall use_valid_datastore_one_hpe_eia_cabinet_cabinet # deploy a valid datastore with one cabinet
-  When call bin/cani alpha add blade --config "$CANI_CONF" "$1" --cabinet 3000 --chassis 1234 --blade 0
+  When call bin/cani alpha add blade csm --config "$CANI_CONF" "$1" --cabinet 3000 --chassis 1234 --blade 0
   The status should equal 1
   The line 1 of stderr should equal 'Error: in order to add a NodeBlade, a Chassis is needed'
   The line 2 of stderr should equal "unable to find Chassis at System:0->Cabinet:3000->Chassis:1234"
@@ -181,7 +181,7 @@ End
 It "--config $CANI_CONF $1 --cabinet 3000 --chassis 0 --blade 0 (happy path)"
   BeforeCall use_active_session # session is active
   BeforeCall use_valid_datastore_one_hpe_eia_cabinet_cabinet # deploy a valid datastore with one cabinet and one blade
-  When call bin/cani alpha add blade --config "$CANI_CONF" "$1" --cabinet 3000 --chassis 0 --blade 0
+  When call bin/cani alpha add blade csm --config "$CANI_CONF" "$1" --cabinet 3000 --chassis 0 --blade 0
   The status should equal 0
   The line 2 of stderr should include "NodeBlade was successfully staged to be added to the system"
   The line 3 of stderr should include "UUID: "
@@ -202,7 +202,7 @@ End
 It "--config $CANI_CONF $1 --cabinet 3000 --chassis 0 --blade 0 (active session, datastore, all flags, existing hardware)"
   BeforeCall use_active_session # session is active
   BeforeCall use_valid_datastore_one_hpe_eia_cabinet_cabinet_one_blade
-  When call bin/cani alpha add blade --config "$CANI_CONF" "$1" --cabinet 3000 --chassis 0 --blade 0
+  When call bin/cani alpha add blade csm --config "$CANI_CONF" "$1" --cabinet 3000 --chassis 0 --blade 0
   The status should equal 1
   The line 1 of stderr should equal "Error: NodeBlade number 0 is already in use"
   The line 2 of stderr should equal "please re-run the command with an available NodeBlade number"
@@ -211,7 +211,7 @@ End
 
 # blade suggestions should fail if there are no empty slots
 It "--config $CANI_CONF $1 --auto --accept (no slots available)"
-  When call bin/cani alpha add blade --config "$CANI_CONF" "$1" --auto --accept
+  When call bin/cani alpha add blade csm --config "$CANI_CONF" "$1" --auto --accept
   The status should equal 1
   The line 1 of stderr should equal 'Error: no available NodeBlade slots'
 End
@@ -224,9 +224,9 @@ Describe 'cani add blade'
 
 Parameters:dynamic
   # For each cabinet type
-  for bld in $(bin/cani --config "$CANI_CONF" alpha add blade -L); do
+  for bld in $(bin/cani --config "$CANI_CONF" alpha add blade csm -L); do
     # add each blade type
-    for cab in $(bin/cani --config "$CANI_CONF" alpha add cabinet -L); do
+    for cab in $(bin/cani --config "$CANI_CONF" alpha add cabinet csm -L); do
       cab_ds_fixture=$(echo "$cab" | awk '{print $1}' | tr '-' '_')
       # ordinals vary depending upon the cabinet
       if [ "$cab_ds_fixture" = "hpe_eia_cabinet" ]; then continue;fi
@@ -249,7 +249,7 @@ It "--config $CANI_CONF $2 --auto --accept (into $1)"
   BeforeCall use_active_session # session is active
   BeforeCall use_valid_datastore_one_"$1"_cabinet # deploy a valid datastore with one cabinet
   BeforeCall use_custom_hw_type
-  When call bin/cani alpha add blade --config "$CANI_CONF" "$2" --auto --accept
+  When call bin/cani alpha add blade csm --config "$CANI_CONF" "$2" --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest cabinet, chassis, and blade for this NodeBlade'
   The line 2 of stderr should include "Suggested Cabinet number: $3"

--- a/spec/functional/cani_add_cabinet_spec.sh
+++ b/spec/functional/cani_add_cabinet_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/functional/cani_add_cabinet_spec.sh
+++ b/spec/functional/cani_add_cabinet_spec.sh
@@ -39,21 +39,21 @@ End
 # it should list the available hardware types
 It "--config $CANI_CONF"
   BeforeCall use_active_session # session is active
-  When call bin/cani alpha add cabinet --config "$CANI_CONF"
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF"
   The status should equal 1
   The line 1 of stderr should include 'Error: No hardware type provided: Choose from: hpe-eia-cabinet", "hpe-ex2000", "hpe-ex2500-1-liquid-cooled-chassis", "hpe-ex2500-2-liquid-cooled-chassis", "hpe-ex2500-3-liquid-cooled-chassis", "hpe-ex3000", "hpe-ex4000'
 End
 
 # Adding a cabinet with an invalid hardware type should fail
 It "--config $CANI_CONF fake-hardware-type"
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" fake-hardware-type
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" fake-hardware-type
   The status should equal 1
   The line 1 of stderr should equal 'Error: Invalid hardware type: fake-hardware-type'
 End
 
 # Listing hardware types should show available hardware types
 It "--config $CANI_CONF -L"
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" -L
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" -L
   The status should equal 0
   The line 1 of stdout should equal "hpe-eia-cabinet"
   The line 2 of stdout should equal "hpe-ex2000"
@@ -68,7 +68,7 @@ End
 It "--config $CANI_CONF hpe-ex2000"
   BeforeCall use_inactive_session # session is inactive
   BeforeCall use_valid_datastore_system_only # deploy a valid datastore
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" hpe-ex2000
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" hpe-ex2000
   The status should equal 1
   The line 1 of stderr should include "No active session."
 End
@@ -79,7 +79,7 @@ End
 It "--config $CANI_CONF hpe-ex2000"
   BeforeCall use_active_session # session is active
   BeforeCall remove_datastore # datastore does not exist
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" hpe-ex2000
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" hpe-ex2000
   The status should equal 1
   The line 1 of stderr should include "Datastore '$CANI_DS' does not exist.  Run 'session init' to begin"
 End
@@ -92,7 +92,7 @@ End
 It "--config $CANI_CONF hpe-ex2000"
   BeforeCall use_active_session # session is active
   BeforeCall use_valid_datastore_system_only # deploy a valid datastore
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" hpe-ex2000
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" hpe-ex2000
   The status should equal 1
   The line 1 of stderr should equal 'Error: required flag(s) "cabinet", "vlan-id" not set'
 End
@@ -105,7 +105,7 @@ End
 It "--config $CANI_CONF hpe-ex2000 --cabinet 1234"
   BeforeCall use_active_session # session is active
   BeforeCall use_valid_datastore_system_only # deploy a valid datastore
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" hpe-ex2000 --cabinet 1234
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" hpe-ex2000 --cabinet 1234
   The status should equal 1
   The line 1 of stderr should equal 'Error: required flag(s) "vlan-id" not set'
 End
@@ -118,7 +118,7 @@ End
 It "--config $CANI_CONF hpe-ex2000 --vlan-id 1234"
   BeforeCall use_active_session # session is active
   BeforeCall use_valid_datastore_system_only # deploy a valid datastore
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" hpe-ex2000 --vlan-id 1234
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" hpe-ex2000 --vlan-id 1234
   The status should equal 1
   The line 1 of stderr should equal 'Error: required flag(s) "cabinet" not set'
 End
@@ -132,7 +132,7 @@ End
 It "--config $CANI_CONF hpe-ex2000 --cabinet 1234 --vlan-id 12345678"
   BeforeCall use_active_session # session is active
   BeforeCall use_valid_datastore_system_only # deploy a valid datastore
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" hpe-ex2000 --cabinet 1234 --vlan-id 12345678
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" hpe-ex2000 --cabinet 1234 --vlan-id 12345678
   The status should equal 1
   The line 1 of stderr should include "Error: VLAN exceeds the provider's maximum range (3999).  Please choose a valid VLAN"
 End
@@ -146,7 +146,7 @@ End
 It "--config $CANI_CONF hpe-ex2000 --cabinet 1234 --vlan-id 1234"
   BeforeCall use_active_session # session is active
   BeforeCall use_valid_datastore_system_only # deploy a valid datastore
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" hpe-ex2000 --cabinet 1234 --vlan-id 1234
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" hpe-ex2000 --cabinet 1234 --vlan-id 1234
   The status should equal 0
   The line 1 of stderr should include "Cabinet 1234 was successfully staged to be added to the system"
   The line 2 of stderr should include "UUID: "
@@ -162,7 +162,7 @@ End
 #   - the cabinet already exists
 It "--config $CANI_CONF hpe-ex2000 --cabinet 1234 --vlan-id 1234"
   BeforeCall use_active_session # session is active
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" hpe-ex2000 --cabinet 1234 --vlan-id 1234
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" hpe-ex2000 --cabinet 1234 --vlan-id 1234
   The status should equal 1
   The line 1 of stderr should equal "Error: Cabinet number 1234 is already in use"
   The line 2 of stderr should equal "please re-run the command with an available Cabinet number"
@@ -177,7 +177,7 @@ End
 #   - the vlan already exists 
 It "--config $CANI_CONF hpe-ex2000 --cabinet 4321 --vlan-id 1234"
   BeforeCall use_active_session # session is active
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" hpe-ex2000 --cabinet 4321 --vlan-id 1234
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" hpe-ex2000 --cabinet 4321 --vlan-id 1234
   The status should equal 1
   The line 1 of stderr should include "Inventory data validation errors encountered"
   The stderr should include "    - Specified HMN Vlan (1234) is not unique, shared by: "
@@ -191,7 +191,7 @@ End
 #   - vlan-id flag is not set 
 It "--config $CANI_CONF hpe-ex2000 --auto --vlan-id 1234"
   BeforeCall use_active_session # session is active
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" hpe-ex2000 --auto --vlan-id 1234
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" hpe-ex2000 --auto --vlan-id 1234
   The status should equal 1
   The line 1 of stderr should equal "Error: if any flags in the group [cabinet vlan-id] are set they must all be set; missing [cabinet]"
 End
@@ -204,7 +204,7 @@ End
 #   - vlan-id flag is set 
 It "--config $CANI_CONF hpe-ex2000 --auto --cabinet 4321"
   BeforeCall use_active_session # session is active
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" hpe-ex2000 --auto --cabinet 4321 
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" hpe-ex2000 --auto --cabinet 4321 
   The status should equal 1
   The line 1 of stderr should equal "Error: if any flags in the group [cabinet vlan-id] are set they must all be set; missing [vlan-id]"
 End
@@ -216,7 +216,7 @@ End
 #   - accept flag is set
 It "--config $CANI_CONF hpe-ex2000 --auto --accept"
   BeforeCall use_active_session # session is active
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" hpe-ex2000 --auto --accept 
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" hpe-ex2000 --auto --accept 
   The status should equal 0
   The line 1 of stderr should include " Querying inventory to suggest Cabinet"
   The line 2 of stderr should include " Suggested cabinet number: "
@@ -251,7 +251,7 @@ Parameters
 End
 
 It "--config $CANI_CONF $1 --auto --accept"
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" "$1" --auto --accept
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" "$1" --auto --accept
   The line 1 of stderr should include " Querying inventory to suggest Cabinet"
   The line 2 of stderr should include " Suggested cabinet number: "
   The line 3 of stderr should include " Suggested VLAN ID: "
@@ -300,7 +300,7 @@ End
 
 # setup a bunch of cabinets with incongruent cabinet numbers
 It "--config $CANI_CONF $1 --cabinet $2 --vlan-id $3 --accept"
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" "$1" --cabinet "$2" --vlan-id "$3" --accept
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" "$1" --cabinet "$2" --vlan-id "$3" --accept
   The line 1 of stderr should include " was successfully staged to be added to the system"
   The line 2 of stderr should include " UUID: "
   The line 3 of stderr should include " Cabinet Number: $2"
@@ -343,7 +343,7 @@ End
 
 # setup a bunch of cabinets with incongruent cabinet numbers
 It "--config $CANI_CONF $1 --auto --accept"
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" "$1" --auto --accept
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" "$1" --auto --accept
   The line 1 of stderr should include " Querying inventory to suggest Cabinet"
   The line 2 of stderr should include " Suggested cabinet number: "
   The line 3 of stderr should include " Suggested VLAN ID: "
@@ -392,7 +392,7 @@ End
 
 # setup a bunch of cabinets with incongruent cabinet numbers
 It "--config $CANI_CONF $1 --cabinet $2 --vlan-id $3 --accept"
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" "$1" --cabinet "$2" --vlan-id "$3" --accept
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" "$1" --cabinet "$2" --vlan-id "$3" --accept
   The line 1 of stderr should include " was successfully staged to be added to the system"
   The line 2 of stderr should include " UUID: "
   The line 3 of stderr should include " Cabinet Number: $2"
@@ -435,7 +435,7 @@ End
 
 # setup a bunch of cabinets with incongruent cabinet numbers
 It "--config $CANI_CONF $1 --auto --accept"
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" "$1" --auto --accept
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" "$1" --auto --accept
   The line 1 of stderr should include " Querying inventory to suggest Cabinet"
   The line 2 of stderr should include " Suggested cabinet number: "
   The line 3 of stderr should include " Suggested VLAN ID: "
@@ -449,7 +449,7 @@ It 'validates a custom hardware type appears in the list of supported hardware'
   BeforeCall use_active_session
   BeforeCall use_custom_hw_type
   BeforeCall use_valid_datastore_system_only
-  When call bin/cani --config "$CANI_CONF" alpha add cabinet -L
+  When call bin/cani --config "$CANI_CONF" alpha add cabinet csm -L
   The status should equal 0
   The line 8 of stdout should equal 'my-custom-cabinet'
 End
@@ -458,7 +458,7 @@ It "--config $CANI_CONF my-custom-cabinet --auto --accept"
   BeforeCall use_active_session
   BeforeCall use_custom_hw_type
   BeforeCall use_valid_datastore_system_only
-  When call bin/cani alpha add cabinet --config "$CANI_CONF" my-custom-cabinet --auto --accept
+  When call bin/cani alpha add cabinet csm --config "$CANI_CONF" my-custom-cabinet --auto --accept
   The status should equal 0
   The line 1 of stderr should include " Querying inventory to suggest Cabinet"
   The line 2 of stderr should include " Suggested cabinet number: 4321"
@@ -471,7 +471,7 @@ End
 
 It 'validate cabinet is added'
   BeforeCall use_custom_hw_type
-  When call bin/cani alpha list cabinet --config "$CANI_CONF"
+  When call bin/cani alpha list cabinet csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of stdout should include "staged"
   The line 2 of stdout should include "my-custom-cabinet"

--- a/spec/functional/cani_add_cabinet_spec.sh
+++ b/spec/functional/cani_add_cabinet_spec.sh
@@ -148,7 +148,7 @@ It "--config $CANI_CONF hpe-ex2000 --cabinet 1234 --vlan-id 1234"
   BeforeCall use_valid_datastore_system_only # deploy a valid datastore
   When call bin/cani alpha add cabinet csm --config "$CANI_CONF" hpe-ex2000 --cabinet 1234 --vlan-id 1234
   The status should equal 0
-  The line 1 of stderr should include "Cabinet 1234 was successfully staged to be added to the system"
+  The line 1 of stderr should include "Cabinet was successfully staged to be added to the system"
   The line 2 of stderr should include "UUID: "
   The line 3 of stderr should include "Cabinet Number: 1234"
   The line 4 of stderr should include "VLAN ID: 1234"

--- a/spec/functional/cani_session_spec.sh
+++ b/spec/functional/cani_session_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/functional/cani_session_spec.sh
+++ b/spec/functional/cani_session_spec.sh
@@ -207,7 +207,7 @@ Describe 'session migration:'
     BeforeCall use_single_provider_session
     BeforeCall use_valid_datastore_system_only
     BeforeCall "load_sls.sh testdata/fixtures/sls/valid_hardware_networks.json" # simulator is running, load a specific SLS config
-    When call bin/cani --config "$CANI_CONF" alpha add cabinet hpe-ex4000 --auto --accept
+    When call bin/cani --config "$CANI_CONF" alpha add cabinet csm hpe-ex4000 --auto --accept
     The status should equal 0
     The stderr should include 'Translating single-provider config to multi-provider'
 

--- a/spec/functional/cani_update_node_spec.sh
+++ b/spec/functional/cani_update_node_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/functional/cani_update_node_spec.sh
+++ b/spec/functional/cani_update_node_spec.sh
@@ -29,26 +29,26 @@ Describe 'cani update node'
 It "validate blade exists"
   BeforeCall use_active_session # session is active
   BeforeCall use_valid_datastore_one_ex2000_one_blade # deploy a valid datastore with one cabinet
-  When call bin/cani alpha list blade --config "$CANI_CONF"
+  When call bin/cani alpha list blade csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of stdout should include '1d87f035-6c89-4670-a86d-61bb09f1928c'
 End
 
 It "validate nodes exist"
-  When call bin/cani alpha list node --config "$CANI_CONF"
+  When call bin/cani alpha list node csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of stdout should include 'd28c3201-9dfa-4788-852f-86054cd99232'
   The line 3 of stdout should include '8ab879e0-f269-4c88-aaf4-4a345985d41e'
 End
 
-It "update node --config $CANI_CONF --uuid 8ab879e0-f269-4c88-aaf4-4a345985d41e --role Application --subrole Worker --nid 1234"
-  When call bin/cani alpha update node --config "$CANI_CONF" --uuid 8ab879e0-f269-4c88-aaf4-4a345985d41e --role Application --subrole Worker --nid 1234
+It "update node csm --config $CANI_CONF --uuid 8ab879e0-f269-4c88-aaf4-4a345985d41e --role Application --subrole Worker --nid 1234"
+  When call bin/cani alpha update node csm --config "$CANI_CONF" --uuid 8ab879e0-f269-4c88-aaf4-4a345985d41e --role Application --subrole Worker --nid 1234
   The status should equal 0
   The line 1 of stderr should include 'Updated node'
 End
 
 It "validate node is updated"
-  When call bin/cani alpha list node --config "$CANI_CONF"
+  When call bin/cani alpha list node csm --config "$CANI_CONF"
   The status should equal 0
   The line 3 of stdout should include '8ab879e0-f269-4c88-aaf4-4a345985d41e'
   The line 3 of stdout should include 'Application'

--- a/spec/integration/add_blade_ex235a_spec.sh
+++ b/spec/integration/add_blade_ex235a_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/integration/add_blade_ex235a_spec.sh
+++ b/spec/integration/add_blade_ex235a_spec.sh
@@ -52,14 +52,14 @@ It 'start a session'
 End
 
 It 'verify empty blade slot'
-  When call bin/cani alpha list blade --config "$CANI_CONF"
+  When call bin/cani alpha list blade csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of output should include 'empty		System:0->Cabinet:9000->Chassis:1->NodeBlade:0'
   The line 3 of output should include 'empty		System:0->Cabinet:9000->Chassis:1->NodeBlade:1'
 End
 
 It 'verify empty nodes'
-  When call bin/cani alpha list node --config "$CANI_CONF"
+  When call bin/cani alpha list node csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of output should include 'empty		Compute		[nid001000]	1000	System:0->Cabinet:9000->Chassis:1->NodeBlade:0->NodeCard:0->Node:0'
   The line 3 of output should include 'empty		Compute		[nid001001]	1001	System:0->Cabinet:9000->Chassis:1->NodeBlade:0->NodeCard:0->Node:1'
@@ -72,7 +72,7 @@ It 'verify empty nodes'
 End
 
 It 'add ex235a blade'
-  When call bin/cani alpha --config "$CANI_CONF" add blade hpe-crayex-ex235a-compute-blade --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add blade csm hpe-crayex-ex235a-compute-blade --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest cabinet, chassis, and blade for this NodeBlade'
   The line 2 of stderr should include 'Suggested Cabinet number: 9000'
@@ -86,7 +86,7 @@ It 'add ex235a blade'
 End
 
 It 'verify staged blade slot'
-  When call bin/cani alpha list blade --config "$CANI_CONF"
+  When call bin/cani alpha list blade csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of stdout should include 'staged'
   The line 2 of stdout should include 'hpe-crayex-ex235a-compute-blade'
@@ -96,7 +96,7 @@ It 'verify staged blade slot'
 End
 
 It 'verify staged nodes'
-  When call bin/cani alpha list node --config "$CANI_CONF"
+  When call bin/cani alpha list node csm --config "$CANI_CONF"
   The status should equal 0
   # two nodes should be added
   The line 2 of stdout should include 'staged'

--- a/spec/integration/add_blade_ex235n_spec.sh
+++ b/spec/integration/add_blade_ex235n_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/integration/add_blade_ex235n_spec.sh
+++ b/spec/integration/add_blade_ex235n_spec.sh
@@ -50,14 +50,14 @@ It 'start a session'
 End
 
 It 'verify empty blade slot'
-  When call bin/cani alpha list blade --config "$CANI_CONF"
+  When call bin/cani alpha list blade csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of output should include 'empty		System:0->Cabinet:9000->Chassis:1->NodeBlade:0'
   The line 3 of output should include 'empty		System:0->Cabinet:9000->Chassis:1->NodeBlade:1'
 End
 
 It 'verify empty nodes'
-  When call bin/cani alpha list node --config "$CANI_CONF"
+  When call bin/cani alpha list node csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of output should include 'empty		Compute		[nid001000]	1000	System:0->Cabinet:9000->Chassis:1->NodeBlade:0->NodeCard:0->Node:0'
   The line 3 of output should include 'empty		Compute		[nid001001]	1001	System:0->Cabinet:9000->Chassis:1->NodeBlade:0->NodeCard:0->Node:1'
@@ -70,7 +70,7 @@ It 'verify empty nodes'
 End
 
 It 'add ex235n blade'
-  When call bin/cani alpha --config "$CANI_CONF" add blade hpe-crayex-ex235n-compute-blade --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add blade csm hpe-crayex-ex235n-compute-blade --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest cabinet, chassis, and blade for this NodeBlade'
   The line 2 of stderr should include 'Suggested Cabinet number: 9000'
@@ -84,7 +84,7 @@ It 'add ex235n blade'
 End
 
 It 'verify staged blade slot'
-  When call bin/cani alpha list blade --config "$CANI_CONF"
+  When call bin/cani alpha list blade csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of stdout should include 'staged'
   The line 2 of stdout should include 'hpe-crayex-ex235n-compute-blade'
@@ -94,7 +94,7 @@ It 'verify staged blade slot'
 End
 
 It 'verify staged nodes'
-  When call bin/cani alpha list node --config "$CANI_CONF"
+  When call bin/cani alpha list node csm --config "$CANI_CONF"
   The status should equal 0
   # two nodes should be added
   The line 2 of stdout should include 'staged'

--- a/spec/integration/add_blade_ex254n_spec.sh
+++ b/spec/integration/add_blade_ex254n_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/integration/add_blade_ex254n_spec.sh
+++ b/spec/integration/add_blade_ex254n_spec.sh
@@ -50,14 +50,14 @@ It 'start a session'
 End
 
 It 'verify empty blade slot'
-  When call bin/cani alpha list blade --config "$CANI_CONF"
+  When call bin/cani alpha list blade csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of output should include 'empty		System:0->Cabinet:9000->Chassis:1->NodeBlade:0'
   The line 3 of output should include 'empty		System:0->Cabinet:9000->Chassis:1->NodeBlade:1'
 End
 
 It 'verify empty nodes'
-  When call bin/cani alpha list node --config "$CANI_CONF"
+  When call bin/cani alpha list node csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of output should include 'empty		Compute		[nid001000]	1000	System:0->Cabinet:9000->Chassis:1->NodeBlade:0->NodeCard:0->Node:0'
   The line 3 of output should include 'empty		Compute		[nid001001]	1001	System:0->Cabinet:9000->Chassis:1->NodeBlade:0->NodeCard:0->Node:1'
@@ -70,7 +70,7 @@ It 'verify empty nodes'
 End
 
 It 'add ex254n blade'
-  When call bin/cani alpha --config "$CANI_CONF" add blade hpe-crayex-ex254n-compute-blade --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add blade csm hpe-crayex-ex254n-compute-blade --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest cabinet, chassis, and blade for this NodeBlade'
   The line 2 of stderr should include 'Suggested Cabinet number: 9000'
@@ -84,7 +84,7 @@ It 'add ex254n blade'
 End
 
 It 'verify staged blade slot'
-  When call bin/cani alpha list blade --config "$CANI_CONF"
+  When call bin/cani alpha list blade csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of stdout should include 'staged'
   The line 2 of stdout should include 'hpe-crayex-ex254n-compute-blade'
@@ -94,7 +94,7 @@ It 'verify staged blade slot'
 End
 
 It 'verify staged nodes'
-  When call bin/cani alpha list node --config "$CANI_CONF"
+  When call bin/cani alpha list node csm --config "$CANI_CONF"
   The status should equal 0
   # two nodes should be added
   The line 2 of stdout should include 'staged'

--- a/spec/integration/add_blade_ex420_spec.sh
+++ b/spec/integration/add_blade_ex420_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/integration/add_blade_ex420_spec.sh
+++ b/spec/integration/add_blade_ex420_spec.sh
@@ -50,14 +50,14 @@ It 'start a session'
 End
 
 It 'verify empty blade slot'
-  When call bin/cani alpha list blade --config "$CANI_CONF"
+  When call bin/cani alpha list blade csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of output should include 'empty		System:0->Cabinet:9000->Chassis:1->NodeBlade:0'
   The line 3 of output should include 'empty		System:0->Cabinet:9000->Chassis:1->NodeBlade:1'
 End
 
 It 'verify empty nodes'
-  When call bin/cani alpha list node --config "$CANI_CONF"
+  When call bin/cani alpha list node csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of output should include 'empty		Compute		[nid001000]	1000	System:0->Cabinet:9000->Chassis:1->NodeBlade:0->NodeCard:0->Node:0'
   The line 3 of output should include 'empty		Compute		[nid001001]	1001	System:0->Cabinet:9000->Chassis:1->NodeBlade:0->NodeCard:0->Node:1'
@@ -70,7 +70,7 @@ It 'verify empty nodes'
 End
 
 It 'add ex420 blade'
-  When call bin/cani alpha --config "$CANI_CONF" add blade hpe-crayex-ex420-compute-blade --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add blade csm hpe-crayex-ex420-compute-blade --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest cabinet, chassis, and blade for this NodeBlade'
   The line 2 of stderr should include 'Suggested Cabinet number: 9000'
@@ -84,7 +84,7 @@ It 'add ex420 blade'
 End
 
 It 'verify staged blade slot'
-  When call bin/cani alpha list blade --config "$CANI_CONF"
+  When call bin/cani alpha list blade csm --config "$CANI_CONF"
   The status should equal 0
   # four nodes should be added
   The line 2 of stdout should include 'staged'
@@ -93,7 +93,7 @@ It 'verify staged blade slot'
 End
 
 It 'verify staged nodes'
-  When call bin/cani alpha list node --config "$CANI_CONF"
+  When call bin/cani alpha list node csm --config "$CANI_CONF"
   The status should equal 0
   # four nodes should be added
   The line 2 of stdout should include 'staged'

--- a/spec/integration/add_blade_ex4252_spec.sh
+++ b/spec/integration/add_blade_ex4252_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/integration/add_blade_ex4252_spec.sh
+++ b/spec/integration/add_blade_ex4252_spec.sh
@@ -50,14 +50,14 @@ It 'start a session'
 End
 
 It 'verify empty blade slot'
-  When call bin/cani alpha list blade --config "$CANI_CONF"
+  When call bin/cani alpha list blade csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of output should include 'empty		System:0->Cabinet:9000->Chassis:1->NodeBlade:0'
   The line 3 of output should include 'empty		System:0->Cabinet:9000->Chassis:1->NodeBlade:1'
 End
 
 It 'verify empty nodes'
-  When call bin/cani alpha list node --config "$CANI_CONF"
+  When call bin/cani alpha list node csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of output should include 'empty		Compute		[nid001000]	1000	System:0->Cabinet:9000->Chassis:1->NodeBlade:0->NodeCard:0->Node:0'
   The line 3 of output should include 'empty		Compute		[nid001001]	1001	System:0->Cabinet:9000->Chassis:1->NodeBlade:0->NodeCard:0->Node:1'
@@ -70,7 +70,7 @@ It 'verify empty nodes'
 End
 
 It 'add ex4252 blade'
-  When call bin/cani alpha --config "$CANI_CONF" add blade hpe-crayex-ex4252-compute-blade --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add blade csm hpe-crayex-ex4252-compute-blade --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest cabinet, chassis, and blade for this NodeBlade'
   The line 2 of stderr should include 'Suggested Cabinet number: 9000'
@@ -84,7 +84,7 @@ It 'add ex4252 blade'
 End
 
 It 'verify staged blade slot'
-  When call bin/cani alpha list blade --config "$CANI_CONF"
+  When call bin/cani alpha list blade csm --config "$CANI_CONF"
   The status should equal 0
   # four nodes should be added
   The line 2 of stdout should include 'staged'
@@ -93,7 +93,7 @@ It 'verify staged blade slot'
 End
 
 It 'verify staged nodes'
-  When call bin/cani alpha list node --config "$CANI_CONF"
+  When call bin/cani alpha list node csm --config "$CANI_CONF"
   The status should equal 0
   # four nodes should be added
   The line 2 of stdout should include 'staged'
@@ -159,7 +159,7 @@ It 'commit and reconcile with missing require data'
 End
 
 It 'add system role information for node 2'
-  When call bin/cani alpha --config "$CANI_CONF" update node --cabinet 9000 --chassis 1 --blade 0 --nodecard 0 --node 2 \
+  When call bin/cani alpha --config "$CANI_CONF" update node csm --cabinet 9000 --chassis 1 --blade 0 --nodecard 0 --node 2 \
     --role Compute \
     --alias nid002000 \
     --nid 2000
@@ -168,7 +168,7 @@ It 'add system role information for node 2'
 End
 
 It 'add system role information for node 3'
-  When call bin/cani alpha --config "$CANI_CONF" update node --cabinet 9000 --chassis 1 --blade 0 --nodecard 0 --node 3 \
+  When call bin/cani alpha --config "$CANI_CONF" update node csm --cabinet 9000 --chassis 1 --blade 0 --nodecard 0 --node 3 \
     --role Compute \
     --alias nid002001 \
     --nid 2001
@@ -177,7 +177,7 @@ It 'add system role information for node 3'
 End
 
 It 'verify staged nodes'
-  When call bin/cani alpha list node --config "$CANI_CONF"
+  When call bin/cani alpha list node csm --config "$CANI_CONF"
   The status should equal 0
   # four nodes should be added
   The line 2 of stdout should include 'staged'

--- a/spec/integration/add_blade_ex425_spec.sh
+++ b/spec/integration/add_blade_ex425_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/integration/add_blade_ex425_spec.sh
+++ b/spec/integration/add_blade_ex425_spec.sh
@@ -50,14 +50,14 @@ It 'start a session'
 End
 
 It 'verify empty blade slot'
-  When call bin/cani alpha list blade --config "$CANI_CONF"
+  When call bin/cani alpha list blade csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of output should include 'empty		System:0->Cabinet:9000->Chassis:1->NodeBlade:0'
   The line 3 of output should include 'empty		System:0->Cabinet:9000->Chassis:1->NodeBlade:1'
 End
 
 It 'verify empty nodes'
-  When call bin/cani alpha list node --config "$CANI_CONF"
+  When call bin/cani alpha list node csm --config "$CANI_CONF"
   The status should equal 0
   The line 2 of output should include 'empty		Compute		[nid001000]	1000	System:0->Cabinet:9000->Chassis:1->NodeBlade:0->NodeCard:0->Node:0'
   The line 3 of output should include 'empty		Compute		[nid001001]	1001	System:0->Cabinet:9000->Chassis:1->NodeBlade:0->NodeCard:0->Node:1'
@@ -70,7 +70,7 @@ It 'verify empty nodes'
 End
 
 It 'add ex425 blade'
-  When call bin/cani alpha --config "$CANI_CONF" add blade hpe-crayex-ex425-compute-blade --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add blade csm hpe-crayex-ex425-compute-blade --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest cabinet, chassis, and blade for this NodeBlade'
   The line 2 of stderr should include 'Suggested Cabinet number: 9000'
@@ -84,7 +84,7 @@ It 'add ex425 blade'
 End
 
 It 'verify staged blade slot'
-  When call bin/cani alpha list blade --config "$CANI_CONF"
+  When call bin/cani alpha list blade csm --config "$CANI_CONF"
   The status should equal 0
   # four nodes should be added
   The line 2 of stdout should include 'staged'
@@ -93,7 +93,7 @@ It 'verify staged blade slot'
 End
 
 It 'verify staged nodes'
-  When call bin/cani alpha list node --config "$CANI_CONF"
+  When call bin/cani alpha list node csm --config "$CANI_CONF"
   The status should equal 0
   # four nodes should be added
   The line 2 of stdout should include 'staged'

--- a/spec/integration/add_cabinet_ex2000_dryrun_spec.sh
+++ b/spec/integration/add_cabinet_ex2000_dryrun_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/integration/add_cabinet_ex2000_dryrun_spec.sh
+++ b/spec/integration/add_cabinet_ex2000_dryrun_spec.sh
@@ -50,12 +50,13 @@ It 'start a session'
 End
 
 It 'add ex2000 cabinet'
-  When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2000 --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add cabinet csm hpe-ex2000 --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 9001'
   The line 3 of stderr should include 'Suggested VLAN ID: 3001'
-  The line 4 of stderr should include 'Cabinet 9001 was successfully staged to be added to the system'
+  The line 4 of stderr should include 'Cabinet was successfully staged to be added to the system'
+  The line 6 of stderr should include "Cabinet Number: 9001"
 End
 
 It 'commit and reconcile'

--- a/spec/integration/add_cabinet_ex2000_spec.sh
+++ b/spec/integration/add_cabinet_ex2000_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/integration/add_cabinet_ex2000_spec.sh
+++ b/spec/integration/add_cabinet_ex2000_spec.sh
@@ -55,7 +55,7 @@ It 'add ex2000 cabinet'
   The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 9001'
   The line 3 of stderr should include 'Suggested VLAN ID: 3001'
-  The line 4 of stderr should include 'Cabinet 9001 was successfully staged to be added to the system'
+  The line 4 of stderr should include 'Cabinet was successfully staged to be added to the system'
 End
 
 It 'commit and reconcile'

--- a/spec/integration/add_cabinet_ex2000_spec.sh
+++ b/spec/integration/add_cabinet_ex2000_spec.sh
@@ -50,7 +50,7 @@ It 'start a session'
 End
 
 It 'add ex2000 cabinet'
-  When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2000 --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add cabinet csm hpe-ex2000 --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 9001'

--- a/spec/integration/add_cabinet_ex2500_spec.sh
+++ b/spec/integration/add_cabinet_ex2500_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/integration/add_cabinet_ex2500_spec.sh
+++ b/spec/integration/add_cabinet_ex2500_spec.sh
@@ -50,30 +50,33 @@ It 'start a session'
 End
 
 It 'add hpe-ex2500-1-liquid-cooled-chassis cabinet'
-  When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2500-1-liquid-cooled-chassis --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add cabinet csm hpe-ex2500-1-liquid-cooled-chassis --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 8000'
   The line 3 of stderr should include 'Suggested VLAN ID: 3001'
-  The line 4 of stderr should include 'Cabinet 8000 was successfully staged to be added to the system'
+  The line 4 of stderr should include 'Cabinet was successfully staged to be added to the system'
+  The line 6 of stderr should include "Cabinet Number: 8000"
 End
 
 It 'add hpe-ex2500-2-liquid-cooled-chassis cabinet'
-  When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2500-2-liquid-cooled-chassis --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add cabinet csm hpe-ex2500-2-liquid-cooled-chassis --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 8001'
   The line 3 of stderr should include 'Suggested VLAN ID: 3002'
-  The line 4 of stderr should include 'Cabinet 8001 was successfully staged to be added to the system'
+  The line 4 of stderr should include 'Cabinet was successfully staged to be added to the system'
+  The line 6 of stderr should include "Cabinet Number: 8001"
 End
 
 It 'add hpe-ex2500-3-liquid-cooled-chassis cabinet'
-  When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2500-3-liquid-cooled-chassis --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add cabinet csm hpe-ex2500-3-liquid-cooled-chassis --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 8002'
   The line 3 of stderr should include 'Suggested VLAN ID: 3003'
-  The line 4 of stderr should include 'Cabinet 8002 was successfully staged to be added to the system'
+  The line 4 of stderr should include 'Cabinet was successfully staged to be added to the system'
+The line 6 of stderr should include "Cabinet Number: 8002"
 End
 
 It 'commit and reconcile'

--- a/spec/integration/add_cabinet_ex3000_spec.sh
+++ b/spec/integration/add_cabinet_ex3000_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/integration/add_cabinet_ex3000_spec.sh
+++ b/spec/integration/add_cabinet_ex3000_spec.sh
@@ -50,12 +50,13 @@ It 'start a session'
 End
 
 It 'add ex3000 cabinet'
-  When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex3000 --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add cabinet csm hpe-ex3000 --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 1000'
   The line 3 of stderr should include 'Suggested VLAN ID: 3001'
-  The line 4 of stderr should include 'Cabinet 1000 was successfully staged to be added to the system'
+  The line 4 of stderr should include 'Cabinet was successfully staged to be added to the system'
+  The line 6 of stderr should include "Cabinet Number: 1000"
 End
 
 It 'commit and reconcile'

--- a/spec/integration/add_cabinet_ex4000_spec.sh
+++ b/spec/integration/add_cabinet_ex4000_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/integration/add_cabinet_ex4000_spec.sh
+++ b/spec/integration/add_cabinet_ex4000_spec.sh
@@ -50,12 +50,13 @@ It 'start a session'
 End
 
 It 'add ex4000 cabinet'
-  When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex4000 --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add cabinet csm hpe-ex4000 --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 1000'
   The line 3 of stderr should include 'Suggested VLAN ID: 3001'
-  The line 4 of stderr should include 'Cabinet 1000 was successfully staged to be added to the system'
+  The line 4 of stderr should include 'Cabinet was successfully staged to be added to the system'
+  The line 6 of stderr should include "Cabinet Number: 1000"
 End
 
 It 'commit and reconcile'

--- a/spec/integration/export_import_spec.sh
+++ b/spec/integration/export_import_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/integration/export_import_spec.sh
+++ b/spec/integration/export_import_spec.sh
@@ -34,16 +34,17 @@ It 'init session'
 End
 
 It 'add cabinet hpe-ex2500-1-liquid-cooled-chassis'
-  When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2500-1-liquid-cooled-chassis --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add cabinet csm hpe-ex2500-1-liquid-cooled-chassis --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 8000'
   The line 3 of stderr should include 'Suggested VLAN ID: 3001'
-  The line 4 of stderr should include 'Cabinet 8000 was successfully staged to be added to the system'
+  The line 4 of stderr should include 'Cabinet was successfully staged to be added to the system'
+  The line 6 of stderr should include "Cabinet Number: 8000"
 End
 
-It 'add blade --config "$CANI_CONF" hpe-crayex-ex235n-compute-blade --cabinet 8000 --chassis 0 --blade 0'
-  When call bin/cani alpha add blade --config "$CANI_CONF" hpe-crayex-ex235n-compute-blade --cabinet 8000 --chassis 0 --blade 0
+It 'add blade csm --config "$CANI_CONF" hpe-crayex-ex235n-compute-blade --cabinet 8000 --chassis 0 --blade 0'
+  When call bin/cani alpha add blade csm --config "$CANI_CONF" hpe-crayex-ex235n-compute-blade --cabinet 8000 --chassis 0 --blade 0
   The status should equal 0
   The line 2 of stderr should include "NodeBlade was successfully staged to be added to the system"
   The line 3 of stderr should include "UUID: "
@@ -54,7 +55,7 @@ End
 
 
 It 'export'
-  When call bin/cani alpha --config "$CANI_CONF" export
+  When call bin/cani alpha --config "$CANI_CONF" export csm
   The status should equal 0
   The line 1 of stdout should include "ID"
   The output should include "Cabinet,3001"
@@ -62,32 +63,32 @@ It 'export'
 End
 
 It 'export id,role,subrole'
-  When call bin/cani alpha --config "$CANI_CONF" export --headers id,role,subrole
+  When call bin/cani alpha --config "$CANI_CONF" export csm --headers id,role,subrole
   The status should equal 0
   The line 1 of stdout should equal "ID,Role,SubRole"
 End
 
 It 'import vlan change'
   When call sh -c '\
-      bin/cani alpha --config "$CANI_CONF" export | \
+      bin/cani alpha --config "$CANI_CONF" export csm | \
       sed s/Cabinet,3001/Cabinet,4000/ | \
-      bin/cani alpha --config "$CANI_CONF" import'
+      bin/cani alpha --config "$CANI_CONF" import csm'
   The status should equal 0
   The line 1 of stderr should include 'Success: Wrote 1 records of a total'
 End
 
 It 'import vlan changes again'
   When call sh -c '\
-      bin/cani alpha --config "$CANI_CONF" export > canitest_export.csv; \
+      bin/cani alpha --config "$CANI_CONF" export csm > canitest_export.csv; \
       cat canitest_export.csv | \
         sed s/Cabinet,3001/Cabinet,4000/ | \
-        bin/cani alpha --config "$CANI_CONF" import'
+        bin/cani alpha --config "$CANI_CONF" import csm'
   The status should equal 0
   The line 1 of stderr should include 'Success: Wrote 0 records of a total'
 End
 
 It 'export after cabinets import'
-  When call bin/cani alpha --config "$CANI_CONF" export --type cabinet --headers id,Type,vlan
+  When call bin/cani alpha --config "$CANI_CONF" export csm --type cabinet --headers id,Type,vlan
   The status should equal 0
   The line 1 of stdout should equal "ID,Type,Vlan"
   The output should include "Cabinet,4000"
@@ -97,17 +98,17 @@ End
 
 It 'import changes to nodes that do not have metadata'
   When call sh -c '\
-      bin/cani alpha --config "$CANI_CONF" export --headers type,vlan,role,subrole,nid,alias,name,id > canitest_export.csv; \
+      bin/cani alpha --config "$CANI_CONF" export csm --headers type,vlan,role,subrole,nid,alias,name,id > canitest_export.csv; \
       cat canitest_export.csv | \
         sed "0,/Node,,,,,,,/s//Node,,Compute,,10000,nid10000,,/" | \
         sed "0,/Node,,,,,,,/s//Node,,Compute,,20000,nid20000,,/" | \
-        bin/cani alpha --config "$CANI_CONF" import'
+        bin/cani alpha --config "$CANI_CONF" import csm'
   The status should equal 0
   The line 1 of stderr should include 'Success: Wrote 2 records of a total'
 End
 
 It 'export after node import'
-  When call bin/cani alpha --config "$CANI_CONF" export --type NODE --headers 'id,Type,role,nid,alias'
+  When call bin/cani alpha --config "$CANI_CONF" export csm --type NODE --headers 'id,Type,role,nid,alias'
   The status should equal 0
   The line 1 of stdout should equal "ID,Type,Role,Nid,Alias"
   The output should include "Node,Compute,10000,nid10000"
@@ -117,16 +118,16 @@ End
 
 It 'import changes to nodes that already have metadata'
   When call sh -c '\
-      bin/cani alpha --config "$CANI_CONF" export --headers type,vlan,role,subrole,nid,alias,name,id > canitest_export.csv;
+      bin/cani alpha --config "$CANI_CONF" export csm --headers type,vlan,role,subrole,nid,alias,name,id > canitest_export.csv;
       cat canitest_export.csv | \
         sed "0,/Node,,Compute,,10000,nid10000,,/s//Node,,Compute,Worker,10000,nid10000,,/" | \
-        bin/cani alpha --config "$CANI_CONF" import'
+        bin/cani alpha --config "$CANI_CONF" import csm'
   The status should equal 0
   The line 1 of stderr should include 'Success: Wrote 1 records of a total'
 End
 
 It 'export after node second import'
-  When call bin/cani alpha --config "$CANI_CONF" export --type NODE,nodeblade --headers 'id,Type,role,subrole,nid,alias'
+  When call bin/cani alpha --config "$CANI_CONF" export csm --type NODE,nodeblade --headers 'id,Type,role,subrole,nid,alias'
   The status should equal 0
   The line 1 of stdout should equal "ID,Type,Role,SubRole,Nid,Alias"
   The output should include "Node,Compute,Worker,10000,nid10000"

--- a/spec/integration/export_sls_json_spec.sh
+++ b/spec/integration/export_sls_json_spec.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/integration/export_sls_json_spec.sh
+++ b/spec/integration/export_sls_json_spec.sh
@@ -34,16 +34,17 @@ It 'init session'
 End
 
 It 'add cabinet hpe-ex2500-1-liquid-cooled-chassis'
-  When call bin/cani alpha --config "$CANI_CONF" add cabinet hpe-ex2500-1-liquid-cooled-chassis --auto --accept
+  When call bin/cani alpha --config "$CANI_CONF" add cabinet csm hpe-ex2500-1-liquid-cooled-chassis --auto --accept
   The status should equal 0
   The line 1 of stderr should include 'Querying inventory to suggest Cabinet'
   The line 2 of stderr should include 'Suggested cabinet number: 8000'
   The line 3 of stderr should include 'Suggested VLAN ID: 3001'
-  The line 4 of stderr should include 'Cabinet 8000 was successfully staged to be added to the system'
+  The line 4 of stderr should include 'Cabinet was successfully staged to be added to the system'
+  The line 6 of stderr should include "Cabinet Number: 8000"
 End
 
 It 'export sls json'
-  When call bin/cani alpha --config "$CANI_CONF" export --format sls-json
+  When call bin/cani alpha --config "$CANI_CONF" export csm --format sls-json
   The status should equal 0
   The stderr should include 'GET http'
   The stderr should include 'sls/v1/dumpstate'
@@ -51,15 +52,15 @@ It 'export sls json'
 End
 
 It 'export sls json and parse the json'
-  When call sh -c 'bin/cani alpha --config "$CANI_CONF" export --format sls-json | jq'
+  When call sh -c 'bin/cani alpha --config "$CANI_CONF" export csm --format sls-json | jq'
   The status should equal 0
   The stderr should include 'GET http'
   The stderr should include 'sls/v1/dumpstate'
   The output should include '"x8000": {'
 End
 
-It 'add blade --config "$CANI_CONF" hpe-crayex-ex235n-compute-blade --cabinet 8000 --chassis 0 --blade 0'
-  When call bin/cani alpha add blade --config "$CANI_CONF" hpe-crayex-ex235n-compute-blade --cabinet 8000 --chassis 0 --blade 0
+It 'add blade csm --config "$CANI_CONF" hpe-crayex-ex235n-compute-blade --cabinet 8000 --chassis 0 --blade 0'
+  When call bin/cani alpha add blade csm --config "$CANI_CONF" hpe-crayex-ex235n-compute-blade --cabinet 8000 --chassis 0 --blade 0
   The status should equal 0
   The line 2 of stderr should include "NodeBlade was successfully staged to be added to the system"
   The line 3 of stderr should include "UUID: "
@@ -69,7 +70,7 @@ It 'add blade --config "$CANI_CONF" hpe-crayex-ex235n-compute-blade --cabinet 80
 End
 
 It 'export invalid sls data but with ignore-validation option'
-  When call sh -c 'bin/cani alpha --config "$CANI_CONF" export --format sls-json --ignore-validation | jq'
+  When call sh -c 'bin/cani alpha --config "$CANI_CONF" export csm --format sls-json --ignore-validation | jq'
   The status should equal 0
   The stderr should include 'GET http'
   The stderr should include 'sls/v1/dumpstate'
@@ -77,7 +78,7 @@ It 'export invalid sls data but with ignore-validation option'
 End
 
 It 'export invalid sls data and expect validation failure'
-  When call bin/cani alpha --config "$CANI_CONF" export --format sls-json
+  When call bin/cani alpha --config "$CANI_CONF" export csm --format sls-json
   The status should equal 1
   The stderr should include 'GET http'
   The stderr should include 'sls/v1/dumpstate'

--- a/spec/support/bin/cani_integrate.sh
+++ b/spec/support/bin/cani_integrate.sh
@@ -22,7 +22,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# set -e
+set -e
 set -u
 
 # SIM_REPO="${1:-../hms-simulation-environment}"

--- a/spec/support/bin/cani_integrate.sh
+++ b/spec/support/bin/cani_integrate.sh
@@ -22,7 +22,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-set -e
+# set -e
 set -u
 
 # SIM_REPO="${1:-../hms-simulation-environment}"

--- a/spec/support/cab_blade_matrix.sh
+++ b/spec/support/cab_blade_matrix.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/support/cab_blade_matrix.sh
+++ b/spec/support/cab_blade_matrix.sh
@@ -28,8 +28,8 @@ set -u
 
 : "${CANI_CONF:-/tmp/.cani/cani.yml}"
 
-for blade in $(bin/cani --config "$CANI_CONF" alpha add blade -L); do
-  for cabinet in $(bin/cani --config "$CANI_CONF" alpha add cabinet -L); do
+for blade in $(bin/cani --config "$CANI_CONF" alpha add blade csm -L); do
+  for cabinet in $(bin/cani --config "$CANI_CONF" alpha add cabinet csm -L); do
     if [ "$cabinet" = "hpe-eia-cabinet" ];then 
       continue
     else 

--- a/testdata/fixtures/cani/add/blade/help
+++ b/testdata/fixtures/cani/add/blade/help
@@ -1,7 +1,13 @@
 Add blades to the inventory.
 
 Usage:
-  cani alpha add blade [flags]
+  cani alpha add blade PROVIDER [flags]
+  cani alpha add blade [command]
+
+Available Commands:
+  csm         Add blades to the inventory.
+  hpcm        Add blades to the inventory.
+  hpengi      Add blades to the inventory.
 
 Flags:
   -y, --accept                 Automatically accept recommended values.
@@ -16,3 +22,5 @@ Global Flags:
       --config string   Path to the configuration file
   -D, --debug           additional debug output
   -v, --verbose         additional verbose output
+
+Use "cani alpha add blade [command] --help" for more information about a command.

--- a/testdata/fixtures/cani/add/blade/help
+++ b/testdata/fixtures/cani/add/blade/help
@@ -6,8 +6,6 @@ Usage:
 
 Available Commands:
   csm         Add blades to the inventory.
-  hpcm        Add blades to the inventory.
-  hpengi      Add blades to the inventory.
 
 Flags:
   -y, --accept                 Automatically accept recommended values.

--- a/testdata/fixtures/cani/add/cabinet/help
+++ b/testdata/fixtures/cani/add/cabinet/help
@@ -1,17 +1,23 @@
 Add cabinets to the inventory.
 
 Usage:
-  cani alpha add cabinet [flags]
+  cani alpha add cabinet PROVIDER [flags]
+  cani alpha add cabinet [command]
+
+Available Commands:
+  csm         Add cabinets to the inventory.
+  hpcm        Add cabinets to the inventory.
+  hpengi      Add cabinets to the inventory.
 
 Flags:
   -y, --accept                 Automatically accept recommended values.
       --auto                   Automatically recommend and assign required flags.
-      --cabinet int            Cabinet number. (default 1001)
   -h, --help                   help for cabinet
   -L, --list-supported-types   List supported hardware types.
-      --vlan-id int            Vlan ID for the cabinet. (default -1)
 
 Global Flags:
       --config string   Path to the configuration file
   -D, --debug           additional debug output
   -v, --verbose         additional verbose output
+
+Use "cani alpha add cabinet [command] --help" for more information about a command.

--- a/testdata/fixtures/cani/add/cabinet/help
+++ b/testdata/fixtures/cani/add/cabinet/help
@@ -6,8 +6,6 @@ Usage:
 
 Available Commands:
   csm         Add cabinets to the inventory.
-  hpcm        Add cabinets to the inventory.
-  hpengi      Add cabinets to the inventory.
 
 Flags:
   -y, --accept                 Automatically accept recommended values.

--- a/testdata/fixtures/cani/add/node/help
+++ b/testdata/fixtures/cani/add/node/help
@@ -6,8 +6,6 @@ Usage:
 
 Available Commands:
   csm         Add nodes to the inventory.
-  hpcm        Add nodes to the inventory.
-  hpengi      Add nodes to the inventory.
 
 Flags:
   -h, --help                   help for node

--- a/testdata/fixtures/cani/add/node/help
+++ b/testdata/fixtures/cani/add/node/help
@@ -1,17 +1,21 @@
 Add nodes to the inventory.
 
 Usage:
-  cani alpha add node [flags]
+  cani alpha add node PROVIDER [flags]
+  cani alpha add node [command]
+
+Available Commands:
+  csm         Add nodes to the inventory.
+  hpcm        Add nodes to the inventory.
+  hpengi      Add nodes to the inventory.
 
 Flags:
-      --alias string           Alias of the node
   -h, --help                   help for node
   -L, --list-supported-types   List supported hardware types.
-      --nid int                NID of the node
-      --role string            Role of the node
-      --subrole string         Subrole of the node
 
 Global Flags:
       --config string   Path to the configuration file
   -D, --debug           additional debug output
   -v, --verbose         additional verbose output
+
+Use "cani alpha add node [command] --help" for more information about a command.

--- a/testdata/fixtures/cani/export/help
+++ b/testdata/fixtures/cani/export/help
@@ -1,18 +1,20 @@
 Export assets from the inventory.
 
 Usage:
-  cani alpha export [flags]
+  cani alpha export PROVIDER [flags]
+  cani alpha export [command]
+
+Available Commands:
+  csm         Export assets from the inventory.
+  hpcm        Export assets from the inventory.
+  hpengi      Export assets from the inventory.
 
 Flags:
-  -a, --all                 List all components. This overrides the --type option
-      --format string       Format option: [csv, sls-json] (default "csv")
-      --headers string      Comma separated list of fields to get (default "Type,Vlan,Role,SubRole,Status,Nid,Alias,Name,ID,Location")
-  -h, --help                help for export
-      --ignore-validation   Skip validating the sls data. This only applies to the sls-json format.
-  -L, --list-fields         List details about the fields in the CSV
-  -t, --type string         Comma separated list of the types of components to output (default "Node,Cabinet")
+  -h, --help   help for export
 
 Global Flags:
       --config string   Path to the configuration file
   -D, --debug           additional debug output
   -v, --verbose         additional verbose output
+
+Use "cani alpha export [command] --help" for more information about a command.

--- a/testdata/fixtures/cani/export/help
+++ b/testdata/fixtures/cani/export/help
@@ -6,8 +6,6 @@ Usage:
 
 Available Commands:
   csm         Export assets from the inventory.
-  hpcm        Export assets from the inventory.
-  hpengi      Export assets from the inventory.
 
 Flags:
   -h, --help   help for export

--- a/testdata/fixtures/cani/import/help
+++ b/testdata/fixtures/cani/import/help
@@ -1,7 +1,13 @@
 Import assets into the inventory.
 
 Usage:
-  cani alpha import [FILE] [flags]
+  cani alpha import PROVIDER [FILE] [flags]
+  cani alpha import [command]
+
+Available Commands:
+  csm         Import assets into the inventory.
+  hpcm        Import assets into the inventory.
+  hpengi      Import assets into the inventory.
 
 Flags:
   -h, --help   help for import
@@ -10,3 +16,5 @@ Global Flags:
       --config string   Path to the configuration file
   -D, --debug           additional debug output
   -v, --verbose         additional verbose output
+
+Use "cani alpha import [command] --help" for more information about a command.

--- a/testdata/fixtures/cani/import/help
+++ b/testdata/fixtures/cani/import/help
@@ -6,8 +6,6 @@ Usage:
 
 Available Commands:
   csm         Import assets into the inventory.
-  hpcm        Import assets into the inventory.
-  hpengi      Import assets into the inventory.
 
 Flags:
   -h, --help   help for import


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- moves all `init()` functions to `main.go` by making each package's
  `init()` public (`Init()`) so they can be run in a specific order
- uses a new `RegisterProviderCommand` to add provider versions of each
  comand as a subcommand to cani's command.  this currently requires the
  passing of a provider name for all calls but easily allows for each
  provider to define their own settings and not clash with each other
- adds a `utils.CloneCommand()` funciton to clone a cobra command, which
  providers can use to create and modify the commands as needed
- converts `recommendations.Print()` method to a provider-specific
  method: `root.D.PrintRecommendations(cmd, args, recommendations)`
- changes some variable names from `bootstrapCmd` to `caniCmd` to better
  distinguish cani vs. provider
- moves additional cray-sauce like cabinet vlans out of the `cmd`
  package and into the `csm` package where it belongs
- updates `provider.ProviderCommands` interface for all
  currently-supported commands
- adjusts test to call `csm`, which will begin to adjust tests for
  multiple providers
- adjusts help fixtures as needed
- converts some CSM `DEBUG` statements to `TRACE` since development will
  be minimal on CSM and less of that info is relevant to multiple
  providers
- changes some `cmd.Name()` conditionals to `cmd.Parent().Name()`
  since the provider command is a sub command
- updated `makeprovider` command for changes (some stupid changes, but
  they meet the immediate need)


# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

