### PR TITLE
Latest only on default branch

### DIFF
--- a/.github/workflows/promote-prerelease.yml
+++ b/.github/workflows/promote-prerelease.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -71,8 +71,8 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version: '1.20' # The Go version to download (if necessary) and use.
-  
-    # generate updated docs from any changes made to cani codebase
+
+      # generate updated docs from any changes made to cani codebase
     - run: go run main.go makedocs
 
     - name: Set up Python
@@ -102,4 +102,3 @@ jobs:
     - name: list doc versions 🚀
       run: |
         mike list -F mkdocs.yml -b gh-pages
-        

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -66,8 +66,8 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version: '1.20' # The Go version to download (if necessary) and use.
-    
-    # generate updated docs from any changes made to cani codebase
+
+      # generate updated docs from any changes made to cani codebase
     - run: go run main.go makedocs
 
     - name: Set up Python
@@ -84,7 +84,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
-        
+
     - name: generate hardware type docs
       run: |
         make generate-hardwaretypes-docs

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -30,6 +30,7 @@ on:
   workflow_dispatch:
 env:
   STREAM: stable
+  LATEST: false
 jobs:
   Promote:
     runs-on: ubuntu-latest
@@ -47,13 +48,26 @@ jobs:
         with:
           STREAM: ${{ env.STREAM }}
 
+      - name: Get Branch
+        run: |
+          mapfile -t branches < <(git branch -r --contains ${{ github.ref }} | awk '{print $1}')
+          echo "${branches[@]}"
+          for branch in "${branches[@]}"; do
+            branch_name="${branch/origin\/}"
+            echo "${branch_name}"
+            if [ "${branch_name}" = 'main' ]; then
+              echo LATEST=true >> $GITHUB_ENV
+              break
+            fi
+          done
+
       - uses: ncipollo/release-action@v1
         with:
           allowUpdates: true # if the job is re-ran to catch missed artifacts, allow updates
           generateReleaseNotes: false
           artifacts: ${{ env.DIR_UPLOAD }}/*
           prerelease: false
-          makeLatest: true
+          makeLatest: ${{ fromJSON(env.LATEST) }}
 
   generate_publish_docs:
     name: generate docs and publish with mike

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: run shellcheck
       uses: ludeeus/action-shellcheck@master
       with:

--- a/.github/workflows/shellspec.yml
+++ b/.github/workflows/shellspec.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -43,19 +43,19 @@ jobs:
           repository: Cray-HPE/hms-simulation-environment
           ref: v1
           fetch-depth: 0
-        
+
       - name: checkout shellspec
         uses: actions/checkout@v3
         with:
           path: shellspec
           repository: shellspec/shellspec
           fetch-depth: 0
-        
+
       - name: set up python
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-        
+
       - name: install python dependencies
         run: pip3 install -r requirements.txt
 


### PR DESCRIPTION
Do not mark stable tags from release or maintenance branches as latest.

Prevents maintenance/release branches from declaring themselves as "latest" over a tag taken from the default branch.