### PR TITLE
add flag for geolocation (off by default), making it configurable

### DIFF
--- a/cmd/blade/add_blade.go
+++ b/cmd/blade/add_blade.go
@@ -87,7 +87,7 @@ func addBlade(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// Add the blade from the inventory using domain methods
-	result, err := root.D.AddBlade(cmd, args, cabinet, chassis, blade)
+	result, err := root.D.AddBlade(cmd, args)
 	if errors.Is(err, provider.ErrDataValidationFailure) {
 		// TODO this validation error print logic could be shared
 

--- a/cmd/blade/init.go
+++ b/cmd/blade/init.go
@@ -55,11 +55,11 @@ func Init() {
 	// Add a flag to show supported types
 	AddBladeCmd.Flags().BoolP("list-supported-types", "L", false, "List supported hardware types.")
 
+	AddBladeCmd.Flags().BoolP("geoloc", "g", false, "Require geolocation (LocationPaths, Ordinals, Parents, Children)")
 	// Blades have several parents, so we need to add flags for each
 	AddBladeCmd.Flags().IntVar(&cabinet, "cabinet", 1001, "Parent cabinet")
 	AddBladeCmd.Flags().IntVar(&chassis, "chassis", 7, "Parent chassis")
 	AddBladeCmd.Flags().IntVar(&blade, "blade", 1, "Blade")
-	AddBladeCmd.MarkFlagsRequiredTogether("cabinet", "chassis", "blade")
 
 	AddBladeCmd.Flags().BoolVar(&auto, "auto", false, "Automatically recommend values for parent hardware")
 	AddBladeCmd.MarkFlagsRequiredTogether("list-supported-types")

--- a/cmd/cabinet/init.go
+++ b/cmd/cabinet/init.go
@@ -54,6 +54,7 @@ func Init() {
 	AddCabinetCmd.Flags().BoolVar(&auto, "auto", false, "Automatically recommend and assign required flags.")
 	AddCabinetCmd.MarkFlagsMutuallyExclusive("auto")
 	AddCabinetCmd.Flags().BoolVarP(&accept, "accept", "y", false, "Automatically accept recommended values.")
+	AddCabinetCmd.Flags().BoolP("geoloc", "g", false, "Require geolocation (LocationPaths, Ordinals, Parents, Children)")
 
 	// Common 'list cabinet' flags and then merge with provider-specified command
 	ListCabinetCmd.Flags().StringVarP(&format, "format", "f", "pretty", "Format out output")

--- a/internal/domain/blade_noloc.go
+++ b/internal/domain/blade_noloc.go
@@ -1,0 +1,123 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package domain
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Cray-HPE/cani/internal/inventory"
+	"github.com/Cray-HPE/cani/internal/provider"
+	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+// addBladeNoGeoLoc adds a blade without worrying about geolocation or ordinals
+func (d *Domain) addBladeNoGeoLoc(cmd *cobra.Command, args []string) (result AddHardwareResult, err error) {
+	deviceTypeSlug := args[0]
+	// Verify the provided device type slug is a node blade
+	deviceType, err := d.hardwareTypeLibrary.GetDeviceType(deviceTypeSlug)
+	if err != nil {
+		return AddHardwareResult{}, err
+	}
+	if deviceType.HardwareType != hardwaretypes.NodeBlade {
+		return AddHardwareResult{}, fmt.Errorf("provided device hardware type (%s) is not a %s", deviceTypeSlug, hardwaretypes.NodeBlade)
+	}
+
+	// Generate a hardware build out
+	hardwareBuildOutItems, err := inventory.GenerateHardwareBuildOut(d.hardwareTypeLibrary, inventory.GenerateHardwareBuildOutOpts{
+		DeviceTypeSlug: deviceTypeSlug,
+	})
+	if err != nil {
+		return result, err
+	}
+
+	for _, hardwareBuildOut := range hardwareBuildOutItems {
+		var hardware inventory.Hardware
+
+		if hardwareBuildOut.ExistingHardware == nil {
+			// New hardware not present in the inventory
+			hardware = inventory.NewHardwareFromBuildOut(hardwareBuildOut, inventory.HardwareStatusStaged)
+
+			if err := d.datastore.Add(&hardware); err != nil {
+				return AddHardwareResult{}, errors.Join(
+					fmt.Errorf("unable to add hardware to inventory datastore"),
+					err,
+				)
+			}
+		} else {
+			// Empty hardware is present in the inventory
+			hardware = *hardwareBuildOut.ExistingHardware
+			// Set hardware type information from build out
+			hardware.DeviceTypeSlug = hardwareBuildOut.DeviceTypeSlug
+			hardware.Type = hardwareBuildOut.DeviceType.HardwareType
+			hardware.Vendor = hardwareBuildOut.DeviceType.Manufacturer
+			hardware.Model = hardwareBuildOut.DeviceType.Model
+			// The hardware is now staged, and not empty
+			hardware.Status = inventory.HardwareStatusStaged
+
+			if err := d.datastore.Update(&hardware); err != nil {
+				return AddHardwareResult{}, errors.Join(
+					fmt.Errorf("unable to add hardware to inventory datastore"),
+					err,
+				)
+			}
+		}
+		pair := HardwareLocationPair{
+			Hardware: hardware,
+		}
+		log.Debug().Msgf("Also adding %s--a %s--with parent %s", pair.Hardware.ID, pair.Hardware.Type, pair.Hardware.Parent)
+		result.AddedHardware = append(result.AddedHardware, pair)
+	}
+
+	// Validate the CANI's datastore
+	if failedValidations, err := d.datastore.Validate(); len(failedValidations) > 0 {
+		result.DatastoreValidationErrors = failedValidations
+	} else if err != nil {
+		return AddHardwareResult{}, errors.Join(
+			fmt.Errorf("failed to validate datastore inventory"),
+			err,
+		)
+	}
+
+	// Validate the current state of CANI's inventory data against the provider plugin
+	// for provider specific data.
+	if failedValidations, err := d.externalInventoryProvider.ValidateInternal(cmd, args, d.datastore, false); len(failedValidations) > 0 {
+		result.ProviderValidationErrors = failedValidations
+	} else if err != nil {
+		return AddHardwareResult{}, errors.Join(
+			fmt.Errorf("failed to validate inventory against inventory provider plugin"),
+			err,
+		)
+	}
+
+	if len(result.DatastoreValidationErrors) > 0 || len(result.ProviderValidationErrors) > 0 {
+		return result, provider.ErrDataValidationFailure
+	}
+
+	return result, nil
+}

--- a/internal/domain/cabinet_noloc.go
+++ b/internal/domain/cabinet_noloc.go
@@ -1,0 +1,96 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package domain
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Cray-HPE/cani/internal/inventory"
+	"github.com/Cray-HPE/cani/internal/provider"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+func (d *Domain) addCabinetNoGeoLoc(cmd *cobra.Command, args []string, recommendations provider.HardwareRecommendations) (result AddHardwareResult, err error) {
+	// Verify the provided device type slug is a node blade
+	deviceTypeSlug := args[0]
+	system, err := d.datastore.GetSystemZero()
+	if err != nil {
+		return AddHardwareResult{}, errors.Join(
+			fmt.Errorf("unable to get system zero"),
+			err,
+		)
+	}
+
+	// Generate a hardware build out using the system as a parent
+	hardwareBuildOutItems, err := inventory.GenerateDefaultHardwareBuildOutNoLoc(d.hardwareTypeLibrary, deviceTypeSlug, system)
+	if err != nil {
+		return AddHardwareResult{}, errors.Join(
+			fmt.Errorf("unable to build default hardware build out for %s", deviceTypeSlug),
+			err,
+		)
+	}
+
+	for _, hardwareBuildOut := range hardwareBuildOutItems {
+		// Generate the CANI hardware inventory version of the hardware build out data
+		hardware := inventory.NewHardwareFromBuildOut(hardwareBuildOut, inventory.HardwareStatusStaged)
+
+		// Ask the inventory provider to craft a metadata object for this information
+		if err := d.externalInventoryProvider.BuildHardwareMetadata(&hardware, cmd, args, recommendations); err != nil {
+			return AddHardwareResult{}, err
+		}
+
+		// Metadata is now set by the BuildHardwareMetadata so it can be added to the datastore
+		if err := d.datastore.Add(&hardware); err != nil {
+			return AddHardwareResult{}, errors.Join(
+				fmt.Errorf("unable to add hardware to inventory datastore"),
+				err,
+			)
+		}
+
+		pair := HardwareLocationPair{
+			Hardware: hardware,
+		}
+
+		log.Debug().Msgf("Also adding %s--a %s--with parent %s", pair.Hardware.ID, pair.Hardware.Type, pair.Hardware.Parent)
+		result.AddedHardware = append(result.AddedHardware, pair)
+
+		// Validate the current state of CANI's inventory data against the provider plugin
+		// for provider specific data.
+		if failedValidations, err := d.externalInventoryProvider.ValidateInternal(cmd, args, d.datastore, false); len(failedValidations) > 0 {
+			result.ProviderValidationErrors = failedValidations
+			return result, provider.ErrDataValidationFailure
+		} else if err != nil {
+			return AddHardwareResult{}, errors.Join(
+				fmt.Errorf("failed to validate inventory against inventory provider plugin"),
+				err,
+			)
+		}
+	}
+
+	return result, d.datastore.Flush()
+}

--- a/internal/inventory/buildout.go
+++ b/internal/inventory/buildout.go
@@ -58,6 +58,13 @@ func GenerateDefaultHardwareBuildOut(l *hardwaretypes.Library, deviceTypeSlug st
 	})
 }
 
+func GenerateDefaultHardwareBuildOutNoLoc(l *hardwaretypes.Library, deviceTypeSlug string, parentHardware Hardware) (results []HardwareBuildOut, err error) {
+	return GenerateHardwareBuildOut(l, GenerateHardwareBuildOutOpts{
+		DeviceTypeSlug: deviceTypeSlug,
+		ParentHardware: parentHardware,
+	})
+}
+
 type GenerateHardwareBuildOutOpts struct {
 	DeviceTypeSlug string
 	DeviceOrdinal  int

--- a/internal/inventory/datastore_json.go
+++ b/internal/inventory/datastore_json.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),
@@ -36,7 +36,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Cray-HPE/cani/internal/util/uuidutil"
 	"github.com/Cray-HPE/cani/pkg/hardwaretypes"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
@@ -258,42 +257,6 @@ func (ds *DatastoreJSON) Validate() (map[uuid.UUID]ValidateResult, error) {
 	//
 	// Verify all complete location paths are unique.
 	//
-
-	// Build up a lookup map of location paths to hardware UUIDs
-	foundLocationPaths := map[string][]uuid.UUID{}
-	for _, hardware := range ds.inventory.Hardware {
-		if len(hardware.LocationPath) == 0 {
-			continue
-		}
-
-		if hardware.LocationPath[0].HardwareType != hardwaretypes.System {
-			// Skip any piece of hardware that does not begin with System type, as it is not complete
-			continue
-		}
-
-		key := hardware.LocationPath.String()
-		foundLocationPaths[key] = append(foundLocationPaths[key], hardware.ID)
-	}
-
-	// Verify all location paths have only one Hardware object present
-	for _, hardwareIDs := range foundLocationPaths {
-		if len(hardwareIDs) == 1 {
-			continue
-		}
-
-		for _, hardwareID := range hardwareIDs {
-			if _, exists := validationResults[hardwareID]; !exists {
-				validationResults[hardwareID] = ValidateResult{Hardware: ds.inventory.Hardware[hardwareID]}
-			}
-
-			// Add the validation error and push it back into the map
-			validationResult := validationResults[hardwareID]
-			validationResult.Errors = append(validationResult.Errors,
-				fmt.Sprintf("Location path not unique shared by: %s", uuidutil.Join(hardwareIDs, ", ", hardwareID)),
-			)
-			validationResults[hardwareID] = validationResult
-		}
-	}
 
 	if len(validationResults) > 0 {
 		return validationResults, ErrDatastoreValidationFailure

--- a/testdata/fixtures/cani/add/blade/help
+++ b/testdata/fixtures/cani/add/blade/help
@@ -13,6 +13,7 @@ Flags:
       --blade int              Blade (default 1)
       --cabinet int            Parent cabinet (default 1001)
       --chassis int            Parent chassis (default 7)
+  -g, --geoloc                 Require geolocation (LocationPaths, Ordinals, Parents, Children)
   -h, --help                   help for blade
   -L, --list-supported-types   List supported hardware types.
 

--- a/testdata/fixtures/cani/add/cabinet/help
+++ b/testdata/fixtures/cani/add/cabinet/help
@@ -10,6 +10,7 @@ Available Commands:
 Flags:
   -y, --accept                 Automatically accept recommended values.
       --auto                   Automatically recommend and assign required flags.
+  -g, --geoloc                 Require geolocation (LocationPaths, Ordinals, Parents, Children)
   -h, --help                   help for cabinet
   -L, --list-supported-types   List supported hardware types.
 


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- makes geolocation optional (for upcoming providers like HPCM, which may not necessarily use geoloc with every component of hardware)
- moves geolocation-related flags and prerun checks to the csm provider packge
-  removes geoloc code from the DatastoreJSON (not currently used by csm)
- adds a `geoloc` flag that can be enabled (and is with csm) 
- converts the `AddBlade`, `Add Cabinet` domain functions to key off this flag and run the appropriate function where `d.addBladeWithGeoLoc` is the existing code:

```
	if geoloc {
 		result, err = d.addBladeWithGeoLoc(cmd, args)
 	} else {
 		result, err = d.addBladeNoGeoLoc(cmd, args)
 	}
```

# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

Low.  Existing tests all pass.  The same code is run, just keyed off a new flag.

Geolocation is generally HPC-specific, so if you want to use a simple key/val inventory, you cannot currently do that without setting the location info.  This opens the ability to use cani without the need for it, and further reduces assumptions put in when the csm provider was developed.