### PR TITLE
Add import export shellspec test matrix

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,7 @@ func newRootCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&cfgFile, "config", defaultCfg, "config file")
 	cmd.PersistentFlags().Bool("debug", false, "enable debug mode")
 	cmd.PersistentFlags().String("datastore", "json", "datastore type (json, postgres)")
+	cmd.PersistentFlags().String("datastore-path", "", "override path to the datastore file (for testing)")
 	cmd.PersistentFlags().StringSlice("types-dirs", nil, "local directories with additional hardware types")
 	cmd.PersistentFlags().StringSlice("types-repos", nil, "git repo URLs with additional hardware types")
 	cmd.PersistentFlags().Bool("types-repo-clone", false, "clone types repos that are not yet cached locally")
@@ -127,6 +128,12 @@ func setupDomain(cmd *cobra.Command, args []string) error {
 	// write defaults (in case we injected new maps)
 	if err := config.Save(cfgFile); err != nil {
 		return err
+	}
+
+	// Override the datastore path if the flag was explicitly set.
+	// Applied after Save so the override is not persisted to the config file.
+	if dsPath, _ := cmd.Flags().GetString("datastore-path"); dsPath != "" {
+		config.Cfg.Datastore = dsPath
 	}
 
 	// 3) hand each plugin its own section of the map

--- a/pkg/datastores/json.go
+++ b/pkg/datastores/json.go
@@ -41,10 +41,14 @@ type JSONStore struct {
 }
 
 // NewJSONStore creates a new store with the config path.
+// If the configured datastore path is absolute it is used as-is;
+// otherwise it is resolved relative to the config file directory.
 func NewJSONStore() *JSONStore {
-	return &JSONStore{
-		Path: filepath.Join(filepath.Dir(config.Cfg.Path), filepath.Base(config.Cfg.Datastore)),
+	ds := config.Cfg.Datastore
+	if !filepath.IsAbs(ds) {
+		ds = filepath.Join(filepath.Dir(config.Cfg.Path), filepath.Base(ds))
 	}
+	return &JSONStore{Path: ds}
 }
 
 // Load reads the inventory from disk.

--- a/pkg/datastores/json_test.go
+++ b/pkg/datastores/json_test.go
@@ -32,6 +32,22 @@ func TestNewJSONStoreHappyPath(t *testing.T) {
 	}
 }
 
+func TestNewJSONStoreAbsolutePath(t *testing.T) {
+	original := config.Cfg
+	config.Cfg = &config.Config{
+		Path:      "/tmp/cani-test/config.yaml",
+		Datastore: "/tmp/override/test.json",
+	}
+	defer func() { config.Cfg = original }()
+
+	store := NewJSONStore()
+
+	expected := "/tmp/override/test.json"
+	if store.Path != expected {
+		t.Errorf("expected path %q, got %q", expected, store.Path)
+	}
+}
+
 func TestNewJSONStoreNilConfig(t *testing.T) {
 	original := config.Cfg
 	config.Cfg = nil

--- a/pkg/devicetypes/connections/apply.go
+++ b/pkg/devicetypes/connections/apply.go
@@ -1,0 +1,69 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package connections
+
+import (
+	"fmt"
+
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+)
+
+// ApplyConnections creates cables in the inventory from a list of
+// resolved connections. Returns the number of cables created and any
+// per-cable errors encountered.
+func ApplyConnections(resolved []ResolvedConnection, inv *devicetypes.Inventory) (int, []error) {
+	var errs []error
+	created := 0
+
+	for _, conn := range resolved {
+		cable := devicetypes.NewCable(conn.Cable.Type, conn.Cable.Label)
+		cable.TerminationADevice = conn.ADevice
+		cable.TerminationAPort = conn.APort
+		cable.TerminationBDevice = conn.BDevice
+		cable.TerminationBPort = conn.BPort
+
+		if conn.Cable.Color != "" {
+			cable.Color = conn.Cable.Color
+		}
+		if conn.Cable.Length != nil {
+			cable.Length = conn.Cable.Length
+		}
+		if conn.Cable.LengthUnit != "" {
+			cable.LengthUnit = conn.Cable.LengthUnit
+		}
+		if conn.Cable.Status != "" {
+			cable.Status = conn.Cable.Status
+		}
+
+		if err := inv.AddCable(cable); err != nil {
+			errs = append(errs, fmt.Errorf("cable %s->%s: %w", conn.APort, conn.BPort, err))
+			continue
+		}
+		created++
+	}
+
+	return created, errs
+}

--- a/pkg/devicetypes/connections/csv.go
+++ b/pkg/devicetypes/connections/csv.go
@@ -1,0 +1,368 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package connections
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// csvInterface holds the fields extracted from one row of a Nautobot
+// interfaces CSV export.
+type csvInterface struct {
+	ID         string // interface UUID
+	Name       string // port / interface name
+	DeviceName string // device__name
+	CablePeer  string // UUID of the peer interface on the other end of the cable
+	CablePK    string // UUID of the cable object (optional, used for dedup)
+	Type       string // interface type (e.g. 100gbase-x-qsfp28)
+	Status     string // status__name
+	Label      string // label
+}
+
+// requiredInterfaceColumns lists columns required for Nautobot interfaces CSV.
+var requiredInterfaceColumns = []string{"name", "device__name", "id", "cable_peer"}
+
+// requiredConnectionColumns lists columns required for human-friendly CSV.
+var requiredConnectionColumns = []string{"a_device", "a_port", "b_device", "b_port"}
+
+// ParseCSV reads a CSV and auto-detects the format from the header row.
+// If the header contains "a_device" it uses the human-friendly single-row
+// parser; if it contains "cable_peer" it uses the Nautobot interfaces parser.
+func ParseCSV(r io.Reader) (*ConnectionMap, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading CSV: %w", err)
+	}
+
+	// Peek at header to detect format
+	header, err := csv.NewReader(bytes.NewReader(data)).Read()
+	if err != nil {
+		return nil, fmt.Errorf("reading CSV header: %w", err)
+	}
+
+	idx := buildColumnIndex(header)
+	if _, ok := idx["a_device"]; ok {
+		return ParseConnectionsCSV(bytes.NewReader(data))
+	}
+	if _, ok := idx["cable_peer"]; ok {
+		return ParseInterfacesCSV(bytes.NewReader(data))
+	}
+
+	return nil, fmt.Errorf("CSV format not recognized: header must contain either 'a_device' (human) or 'cable_peer' (Nautobot interfaces)")
+}
+
+// ParseConnectionsCSV reads a human-friendly CSV where each row is one
+// cable connection. No UUIDs required.
+//
+// Required columns: a_device, a_port, b_device, b_port.
+// Optional columns: type, label, color, length, length_unit, status.
+//
+// A row with a_device set to "_defaults" is treated as cable defaults
+// that apply to all connections (like cable_defaults in YAML). The
+// type, color, status, and length_unit columns from the defaults row
+// are applied to every connection that does not set them explicitly.
+func ParseConnectionsCSV(r io.Reader) (*ConnectionMap, error) {
+	reader := csv.NewReader(r)
+	reader.FieldsPerRecord = -1
+
+	header, err := reader.Read()
+	if err != nil {
+		return nil, fmt.Errorf("reading CSV header: %w", err)
+	}
+
+	idx := buildColumnIndex(header)
+	if err := validateColumns(idx, requiredConnectionColumns); err != nil {
+		return nil, err
+	}
+
+	var defaults *CableDefaults
+	var entries []ConnectionEntry
+	lineNum := 1 // header is line 1
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading CSV row %d: %w", lineNum+1, err)
+		}
+		lineNum++
+
+		aDevice := getField(record, idx, "a_device")
+
+		// Sentinel row: "_defaults" sets cable defaults for all rows
+		if aDevice == "_defaults" {
+			defaults = buildCableDefaults(record, idx)
+			continue
+		}
+
+		aPort := getField(record, idx, "a_port")
+		bDevice := getField(record, idx, "b_device")
+		bPort := getField(record, idx, "b_port")
+
+		if aDevice == "" || aPort == "" || bDevice == "" || bPort == "" {
+			continue // skip incomplete rows
+		}
+
+		entry := ConnectionEntry{
+			A: Endpoint{Device: aDevice, Port: aPort},
+			B: Endpoint{Device: bDevice, Port: bPort},
+		}
+
+		// Attach optional cable properties
+		cable := buildCableProps(record, idx)
+		if cable != nil {
+			entry.Cable = cable
+		}
+
+		entries = append(entries, entry)
+	}
+
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("no connections found in CSV (0 complete rows)")
+	}
+
+	return &ConnectionMap{
+		Version:       "v1",
+		CableDefaults: defaults,
+		Connections:   entries,
+	}, nil
+}
+
+// buildCableDefaults extracts cable default properties from a _defaults row.
+func buildCableDefaults(record []string, idx map[string]int) *CableDefaults {
+	d := &CableDefaults{
+		Type:       getField(record, idx, "type"),
+		Status:     getField(record, idx, "status"),
+		Color:      getField(record, idx, "color"),
+		LengthUnit: getField(record, idx, "length_unit"),
+	}
+	if d.Type == "" && d.Status == "" && d.Color == "" && d.LengthUnit == "" {
+		return nil
+	}
+	return d
+}
+
+// buildCableProps extracts optional cable properties from a CSV row.
+// Returns nil if no cable properties are present.
+func buildCableProps(record []string, idx map[string]int) *CableProps {
+	cType := getField(record, idx, "type")
+	label := getField(record, idx, "label")
+	color := getField(record, idx, "color")
+	lengthStr := getField(record, idx, "length")
+	lengthUnit := getField(record, idx, "length_unit")
+	status := getField(record, idx, "status")
+
+	if cType == "" && label == "" && color == "" && lengthStr == "" && status == "" {
+		return nil
+	}
+
+	props := &CableProps{
+		Type:       cType,
+		Label:      label,
+		Color:      color,
+		LengthUnit: lengthUnit,
+		Status:     status,
+	}
+
+	if lengthStr != "" {
+		var length float64
+		if _, err := fmt.Sscanf(lengthStr, "%f", &length); err == nil {
+			props.Length = &length
+		}
+	}
+
+	return props
+}
+
+// ParseInterfacesCSV reads a Nautobot interfaces CSV export and
+// reconstructs a ConnectionMap by pairing cabled interfaces.
+//
+// Minimum required columns: name, device__name, id, cable_peer.
+// Optional columns: cable__pk, type, status__name, label.
+//
+// Each cable appears twice in the CSV (once per side). The function
+// deduplicates by keeping only the pair where side-A's id is
+// lexicographically less than side-B's id.
+func ParseInterfacesCSV(r io.Reader) (*ConnectionMap, error) {
+	reader := csv.NewReader(r)
+	reader.FieldsPerRecord = -1 // allow variable column counts
+
+	header, err := reader.Read()
+	if err != nil {
+		return nil, fmt.Errorf("reading CSV header: %w", err)
+	}
+
+	colIndex := buildColumnIndex(header)
+	if err := validateColumns(colIndex, requiredInterfaceColumns); err != nil {
+		return nil, err
+	}
+
+	interfaces, err := readInterfaceRows(reader, colIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	return pairInterfaces(interfaces)
+}
+
+// buildColumnIndex maps column names to their position indices.
+func buildColumnIndex(header []string) map[string]int {
+	idx := make(map[string]int, len(header))
+	for i, col := range header {
+		idx[strings.TrimSpace(col)] = i
+	}
+	return idx
+}
+
+// validateColumns checks that all specified columns are present in the index.
+func validateColumns(idx map[string]int, required []string) error {
+	var missing []string
+	for _, col := range required {
+		if _, ok := idx[col]; !ok {
+			missing = append(missing, col)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("CSV missing required columns: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// readInterfaceRows parses all data rows into csvInterface structs,
+// skipping rows that have no cable_peer (uncabled interfaces).
+func readInterfaceRows(reader *csv.Reader, idx map[string]int) (map[string]csvInterface, error) {
+	interfaces := make(map[string]csvInterface)
+
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading CSV row: %w", err)
+		}
+
+		iface := csvInterface{
+			ID:         getField(record, idx, "id"),
+			Name:       getField(record, idx, "name"),
+			DeviceName: getField(record, idx, "device__name"),
+			CablePeer:  getField(record, idx, "cable_peer"),
+			CablePK:    getField(record, idx, "cable__pk"),
+			Type:       getField(record, idx, "type"),
+			Status:     getField(record, idx, "status__name"),
+			Label:      getField(record, idx, "label"),
+		}
+
+		// Skip uncabled interfaces
+		if iface.CablePeer == "" || iface.CablePeer == "NULL" {
+			continue
+		}
+		if iface.ID == "" {
+			continue
+		}
+
+		interfaces[iface.ID] = iface
+	}
+
+	return interfaces, nil
+}
+
+// pairInterfaces matches cabled interfaces by cable_peer UUID and
+// builds a ConnectionMap. Deduplicates by keeping the pair where
+// side-A has the lexicographically smaller ID.
+func pairInterfaces(interfaces map[string]csvInterface) (*ConnectionMap, error) {
+	seen := make(map[string]bool)
+	var entries []ConnectionEntry
+
+	for _, iface := range interfaces {
+		peer, ok := interfaces[iface.CablePeer]
+		if !ok {
+			// Peer not in this export — skip (partial export)
+			continue
+		}
+
+		// Deduplicate: each cable produces two rows. Keep the pair where
+		// side-A's ID is lexicographically smaller.
+		cableKey := iface.ID
+		if iface.ID > peer.ID {
+			cableKey = peer.ID
+		}
+		if seen[cableKey] {
+			continue
+		}
+		seen[cableKey] = true
+
+		// Ensure consistent ordering: smaller ID is side A
+		a, b := iface, peer
+		if a.ID > b.ID {
+			a, b = b, a
+		}
+
+		entry := ConnectionEntry{
+			A: Endpoint{Device: a.DeviceName, Port: a.Name},
+			B: Endpoint{Device: b.DeviceName, Port: b.Name},
+		}
+
+		// Attach any available cable metadata
+		if a.Label != "" || a.Status != "" {
+			entry.Cable = &CableProps{
+				Label:  a.Label,
+				Status: a.Status,
+			}
+		}
+
+		entries = append(entries, entry)
+	}
+
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("no cable connections found in CSV (0 interfaces with cable_peer)")
+	}
+
+	return &ConnectionMap{
+		Version:     "v1",
+		Connections: entries,
+	}, nil
+}
+
+// getField safely retrieves a column value from a CSV record.
+// Returns empty string if the column doesn't exist or the record is
+// too short. Trims whitespace and treats "NULL" as empty.
+func getField(record []string, idx map[string]int, col string) string {
+	i, ok := idx[col]
+	if !ok || i >= len(record) {
+		return ""
+	}
+	val := strings.TrimSpace(record[i])
+	if val == "NULL" {
+		return ""
+	}
+	return val
+}

--- a/pkg/devicetypes/connections/csv_test.go
+++ b/pkg/devicetypes/connections/csv_test.go
@@ -1,0 +1,310 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package connections
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseInterfacesCSV_SkipsUncabled(t *testing.T) {
+	csv := `name,device__name,id,cable_peer,cable__pk,type,status__name,label
+iLO,GH-x3701u34,aaaa0001-0000-0000-0000-000000000001,aaaa0002-0000-0000-0000-000000000001,cccc0001-0000-0000-0000-000000000001,1000base-t,Active,
+1,MAN-x3701u48,aaaa0002-0000-0000-0000-000000000001,aaaa0001-0000-0000-0000-000000000001,cccc0001-0000-0000-0000-000000000001,1000base-t,Active,
+2,MAN-x3701u48,aaaa0099-0000-0000-0000-000000000001,NULL,NULL,1000base-t,Active,
+3,MAN-x3701u48,aaaa0098-0000-0000-0000-000000000001,,NULL,1000base-t,Active,
+`
+	cm, err := ParseInterfacesCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("ParseInterfacesCSV: %v", err)
+	}
+
+	// Should only get 1 connection (the cabled pair), not the uncabled rows
+	if got := len(cm.Connections); got != 1 {
+		t.Fatalf("connections = %d, want 1", got)
+	}
+}
+
+func TestParseInterfacesCSV_Dedup(t *testing.T) {
+	// Same cable appears from both sides — should produce exactly 1 connection
+	csv := `name,device__name,id,cable_peer
+port1,switch-a,id-aaa,id-bbb
+port2,switch-b,id-bbb,id-aaa
+`
+	cm, err := ParseInterfacesCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("ParseInterfacesCSV: %v", err)
+	}
+	if got := len(cm.Connections); got != 1 {
+		t.Errorf("connections = %d, want 1 (dedup failed)", got)
+	}
+}
+
+func TestParseInterfacesCSV_MissingColumns(t *testing.T) {
+	csv := `name,device__name,id
+port1,switch-a,id-aaa
+`
+	_, err := ParseInterfacesCSV(strings.NewReader(csv))
+	if err == nil {
+		t.Fatal("expected error for missing cable_peer column")
+	}
+	if !strings.Contains(err.Error(), "cable_peer") {
+		t.Errorf("error should mention cable_peer, got: %v", err)
+	}
+}
+
+func TestParseInterfacesCSV_MinimalColumns(t *testing.T) {
+	// Only the 4 required columns — no optional ones
+	csv := `name,device__name,id,cable_peer
+port1,switch-a,id-aaa,id-bbb
+port2,switch-b,id-bbb,id-aaa
+`
+	cm, err := ParseInterfacesCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("ParseInterfacesCSV: %v", err)
+	}
+	if got := len(cm.Connections); got != 1 {
+		t.Errorf("connections = %d, want 1", got)
+	}
+	c := cm.Connections[0]
+	// Verify device and port names are populated
+	if c.A.Device == "" || c.A.Port == "" || c.B.Device == "" || c.B.Port == "" {
+		t.Errorf("endpoints not fully populated: A=%+v, B=%+v", c.A, c.B)
+	}
+}
+
+func TestParseInterfacesCSV_NoCabledRows(t *testing.T) {
+	csv := `name,device__name,id,cable_peer
+port1,switch-a,id-aaa,NULL
+port2,switch-b,id-bbb,
+`
+	_, err := ParseInterfacesCSV(strings.NewReader(csv))
+	if err == nil {
+		t.Fatal("expected error when no cables found")
+	}
+}
+
+func TestParseInterfacesCSV_EmptyFile(t *testing.T) {
+	_, err := ParseInterfacesCSV(strings.NewReader(""))
+	if err == nil {
+		t.Fatal("expected error on empty input")
+	}
+}
+
+func TestParseInterfacesCSV_PartialExport(t *testing.T) {
+	// Peer id-ccc is not in the export — should be silently skipped
+	csv := `name,device__name,id,cable_peer
+port1,switch-a,id-aaa,id-bbb
+port2,switch-b,id-bbb,id-aaa
+port3,switch-c,id-ccc-has-peer,id-ddd-missing
+`
+	cm, err := ParseInterfacesCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("ParseInterfacesCSV: %v", err)
+	}
+	// Only the aaa<->bbb pair should be included
+	if got := len(cm.Connections); got != 1 {
+		t.Errorf("connections = %d, want 1 (partial export)", got)
+	}
+}
+
+// ── ParseConnectionsCSV (human-friendly) ─────────────────────────
+
+func TestParseConnectionsCSV_Defaults(t *testing.T) {
+	csv := `a_device,a_port,b_device,b_port,type,color,status,length_unit
+_defaults,,,,cat6a,blue,Connected,m
+switch-a,1,switch-b,1,,,,
+switch-a,2,switch-b,2,fiber,red,,
+`
+	cm, err := ParseConnectionsCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("ParseConnectionsCSV: %v", err)
+	}
+
+	if cm.CableDefaults == nil {
+		t.Fatal("expected CableDefaults")
+	}
+	if cm.CableDefaults.Type != "cat6a" {
+		t.Errorf("default type = %q, want cat6a", cm.CableDefaults.Type)
+	}
+	if cm.CableDefaults.Color != "blue" {
+		t.Errorf("default color = %q, want blue", cm.CableDefaults.Color)
+	}
+	if cm.CableDefaults.Status != "Connected" {
+		t.Errorf("default status = %q, want Connected", cm.CableDefaults.Status)
+	}
+	if cm.CableDefaults.LengthUnit != "m" {
+		t.Errorf("default length_unit = %q, want m", cm.CableDefaults.LengthUnit)
+	}
+
+	// 2 connections (defaults row not counted)
+	if got := len(cm.Connections); got != 2 {
+		t.Fatalf("connections = %d, want 2", got)
+	}
+
+	// Row 1 has no per-row cable props — Cable should be nil (defaults apply at resolve time)
+	if cm.Connections[0].Cable != nil {
+		t.Error("expected nil Cable on row with no per-row props")
+	}
+
+	// Row 2 overrides type and color
+	c1 := cm.Connections[1]
+	if c1.Cable == nil || c1.Cable.Type != "fiber" {
+		t.Errorf("row 2 cable type = %v, want fiber", c1.Cable)
+	}
+	if c1.Cable.Color != "red" {
+		t.Errorf("row 2 cable color = %q, want red", c1.Cable.Color)
+	}
+}
+
+func TestParseConnectionsCSV_MinimalColumns(t *testing.T) {
+	csv := `a_device,a_port,b_device,b_port
+switch-a,1,switch-b,1
+switch-a,2,switch-b,2
+`
+	cm, err := ParseConnectionsCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("ParseConnectionsCSV: %v", err)
+	}
+	if got := len(cm.Connections); got != 2 {
+		t.Errorf("connections = %d, want 2", got)
+	}
+	// No cable props when optional columns absent
+	if cm.Connections[0].Cable != nil {
+		t.Error("expected nil Cable when no optional columns")
+	}
+}
+
+func TestParseConnectionsCSV_SkipsIncomplete(t *testing.T) {
+	csv := `a_device,a_port,b_device,b_port
+switch-a,1,switch-b,1
+switch-a,,switch-b,2
+,1,switch-b,3
+`
+	cm, err := ParseConnectionsCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("ParseConnectionsCSV: %v", err)
+	}
+	if got := len(cm.Connections); got != 1 {
+		t.Errorf("connections = %d, want 1 (skip incomplete)", got)
+	}
+}
+
+func TestParseConnectionsCSV_MissingColumns(t *testing.T) {
+	csv := `a_device,a_port,b_device
+switch-a,1,switch-b
+`
+	_, err := ParseConnectionsCSV(strings.NewReader(csv))
+	if err == nil {
+		t.Fatal("expected error for missing b_port column")
+	}
+	if !strings.Contains(err.Error(), "b_port") {
+		t.Errorf("error should mention b_port, got: %v", err)
+	}
+}
+
+func TestParseConnectionsCSV_NoRows(t *testing.T) {
+	csv := `a_device,a_port,b_device,b_port
+`
+	_, err := ParseConnectionsCSV(strings.NewReader(csv))
+	if err == nil {
+		t.Fatal("expected error when no data rows")
+	}
+}
+
+func TestParseConnectionsCSV_CableProps(t *testing.T) {
+	csv := `a_device,a_port,b_device,b_port,type,label,color,length,length_unit,status
+switch-a,1,switch-b,1,cat6,uplink,blue,3,m,Active
+`
+	cm, err := ParseConnectionsCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("ParseConnectionsCSV: %v", err)
+	}
+	c := cm.Connections[0]
+	if c.Cable == nil {
+		t.Fatal("expected Cable to be populated")
+	}
+	if c.Cable.Type != "cat6" {
+		t.Errorf("cable type = %q, want cat6", c.Cable.Type)
+	}
+	if c.Cable.Label != "uplink" {
+		t.Errorf("cable label = %q, want uplink", c.Cable.Label)
+	}
+	if c.Cable.Color != "blue" {
+		t.Errorf("cable color = %q, want blue", c.Cable.Color)
+	}
+	if c.Cable.Length == nil || *c.Cable.Length != 3.0 {
+		t.Errorf("cable length = %v, want 3.0", c.Cable.Length)
+	}
+	if c.Cable.LengthUnit != "m" {
+		t.Errorf("cable length_unit = %q, want m", c.Cable.LengthUnit)
+	}
+	if c.Cable.Status != "Active" {
+		t.Errorf("cable status = %q, want Active", c.Cable.Status)
+	}
+}
+
+// ── ParseCSV (auto-detection) ────────────────────────────────────
+
+func TestParseCSV_DetectsHumanFormat(t *testing.T) {
+	csv := `a_device,a_port,b_device,b_port
+switch-a,1,switch-b,1
+`
+	cm, err := ParseCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("ParseCSV: %v", err)
+	}
+	if got := len(cm.Connections); got != 1 {
+		t.Errorf("connections = %d, want 1", got)
+	}
+}
+
+func TestParseCSV_DetectsNautobotFormat(t *testing.T) {
+	csv := `name,device__name,id,cable_peer
+port1,switch-a,id-aaa,id-bbb
+port2,switch-b,id-bbb,id-aaa
+`
+	cm, err := ParseCSV(strings.NewReader(csv))
+	if err != nil {
+		t.Fatalf("ParseCSV: %v", err)
+	}
+	if got := len(cm.Connections); got != 1 {
+		t.Errorf("connections = %d, want 1", got)
+	}
+}
+
+func TestParseCSV_UnknownFormat(t *testing.T) {
+	csv := `foo,bar,baz
+1,2,3
+`
+	_, err := ParseCSV(strings.NewReader(csv))
+	if err == nil {
+		t.Fatal("expected error for unknown CSV format")
+	}
+	if !strings.Contains(err.Error(), "not recognized") {
+		t.Errorf("error should mention format not recognized, got: %v", err)
+	}
+}

--- a/pkg/devicetypes/connections/csv_write.go
+++ b/pkg/devicetypes/connections/csv_write.go
@@ -1,0 +1,99 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package connections
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+)
+
+// csvHeader is the column order for human-friendly connection CSV files.
+var csvHeader = []string{
+	"a_device", "a_port", "b_device", "b_port",
+	"type", "label", "color", "length", "length_unit", "status",
+}
+
+// WriteCSV writes a ConnectionMap as a human-friendly CSV to w.
+// The format is round-trippable with ParseConnectionsCSV.
+func WriteCSV(w io.Writer, cm ConnectionMap) error {
+	writer := csv.NewWriter(w)
+
+	if err := writer.Write(csvHeader); err != nil {
+		return fmt.Errorf("writing CSV header: %w", err)
+	}
+
+	if cm.CableDefaults != nil {
+		row := []string{
+			"_defaults", "", "", "",
+			cm.CableDefaults.Type,
+			"",
+			cm.CableDefaults.Color,
+			"",
+			cm.CableDefaults.LengthUnit,
+			cm.CableDefaults.Status,
+		}
+		if err := writer.Write(row); err != nil {
+			return fmt.Errorf("writing CSV defaults row: %w", err)
+		}
+	}
+
+	for _, entry := range cm.Connections {
+		row := []string{
+			entry.A.Device,
+			entry.A.Port,
+			entry.B.Device,
+			entry.B.Port,
+			"", "", "", "", "", "",
+		}
+
+		if entry.Cable != nil {
+			row[4] = entry.Cable.Type
+			row[5] = entry.Cable.Label
+			row[6] = entry.Cable.Color
+			if entry.Cable.Length != nil {
+				row[7] = formatLength(*entry.Cable.Length)
+			}
+			row[8] = entry.Cable.LengthUnit
+			row[9] = entry.Cable.Status
+		}
+
+		if err := writer.Write(row); err != nil {
+			return fmt.Errorf("writing CSV row: %w", err)
+		}
+	}
+
+	writer.Flush()
+	return writer.Error()
+}
+
+// formatLength formats a float64 length, using integer notation when possible.
+func formatLength(v float64) string {
+	if v == float64(int64(v)) {
+		return fmt.Sprintf("%d", int64(v))
+	}
+	return fmt.Sprintf("%g", v)
+}

--- a/pkg/devicetypes/connections/csv_write_test.go
+++ b/pkg/devicetypes/connections/csv_write_test.go
@@ -1,0 +1,148 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package connections
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestWriteCSV_Basic(t *testing.T) {
+	length := 3.0
+	cm := ConnectionMap{
+		Version: "v1",
+		Connections: []ConnectionEntry{
+			{
+				A: Endpoint{Device: "sw-leaf01", Port: "1/1/1"},
+				B: Endpoint{Device: "node01", Port: "HSN 0"},
+				Cable: &CableProps{
+					Type:       "cat6a",
+					Label:      "mgmt",
+					Length:     &length,
+					LengthUnit: "m",
+					Status:     "Connected",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteCSV(&buf, cm); err != nil {
+		t.Fatalf("WriteCSV: %v", err)
+	}
+
+	got := buf.String()
+	lines := strings.Split(strings.TrimSpace(got), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (header + 1 row), got %d:\n%s", len(lines), got)
+	}
+
+	wantHeader := "a_device,a_port,b_device,b_port,type,label,color,length,length_unit,status"
+	if lines[0] != wantHeader {
+		t.Errorf("header = %q, want %q", lines[0], wantHeader)
+	}
+
+	wantRow := "sw-leaf01,1/1/1,node01,HSN 0,cat6a,mgmt,,3,m,Connected"
+	if lines[1] != wantRow {
+		t.Errorf("row = %q, want %q", lines[1], wantRow)
+	}
+}
+
+func TestWriteCSV_WithDefaults(t *testing.T) {
+	cm := ConnectionMap{
+		Version: "v1",
+		CableDefaults: &CableDefaults{
+			Status:     "Connected",
+			LengthUnit: "m",
+		},
+		Connections: []ConnectionEntry{
+			{
+				A: Endpoint{Device: "sw01", Port: "1"},
+				B: Endpoint{Device: "sw02", Port: "1"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteCSV(&buf, cm); err != nil {
+		t.Fatalf("WriteCSV: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (header + defaults + 1 row), got %d:\n%s", len(lines), buf.String())
+	}
+
+	if !strings.HasPrefix(lines[1], "_defaults,") {
+		t.Errorf("defaults row = %q, expected prefix '_defaults,'", lines[1])
+	}
+}
+
+func TestWriteCSV_RoundTrip(t *testing.T) {
+	length := 15.0
+	cm := ConnectionMap{
+		Version: "v1",
+		CableDefaults: &CableDefaults{
+			Status: "Connected",
+		},
+		Connections: []ConnectionEntry{
+			{
+				A:     Endpoint{Device: "sw01", Port: "1/1/1"},
+				B:     Endpoint{Device: "sw02", Port: "1/1/25"},
+				Cable: &CableProps{Type: "cat6a", Length: &length, LengthUnit: "m"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteCSV(&buf, cm); err != nil {
+		t.Fatalf("WriteCSV: %v", err)
+	}
+
+	parsed, err := ParseConnectionsCSV(strings.NewReader(buf.String()))
+	if err != nil {
+		t.Fatalf("ParseConnectionsCSV round-trip: %v", err)
+	}
+
+	if len(parsed.Connections) != 1 {
+		t.Fatalf("expected 1 connection, got %d", len(parsed.Connections))
+	}
+
+	entry := parsed.Connections[0]
+	if entry.A.Device != "sw01" || entry.A.Port != "1/1/1" {
+		t.Errorf("A endpoint = %+v, want {sw01, 1/1/1}", entry.A)
+	}
+	if entry.B.Device != "sw02" || entry.B.Port != "1/1/25" {
+		t.Errorf("B endpoint = %+v, want {sw02, 1/1/25}", entry.B)
+	}
+	if entry.Cable == nil || entry.Cable.Type != "cat6a" {
+		t.Errorf("cable type = %v, want cat6a", entry.Cable)
+	}
+	if parsed.CableDefaults == nil || parsed.CableDefaults.Status != "Connected" {
+		t.Errorf("cable defaults = %+v, want Status=Connected", parsed.CableDefaults)
+	}
+}

--- a/pkg/devicetypes/connections/export.go
+++ b/pkg/devicetypes/connections/export.go
@@ -1,0 +1,93 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package connections
+
+import (
+	"sort"
+
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	"github.com/google/uuid"
+)
+
+// InventoryToConnectionMap converts inventory cables into a ConnectionMap.
+// Output is sorted by cable UUID for deterministic results.
+func InventoryToConnectionMap(inv *devicetypes.Inventory) ConnectionMap {
+	cm := ConnectionMap{Version: "v1"}
+
+	// Sort cable IDs for deterministic output.
+	cableIDs := make([]uuid.UUID, 0, len(inv.Cables))
+	for id := range inv.Cables {
+		cableIDs = append(cableIDs, id)
+	}
+	sort.Slice(cableIDs, func(i, j int) bool {
+		return cableIDs[i].String() < cableIDs[j].String()
+	})
+
+	for _, id := range cableIDs {
+		cable := inv.Cables[id]
+		if cable == nil {
+			continue
+		}
+
+		entry := ConnectionEntry{
+			A: Endpoint{
+				Device: resolveDeviceName(cable.TerminationADevice, inv),
+				Port:   cable.TerminationAPort,
+			},
+			B: Endpoint{
+				Device: resolveDeviceName(cable.TerminationBDevice, inv),
+				Port:   cable.TerminationBPort,
+			},
+		}
+
+		// Only emit cable props when they differ from empty defaults.
+		if cable.Slug != "" || cable.Label != "" || cable.Color != "" || cable.Length != nil {
+			entry.Cable = &CableProps{
+				Type:       cable.Slug,
+				Label:      cable.Label,
+				Color:      cable.Color,
+				Length:     cable.Length,
+				LengthUnit: cable.LengthUnit,
+			}
+		}
+
+		cm.Connections = append(cm.Connections, entry)
+	}
+
+	return cm
+}
+
+// resolveDeviceName returns the device name for a UUID, falling back to
+// the UUID string if the device is not in the inventory.
+func resolveDeviceName(id uuid.UUID, inv *devicetypes.Inventory) string {
+	if id == uuid.Nil {
+		return ""
+	}
+	if dev, ok := inv.Devices[id]; ok && dev.Name != "" {
+		return dev.Name
+	}
+	return id.String()
+}

--- a/pkg/devicetypes/connections/resolve.go
+++ b/pkg/devicetypes/connections/resolve.go
@@ -1,0 +1,179 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package connections
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Cray-HPE/cani/internal/util/nameexpand"
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	"github.com/google/uuid"
+)
+
+// ResolvedConnection is a single fully-resolved cable ready to be added
+// to the inventory.
+type ResolvedConnection struct {
+	ADevice uuid.UUID
+	APort   string
+	BDevice uuid.UUID
+	BPort   string
+	Cable   CableProps
+}
+
+// ResolveConnectionMap expands patterns and resolves device names in a
+// ConnectionMap against the inventory, returning a flat list of concrete
+// cable connections. Errors are collected per-entry so the caller can
+// report all problems at once.
+func ResolveConnectionMap(cm *ConnectionMap, inv *devicetypes.Inventory) ([]ResolvedConnection, []error) {
+	var resolved []ResolvedConnection
+	var errs []error
+
+	for i, entry := range cm.Connections {
+		conns, err := resolveEntry(entry, cm.CableDefaults, inv)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("connection[%d]: %w", i, err))
+			continue
+		}
+		resolved = append(resolved, conns...)
+	}
+	return resolved, errs
+}
+
+// resolveEntry expands a single ConnectionEntry into one or more
+// ResolvedConnections using brace expansion + zip semantics.
+func resolveEntry(entry ConnectionEntry, defaults *CableDefaults, inv *devicetypes.Inventory) ([]ResolvedConnection, error) {
+	aDevices := expandPattern(entry.A.Device)
+	aPorts := expandPattern(entry.A.Port)
+	bDevices := expandPattern(entry.B.Device)
+	bPorts := expandPattern(entry.B.Port)
+
+	count, err := ZipCount(len(aDevices), len(aPorts), len(bDevices), len(bPorts))
+	if err != nil {
+		return nil, err
+	}
+
+	aDevices = Broadcast(aDevices, count)
+	aPorts = Broadcast(aPorts, count)
+	bDevices = Broadcast(bDevices, count)
+	bPorts = Broadcast(bPorts, count)
+
+	result := make([]ResolvedConnection, 0, count)
+	for i := range count {
+		aDev := inv.FindDeviceByNameOrID(aDevices[i])
+		if aDev == nil {
+			return nil, fmt.Errorf("device not found: %s", aDevices[i])
+		}
+		bDev := inv.FindDeviceByNameOrID(bDevices[i])
+		if bDev == nil {
+			return nil, fmt.Errorf("device not found: %s", bDevices[i])
+		}
+		result = append(result, ResolvedConnection{
+			ADevice: aDev.ID,
+			APort:   aPorts[i],
+			BDevice: bDev.ID,
+			BPort:   bPorts[i],
+			Cable:   mergeProps(entry.Cable, defaults),
+		})
+	}
+	return result, nil
+}
+
+// expandPattern expands a brace pattern or returns a single-element slice.
+func expandPattern(s string) []string {
+	if s == "" {
+		return []string{""}
+	}
+	if strings.Contains(s, "{") && strings.Contains(s, "}") {
+		expanded, err := nameexpand.Expand(s)
+		if err == nil && len(expanded) > 0 {
+			return expanded
+		}
+	}
+	return []string{s}
+}
+
+// ZipCount determines the aligned count from multiple list lengths.
+// All lengths > 1 must agree; lengths of 0 or 1 are broadcast.
+func ZipCount(lengths ...int) (int, error) {
+	maxLen := 1
+	for _, l := range lengths {
+		if l > 1 {
+			if maxLen > 1 && l != maxLen {
+				return 0, fmt.Errorf("pattern length mismatch: %d vs %d", maxLen, l)
+			}
+			maxLen = l
+		}
+	}
+	return maxLen, nil
+}
+
+// Broadcast replicates a single-element slice to length n.
+func Broadcast(s []string, n int) []string {
+	if len(s) == n {
+		return s
+	}
+	out := make([]string, n)
+	if len(s) == 1 {
+		for i := range out {
+			out[i] = s[0]
+		}
+	}
+	return out
+}
+
+// mergeProps combines per-entry cable props with defaults.
+// Per-entry values override defaults.
+func mergeProps(entry *CableProps, defaults *CableDefaults) CableProps {
+	var p CableProps
+	if defaults != nil {
+		p.Type = defaults.Type
+		p.Status = defaults.Status
+		p.Color = defaults.Color
+		p.LengthUnit = defaults.LengthUnit
+	}
+	if entry != nil {
+		if entry.Type != "" {
+			p.Type = entry.Type
+		}
+		if entry.Label != "" {
+			p.Label = entry.Label
+		}
+		if entry.Color != "" {
+			p.Color = entry.Color
+		}
+		if entry.Length != nil {
+			p.Length = entry.Length
+		}
+		if entry.LengthUnit != "" {
+			p.LengthUnit = entry.LengthUnit
+		}
+		if entry.Status != "" {
+			p.Status = entry.Status
+		}
+	}
+	return p
+}

--- a/pkg/devicetypes/connections/resolve_test.go
+++ b/pkg/devicetypes/connections/resolve_test.go
@@ -1,0 +1,249 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package connections
+
+import (
+	"testing"
+
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	"github.com/google/uuid"
+)
+
+func testInventoryWithDevices(names ...string) *devicetypes.Inventory {
+	inv := devicetypes.NewInventory()
+	for _, name := range names {
+		id := uuid.New()
+		inv.Devices[id] = &devicetypes.CaniDeviceType{
+			ID:   id,
+			Name: name,
+			Interfaces: []devicetypes.InterfaceSpec{
+				{ID: uuid.New(), Name: "eth0", Type: devicetypes.InterfacesElemTypeA1000BaseT},
+				{ID: uuid.New(), Name: "eth1", Type: devicetypes.InterfacesElemTypeA1000BaseT},
+			},
+		}
+	}
+	return inv
+}
+
+func TestResolveConnectionMap_SingleConnection(t *testing.T) {
+	inv := testInventoryWithDevices("node-01", "switch-01")
+
+	cm := &ConnectionMap{
+		Version: "v1",
+		Connections: []ConnectionEntry{
+			{
+				A: Endpoint{Device: "node-01", Port: "eth0"},
+				B: Endpoint{Device: "switch-01", Port: "eth1"},
+			},
+		},
+	}
+
+	resolved, errs := ResolveConnectionMap(cm, inv)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 connection, got %d", len(resolved))
+	}
+	if resolved[0].APort != "eth0" || resolved[0].BPort != "eth1" {
+		t.Errorf("unexpected ports: %s -> %s", resolved[0].APort, resolved[0].BPort)
+	}
+}
+
+func TestResolveConnectionMap_PatternExpansion(t *testing.T) {
+	inv := testInventoryWithDevices("node-01", "node-02", "node-03", "switch-01")
+
+	cm := &ConnectionMap{
+		Version: "v1",
+		Connections: []ConnectionEntry{
+			{
+				A: Endpoint{Device: "node-{01..03}", Port: "eth0"},
+				B: Endpoint{Device: "switch-01", Port: "eth{1..3}"},
+			},
+		},
+	}
+
+	resolved, errs := ResolveConnectionMap(cm, inv)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(resolved) != 3 {
+		t.Fatalf("expected 3 connections, got %d", len(resolved))
+	}
+
+	expectedPorts := []string{"eth1", "eth2", "eth3"}
+	for i, conn := range resolved {
+		if conn.APort != "eth0" {
+			t.Errorf("connection[%d]: expected A port eth0, got %s", i, conn.APort)
+		}
+		if conn.BPort != expectedPorts[i] {
+			t.Errorf("connection[%d]: expected B port %s, got %s", i, expectedPorts[i], conn.BPort)
+		}
+	}
+}
+
+func TestResolveConnectionMap_DeviceNotFound(t *testing.T) {
+	inv := testInventoryWithDevices("node-01")
+
+	cm := &ConnectionMap{
+		Version: "v1",
+		Connections: []ConnectionEntry{
+			{
+				A: Endpoint{Device: "node-01", Port: "eth0"},
+				B: Endpoint{Device: "nonexistent", Port: "eth0"},
+			},
+		},
+	}
+
+	resolved, errs := ResolveConnectionMap(cm, inv)
+	if len(errs) == 0 {
+		t.Fatal("expected errors for missing device")
+	}
+	if len(resolved) != 0 {
+		t.Errorf("expected 0 resolved connections, got %d", len(resolved))
+	}
+}
+
+func TestResolveConnectionMap_CableDefaults(t *testing.T) {
+	inv := testInventoryWithDevices("node-01", "switch-01")
+
+	cm := &ConnectionMap{
+		Version:       "v1",
+		CableDefaults: &CableDefaults{Type: "cat6a", Status: "connected", Color: "blue"},
+		Connections: []ConnectionEntry{
+			{
+				A: Endpoint{Device: "node-01", Port: "eth0"},
+				B: Endpoint{Device: "switch-01", Port: "eth0"},
+			},
+		},
+	}
+
+	resolved, errs := ResolveConnectionMap(cm, inv)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if resolved[0].Cable.Type != "cat6a" {
+		t.Errorf("expected cable type cat6a, got %s", resolved[0].Cable.Type)
+	}
+	if resolved[0].Cable.Color != "blue" {
+		t.Errorf("expected cable color blue, got %s", resolved[0].Cable.Color)
+	}
+}
+
+func TestResolveConnectionMap_PerEntryOverride(t *testing.T) {
+	inv := testInventoryWithDevices("node-01", "switch-01")
+
+	length := 3.0
+	cm := &ConnectionMap{
+		Version:       "v1",
+		CableDefaults: &CableDefaults{Type: "cat6a", Color: "blue"},
+		Connections: []ConnectionEntry{
+			{
+				A:     Endpoint{Device: "node-01", Port: "eth0"},
+				B:     Endpoint{Device: "switch-01", Port: "eth0"},
+				Cable: &CableProps{Type: "dac-passive", Length: &length},
+			},
+		},
+	}
+
+	resolved, errs := ResolveConnectionMap(cm, inv)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	c := resolved[0].Cable
+	if c.Type != "dac-passive" {
+		t.Errorf("expected type override dac-passive, got %s", c.Type)
+	}
+	if c.Color != "blue" {
+		t.Errorf("expected inherited color blue, got %s", c.Color)
+	}
+	if c.Length == nil || *c.Length != 3.0 {
+		t.Errorf("expected length 3.0, got %v", c.Length)
+	}
+}
+
+func TestResolveConnectionMap_PatternLengthMismatch(t *testing.T) {
+	inv := testInventoryWithDevices("node-01", "node-02", "switch-01")
+
+	cm := &ConnectionMap{
+		Version: "v1",
+		Connections: []ConnectionEntry{
+			{
+				A: Endpoint{Device: "node-{01..02}", Port: "eth0"},
+				B: Endpoint{Device: "switch-01", Port: "eth{1..3}"},
+			},
+		},
+	}
+
+	_, errs := ResolveConnectionMap(cm, inv)
+	if len(errs) == 0 {
+		t.Fatal("expected error for pattern length mismatch")
+	}
+}
+
+func TestZipCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		lengths []int
+		want    int
+		wantErr bool
+	}{
+		{"all ones", []int{1, 1, 1, 1}, 1, false},
+		{"one expanded", []int{4, 1, 1, 1}, 4, false},
+		{"two matching", []int{4, 1, 4, 1}, 4, false},
+		{"mismatch", []int{3, 1, 4, 1}, 0, true},
+		{"all zero", []int{0, 0, 0, 0}, 1, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ZipCount(tt.lengths...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ZipCount() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("ZipCount() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBroadcast(t *testing.T) {
+	result := Broadcast([]string{"x"}, 3)
+	if len(result) != 3 || result[0] != "x" || result[2] != "x" {
+		t.Errorf("Broadcast single: got %v", result)
+	}
+
+	result = Broadcast([]string{"a", "b", "c"}, 3)
+	if len(result) != 3 || result[0] != "a" {
+		t.Errorf("Broadcast passthrough: got %v", result)
+	}
+
+	result = Broadcast(nil, 2)
+	if len(result) != 2 || result[0] != "" {
+		t.Errorf("Broadcast nil: got %v", result)
+	}
+}

--- a/pkg/devicetypes/connections/topology.go
+++ b/pkg/devicetypes/connections/topology.go
@@ -1,0 +1,146 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package connections
+
+import (
+	"fmt"
+)
+
+// TopologyStarParams configures a star (hub-spoke) topology.
+type TopologyStarParams struct {
+	Hub       string // Hub device name
+	HubPorts  string // Port pattern on hub (e.g. "eth{1..48}")
+	Spokes    string // Spoke device pattern (e.g. "node-{01..48}")
+	SpokePort string // Port name on each spoke (e.g. "eth0")
+}
+
+// GenerateStarTopology creates connections for a star topology where
+// every spoke connects to a single hub. Hub ports and spoke devices
+// are expanded and zipped.
+func GenerateStarTopology(p TopologyStarParams) ([]ConnectionEntry, error) {
+	if p.Hub == "" || p.Spokes == "" {
+		return nil, fmt.Errorf("hub and spokes are required")
+	}
+	spokePort := p.SpokePort
+	if spokePort == "" {
+		spokePort = "eth0"
+	}
+	hubPorts := p.HubPorts
+	if hubPorts == "" {
+		hubPorts = "auto"
+	}
+	return []ConnectionEntry{
+		{
+			A: Endpoint{Device: p.Spokes, Port: spokePort},
+			B: Endpoint{Device: p.Hub, Port: hubPorts},
+		},
+	}, nil
+}
+
+// TopologyLeafSpineParams configures a leaf-spine fabric topology.
+type TopologyLeafSpineParams struct {
+	Leaves         []string // Leaf switch names
+	Spines         []string // Spine switch names
+	UplinksPerLeaf int      // Number of uplinks from each leaf to each spine
+	LeafUplinkPort string   // Port pattern on leaves (e.g. "eth49")
+	SpinePort      string   // Port pattern on spines (e.g. "eth1")
+}
+
+// GenerateLeafSpineTopology creates connections for a leaf-spine fabric.
+// Each leaf connects to every spine with UplinksPerLeaf links.
+func GenerateLeafSpineTopology(p TopologyLeafSpineParams) ([]ConnectionEntry, error) {
+	if len(p.Leaves) == 0 || len(p.Spines) == 0 {
+		return nil, fmt.Errorf("at least one leaf and one spine are required")
+	}
+	uplinks := p.UplinksPerLeaf
+	if uplinks < 1 {
+		uplinks = 1
+	}
+
+	var entries []ConnectionEntry
+	spinePort := 1
+	for _, leaf := range p.Leaves {
+		leafPort := 49 // conventional first uplink port
+		if p.LeafUplinkPort != "" {
+			leafPort = 0 // will use explicit pattern
+		}
+		for _, spine := range p.Spines {
+			for u := range uplinks {
+				aPort := p.LeafUplinkPort
+				if aPort == "" {
+					aPort = fmt.Sprintf("eth%d", leafPort+u)
+				}
+				bPort := p.SpinePort
+				if bPort == "" {
+					bPort = fmt.Sprintf("eth%d", spinePort)
+				}
+				entries = append(entries, ConnectionEntry{
+					A: Endpoint{Device: leaf, Port: aPort},
+					B: Endpoint{Device: spine, Port: bPort},
+				})
+				spinePort++
+			}
+			if p.LeafUplinkPort == "" {
+				leafPort += uplinks
+			}
+		}
+	}
+	return entries, nil
+}
+
+// TopologyRingParams configures a ring topology.
+type TopologyRingParams struct {
+	Devices []string // Ordered device names forming the ring
+	PortA   string   // Port used for the "next" link
+	PortB   string   // Port used for the "prev" link
+}
+
+// GenerateRingTopology creates connections that form a ring where each
+// device connects to its neighbor. The last device connects back to
+// the first.
+func GenerateRingTopology(p TopologyRingParams) ([]ConnectionEntry, error) {
+	if len(p.Devices) < 2 {
+		return nil, fmt.Errorf("ring topology requires at least 2 devices")
+	}
+	portA := p.PortA
+	if portA == "" {
+		portA = "eth0"
+	}
+	portB := p.PortB
+	if portB == "" {
+		portB = "eth1"
+	}
+
+	entries := make([]ConnectionEntry, len(p.Devices))
+	for i := range p.Devices {
+		next := (i + 1) % len(p.Devices)
+		entries[i] = ConnectionEntry{
+			A: Endpoint{Device: p.Devices[i], Port: portA},
+			B: Endpoint{Device: p.Devices[next], Port: portB},
+		}
+	}
+	return entries, nil
+}

--- a/pkg/devicetypes/connections/topology_test.go
+++ b/pkg/devicetypes/connections/topology_test.go
@@ -1,0 +1,133 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package connections
+
+import "testing"
+
+func TestGenerateStarTopology(t *testing.T) {
+	entries, err := GenerateStarTopology(TopologyStarParams{
+		Hub:       "switch-01",
+		HubPorts:  "eth{1..4}",
+		Spokes:    "node-{01..04}",
+		SpokePort: "eth0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry (with patterns), got %d", len(entries))
+	}
+	if entries[0].A.Device != "node-{01..04}" {
+		t.Errorf("unexpected A device: %s", entries[0].A.Device)
+	}
+	if entries[0].B.Port != "eth{1..4}" {
+		t.Errorf("unexpected B port: %s", entries[0].B.Port)
+	}
+}
+
+func TestGenerateStarTopology_MissingParams(t *testing.T) {
+	_, err := GenerateStarTopology(TopologyStarParams{})
+	if err == nil {
+		t.Fatal("expected error for empty params")
+	}
+}
+
+func TestGenerateLeafSpineTopology(t *testing.T) {
+	entries, err := GenerateLeafSpineTopology(TopologyLeafSpineParams{
+		Leaves:         []string{"leaf-01", "leaf-02"},
+		Spines:         []string{"spine-01", "spine-02"},
+		UplinksPerLeaf: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 2 leaves x 2 spines x 1 uplink = 4 connections
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(entries))
+	}
+
+	if entries[0].A.Device != "leaf-01" || entries[0].B.Device != "spine-01" {
+		t.Errorf("entry[0]: %s -> %s", entries[0].A.Device, entries[0].B.Device)
+	}
+	if entries[1].A.Device != "leaf-01" || entries[1].B.Device != "spine-02" {
+		t.Errorf("entry[1]: %s -> %s", entries[1].A.Device, entries[1].B.Device)
+	}
+}
+
+func TestGenerateLeafSpineTopology_MultipleUplinks(t *testing.T) {
+	entries, err := GenerateLeafSpineTopology(TopologyLeafSpineParams{
+		Leaves:         []string{"leaf-01"},
+		Spines:         []string{"spine-01"},
+		UplinksPerLeaf: 2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries for 2 uplinks, got %d", len(entries))
+	}
+	if entries[0].A.Port != "eth49" {
+		t.Errorf("expected eth49, got %s", entries[0].A.Port)
+	}
+	if entries[1].A.Port != "eth50" {
+		t.Errorf("expected eth50, got %s", entries[1].A.Port)
+	}
+}
+
+func TestGenerateLeafSpineTopology_MissingParams(t *testing.T) {
+	_, err := GenerateLeafSpineTopology(TopologyLeafSpineParams{})
+	if err == nil {
+		t.Fatal("expected error for empty params")
+	}
+}
+
+func TestGenerateRingTopology(t *testing.T) {
+	devices := []string{"sw-01", "sw-02", "sw-03", "sw-04"}
+	entries, err := GenerateRingTopology(TopologyRingParams{
+		Devices: devices,
+		PortA:   "eth0",
+		PortB:   "eth1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(entries))
+	}
+	last := entries[3]
+	if last.A.Device != "sw-04" || last.B.Device != "sw-01" {
+		t.Errorf("ring wrap: %s -> %s", last.A.Device, last.B.Device)
+	}
+}
+
+func TestGenerateRingTopology_TooFew(t *testing.T) {
+	_, err := GenerateRingTopology(TopologyRingParams{
+		Devices: []string{"only-one"},
+	})
+	if err == nil {
+		t.Fatal("expected error for < 2 devices")
+	}
+}

--- a/pkg/devicetypes/connections/types.go
+++ b/pkg/devicetypes/connections/types.go
@@ -1,0 +1,69 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package connections
+
+// ConnectionMap is the top-level structure of a connection map YAML file.
+// It declaratively describes desired cable connections between devices
+// using human-readable names and brace-expansion patterns.
+type ConnectionMap struct {
+	Version       string            `yaml:"version" json:"version"`
+	CableDefaults *CableDefaults    `yaml:"cable_defaults,omitempty" json:"cable_defaults,omitempty"`
+	Connections   []ConnectionEntry `yaml:"connections" json:"connections"`
+}
+
+// CableDefaults provides default cable properties applied to every
+// connection that does not override them.
+type CableDefaults struct {
+	Type       string `yaml:"type,omitempty" json:"type,omitempty"`
+	Status     string `yaml:"status,omitempty" json:"status,omitempty"`
+	Color      string `yaml:"color,omitempty" json:"color,omitempty"`
+	LengthUnit string `yaml:"length_unit,omitempty" json:"length_unit,omitempty"`
+}
+
+// ConnectionEntry defines one or more cables between device/port pairs.
+// Device and port fields support brace-expansion patterns (e.g.
+// "node-{01..48}") for bulk connections with zip semantics.
+type ConnectionEntry struct {
+	A     Endpoint    `yaml:"a" json:"a"`
+	B     Endpoint    `yaml:"b" json:"b"`
+	Cable *CableProps `yaml:"cable,omitempty" json:"cable,omitempty"`
+}
+
+// Endpoint identifies one side of a cable connection.
+type Endpoint struct {
+	Device string `yaml:"device" json:"device"`
+	Port   string `yaml:"port" json:"port"`
+}
+
+// CableProps holds per-connection cable properties that override defaults.
+type CableProps struct {
+	Type       string   `yaml:"type,omitempty" json:"type,omitempty"`
+	Label      string   `yaml:"label,omitempty" json:"label,omitempty"`
+	Color      string   `yaml:"color,omitempty" json:"color,omitempty"`
+	Length     *float64 `yaml:"length,omitempty" json:"length,omitempty"`
+	LengthUnit string   `yaml:"length_unit,omitempty" json:"length_unit,omitempty"`
+	Status     string   `yaml:"status,omitempty" json:"status,omitempty"`
+}

--- a/pkg/devicetypes/inventory.go
+++ b/pkg/devicetypes/inventory.go
@@ -70,6 +70,7 @@ type TransformResult struct {
 	Modules   map[uuid.UUID]*CaniModuleType
 	Cables    map[uuid.UUID]*CaniCableType
 	Frus      map[uuid.UUID]*CaniFruType
+	Metadata  *InventoryMetadata
 }
 
 // EnsureUniqueDeviceNames detects duplicate names within the transform

--- a/pkg/devicetypes/module-types/NVIDIA/NVIDIA-ConnectX-6-DX-100GbE-2P-QSFP28.yaml
+++ b/pkg/devicetypes/module-types/NVIDIA/NVIDIA-ConnectX-6-DX-100GbE-2P-QSFP28.yaml
@@ -1,0 +1,35 @@
+#
+# MIT License
+#
+# (C) Copyright 2024-2026 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+---
+manufacturer: NVIDIA
+model: NVIDIA ConnectX-6 DX 100GbE Dual-Port QSFP28 Adapter
+slug: nvidia-connectx-6-dx-100gbe-2p-qsfp28
+part_number: MCX623106AC-CDAT
+description: "NVIDIA ConnectX-6 DX dual-port 100GbE QSFP28 PCIe Gen4 x16 SmartNIC. Supports RoCE, GPUDirect, and hardware offloads."
+type: nic
+interfaces:
+  - name: Port 1
+    type: 100gbase-x-qsfp28
+  - name: Port 2
+    type: 100gbase-x-qsfp28

--- a/pkg/provider/example/import/import.go
+++ b/pkg/provider/example/import/import.go
@@ -1,6 +1,7 @@
 package import_
 
 import (
+	"encoding/csv"
 	"fmt"
 	"log"
 	"os"
@@ -38,6 +39,51 @@ func GetProvider() interface {
 		panic("providerGetter not set; ensure example package init() calls SetProviderGetter")
 	}
 	return providerGetter()
+}
+
+// systemProviderGetter returns the Example singleton for system CSV operations.
+var systemProviderGetter func() interface {
+	SetSystemRecords(data *SystemCSV)
+	ClearSystemRecords()
+	IsSystemImport() bool
+}
+
+// SetSystemProviderGetter allows the parent package to provide system CSV access.
+func SetSystemProviderGetter(getter func() interface {
+	SetSystemRecords(data *SystemCSV)
+	ClearSystemRecords()
+	IsSystemImport() bool
+}) {
+	systemProviderGetter = getter
+}
+
+// GetSystemProvider returns the Example singleton for system CSV operations.
+func GetSystemProvider() interface {
+	SetSystemRecords(data *SystemCSV)
+	ClearSystemRecords()
+	IsSystemImport() bool
+} {
+	if systemProviderGetter == nil {
+		panic("systemProviderGetter not set; ensure example package init() calls SetSystemProviderGetter")
+	}
+	return systemProviderGetter()
+}
+
+// peekCSVHeader reads the first line of a CSV file and returns the header fields.
+func peekCSVHeader(filePath string) ([]string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	reader.Comment = '#'
+	header, err := reader.Read()
+	if err != nil {
+		return nil, err
+	}
+	return header, nil
 }
 
 // yamlInventory is an intermediate struct for YAML parsing with string keys
@@ -175,9 +221,48 @@ func mergeYAMLInventory(dst *devicetypes.Inventory, src *yamlInventory) error {
 }
 
 // ImportCSV parses a CSV file and stores raw records on the Example provider.
-// Does NOT create inventory objects; that is the responsibility of the transform phase.
-// When config.Cfg.StepMode is true, displays colorful step output for each record.
+// Auto-detects system CSV format (multi-section with Section column) vs
+// traditional BOM CSV format. Does NOT create inventory objects; that is the
+// responsibility of the transform phase.
 func ImportCSV(cmd *cobra.Command, args []string, inventory *devicetypes.Inventory) error {
+	// Peek at header to detect format
+	header, err := peekCSVHeader(commands.CsvFlag)
+	if err != nil {
+		return fmt.Errorf("failed to read CSV header: %w", err)
+	}
+
+	if IsSystemCSV(header) {
+		return importSystemCSV(cmd, args, inventory)
+	}
+	return importBOMCSV(cmd, args, inventory)
+}
+
+// importSystemCSV parses a system CSV and stores the grouped data on the provider.
+func importSystemCSV(cmd *cobra.Command, args []string, inventory *devicetypes.Inventory) error {
+	data, err := ParseSystemCSV(commands.CsvFlag)
+	if err != nil {
+		return fmt.Errorf("failed to parse system CSV: %w", err)
+	}
+
+	total := len(data.Roles) + len(data.Racks) + len(data.Devices) + len(data.Modules) + len(data.Connections)
+	if total == 0 {
+		log.Println("No valid records found in system CSV")
+		return nil
+	}
+
+	prov := GetSystemProvider()
+	prov.ClearSystemRecords()
+	prov.SetSystemRecords(data)
+
+	log.Printf("Parsed system CSV from %s: %d roles, %d racks, %d devices, %d modules, %d connections",
+		commands.CsvFlag,
+		len(data.Roles), len(data.Racks), len(data.Devices), len(data.Modules), len(data.Connections))
+
+	return nil
+}
+
+// importBOMCSV parses a traditional BOM CSV and stores raw records on the provider.
+func importBOMCSV(cmd *cobra.Command, args []string, inventory *devicetypes.Inventory) error {
 	records, err := ParseCSV(commands.CsvFlag)
 	if err != nil {
 		return fmt.Errorf("failed to parse CSV: %w", err)

--- a/pkg/provider/example/import/system_csv.go
+++ b/pkg/provider/example/import/system_csv.go
@@ -1,0 +1,384 @@
+package import_
+
+import (
+	"encoding/csv"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// SystemRecord holds a parsed row from a system CSV file.
+// The Section field determines which other fields are relevant.
+type SystemRecord struct {
+	Section      string // role, rack, device, module, connection
+	PartNumber   string
+	Name         string
+	Qty          int
+	Rack         string // parent rack name (devices)
+	Position     int    // U position in rack (devices)
+	Face         string // front, rear (devices)
+	Role         string // role name (devices)
+	Status       string
+	Serial       string
+	Device       string // parent device name (modules)
+	Bay          string // module bay (modules)
+	ADevice      string // connection endpoint A device
+	APort        string // connection endpoint A port
+	BDevice      string // connection endpoint B device
+	BPort        string // connection endpoint B port
+	Color        string // cable color (connections)
+	Length       string // cable length value (connections)
+	LengthUnit   string // cable length unit (connections)
+	Location     string // location name (racks)
+	ContentTypes string // comma-separated content types (roles)
+}
+
+// SystemCSV holds parsed system CSV data grouped by section.
+type SystemCSV struct {
+	Defaults        SystemRecord            // global _defaults row
+	SectionDefaults map[string]SystemRecord // per-section defaults (e.g. device_defaults)
+	Roles           []SystemRecord
+	Locations       []SystemRecord
+	Racks           []SystemRecord
+	Devices         []SystemRecord
+	Modules         []SystemRecord
+	Connections     []SystemRecord
+}
+
+// systemColumnIndex maps header positions for system CSV columns.
+type systemColumnIndex struct {
+	section      int
+	partNumber   int
+	name         int
+	qty          int
+	rack         int
+	position     int
+	face         int
+	role         int
+	status       int
+	serial       int
+	device       int
+	bay          int
+	aDevice      int
+	aPort        int
+	bDevice      int
+	bPort        int
+	color        int
+	length       int
+	lengthUnit   int
+	location     int
+	contentTypes int
+}
+
+// IsSystemCSV returns true if the header row contains a "Section" column,
+// indicating this is a system CSV rather than a traditional BOM CSV.
+func IsSystemCSV(header []string) bool {
+	for _, col := range header {
+		if normalizeSystemHeader(col) == "section" {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseSystemCSV reads a system CSV file and returns grouped records.
+func ParseSystemCSV(filePath string) (*SystemCSV, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open system CSV file: %w", err)
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	reader.FieldsPerRecord = -1
+	reader.Comment = '#'
+
+	rows, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read system CSV: %w", err)
+	}
+
+	if len(rows) < 2 {
+		return nil, fmt.Errorf("system CSV must have a header row and at least one data row")
+	}
+
+	idx, err := parseSystemHeader(rows[0])
+	if err != nil {
+		return nil, err
+	}
+
+	result := &SystemCSV{
+		SectionDefaults: make(map[string]SystemRecord),
+	}
+
+	for lineNum, row := range rows[1:] {
+		rec, err := parseSystemRow(row, idx, lineNum+2)
+		if err != nil {
+			log.Printf("WARN: system CSV line %d: %v, skipping", lineNum+2, err)
+			continue
+		}
+
+		section := strings.ToLower(rec.Section)
+
+		// Handle defaults rows
+		if section == "_defaults" {
+			result.Defaults = rec
+			continue
+		}
+		if strings.HasSuffix(section, "_defaults") {
+			key := strings.TrimSuffix(section, "_defaults")
+			result.SectionDefaults[key] = rec
+			continue
+		}
+
+		switch section {
+		case "role":
+			result.Roles = append(result.Roles, rec)
+		case "location":
+			result.Locations = append(result.Locations, rec)
+		case "rack":
+			result.Racks = append(result.Racks, rec)
+		case "device":
+			result.Devices = append(result.Devices, rec)
+		case "module":
+			result.Modules = append(result.Modules, rec)
+		case "connection":
+			result.Connections = append(result.Connections, rec)
+		default:
+			log.Printf("WARN: system CSV line %d: unknown section %q, skipping", lineNum+2, rec.Section)
+		}
+	}
+
+	return result, nil
+}
+
+// parseSystemHeader maps header columns to a systemColumnIndex.
+func parseSystemHeader(header []string) (systemColumnIndex, error) {
+	idx := systemColumnIndex{
+		section:      -1,
+		partNumber:   -1,
+		name:         -1,
+		qty:          -1,
+		rack:         -1,
+		position:     -1,
+		face:         -1,
+		role:         -1,
+		status:       -1,
+		serial:       -1,
+		device:       -1,
+		bay:          -1,
+		aDevice:      -1,
+		aPort:        -1,
+		bDevice:      -1,
+		bPort:        -1,
+		color:        -1,
+		length:       -1,
+		lengthUnit:   -1,
+		location:     -1,
+		contentTypes: -1,
+	}
+
+	for i, col := range header {
+		switch normalizeSystemHeader(col) {
+		case "section":
+			idx.section = i
+		case "partnumber":
+			idx.partNumber = i
+		case "name":
+			idx.name = i
+		case "qty":
+			idx.qty = i
+		case "rack":
+			idx.rack = i
+		case "position":
+			idx.position = i
+		case "face":
+			idx.face = i
+		case "role":
+			idx.role = i
+		case "status":
+			idx.status = i
+		case "serial":
+			idx.serial = i
+		case "device":
+			idx.device = i
+		case "bay":
+			idx.bay = i
+		case "adevice":
+			idx.aDevice = i
+		case "aport":
+			idx.aPort = i
+		case "bdevice":
+			idx.bDevice = i
+		case "bport":
+			idx.bPort = i
+		case "color":
+			idx.color = i
+		case "length":
+			idx.length = i
+		case "lengthunit":
+			idx.lengthUnit = i
+		case "location":
+			idx.location = i
+		case "contenttypes":
+			idx.contentTypes = i
+		}
+	}
+
+	if idx.section < 0 {
+		return idx, fmt.Errorf("missing required column: Section")
+	}
+
+	return idx, nil
+}
+
+// normalizeSystemHeader converts column header variations to canonical names.
+func normalizeSystemHeader(col string) string {
+	lower := strings.ToLower(strings.TrimSpace(col))
+	lower = strings.ReplaceAll(lower, "_", "")
+	lower = strings.ReplaceAll(lower, "-", "")
+	lower = strings.ReplaceAll(lower, " ", "")
+
+	switch lower {
+	case "section", "type", "recordtype":
+		return "section"
+	case "partnumber", "productnumber", "slug", "partno":
+		return "partnumber"
+	case "name", "devicename", "rackname":
+		return "name"
+	case "qty", "quantity", "count":
+		return "qty"
+	case "rack", "rackid", "parentrack":
+		return "rack"
+	case "position", "uposition", "u", "rackunit":
+		return "position"
+	case "face", "rackface", "side":
+		return "face"
+	case "role", "devicerole":
+		return "role"
+	case "status":
+		return "status"
+	case "serial", "serialnumber", "sn":
+		return "serial"
+	case "device", "parentdevice":
+		return "device"
+	case "bay", "modulebay", "slot":
+		return "bay"
+	case "adevice", "devicea", "sourcedevice":
+		return "adevice"
+	case "aport", "porta", "sourceport":
+		return "aport"
+	case "bdevice", "deviceb", "destdevice":
+		return "bdevice"
+	case "bport", "portb", "destport":
+		return "bport"
+	case "color", "cablecolor":
+		return "color"
+	case "length", "cablelength":
+		return "length"
+	case "lengthunit", "unit":
+		return "lengthunit"
+	case "location", "loc", "site":
+		return "location"
+	case "contenttypes", "contenttype":
+		return "contenttypes"
+	default:
+		return lower
+	}
+}
+
+// parseSystemRow extracts a SystemRecord from a CSV row.
+func parseSystemRow(row []string, idx systemColumnIndex, lineNum int) (SystemRecord, error) {
+	section := getColumnValue(row, idx.section)
+	if section == "" {
+		return SystemRecord{}, fmt.Errorf("empty Section")
+	}
+
+	qtyStr := getColumnValue(row, idx.qty)
+	qty := 1
+	if qtyStr != "" {
+		var err error
+		qty, err = strconv.Atoi(qtyStr)
+		if err != nil {
+			return SystemRecord{}, fmt.Errorf("invalid Qty %q: %w", qtyStr, err)
+		}
+		if qty < 1 {
+			return SystemRecord{}, fmt.Errorf("Qty must be >= 1, got %d", qty)
+		}
+	}
+
+	posStr := getColumnValue(row, idx.position)
+	pos := 0
+	if posStr != "" {
+		var err error
+		pos, err = strconv.Atoi(posStr)
+		if err != nil {
+			return SystemRecord{}, fmt.Errorf("invalid Position %q: %w", posStr, err)
+		}
+	}
+
+	return SystemRecord{
+		Section:      section,
+		PartNumber:   getColumnValue(row, idx.partNumber),
+		Name:         getColumnValue(row, idx.name),
+		Qty:          qty,
+		Rack:         getColumnValue(row, idx.rack),
+		Position:     pos,
+		Face:         getColumnValue(row, idx.face),
+		Role:         getColumnValue(row, idx.role),
+		Status:       getColumnValue(row, idx.status),
+		Serial:       getColumnValue(row, idx.serial),
+		Device:       getColumnValue(row, idx.device),
+		Bay:          getColumnValue(row, idx.bay),
+		ADevice:      getColumnValue(row, idx.aDevice),
+		APort:        getColumnValue(row, idx.aPort),
+		BDevice:      getColumnValue(row, idx.bDevice),
+		BPort:        getColumnValue(row, idx.bPort),
+		Color:        getColumnValue(row, idx.color),
+		Length:       getColumnValue(row, idx.length),
+		LengthUnit:   getColumnValue(row, idx.lengthUnit),
+		Location:     getColumnValue(row, idx.location),
+		ContentTypes: getColumnValue(row, idx.contentTypes),
+	}, nil
+}
+
+// ApplyDefaults merges defaults into a record. Fields already set on rec
+// take precedence. Global defaults are applied first, then section-specific.
+func (s *SystemCSV) ApplyDefaults(rec SystemRecord) SystemRecord {
+	section := strings.ToLower(rec.Section)
+
+	// Apply global defaults first
+	rec = mergeSystemDefaults(rec, s.Defaults)
+
+	// Apply section-specific defaults (override global)
+	if sd, ok := s.SectionDefaults[section]; ok {
+		rec = mergeSystemDefaults(rec, sd)
+	}
+
+	return rec
+}
+
+// mergeSystemDefaults fills empty fields in rec from defaults.
+func mergeSystemDefaults(rec, defaults SystemRecord) SystemRecord {
+	if rec.Status == "" && defaults.Status != "" {
+		rec.Status = defaults.Status
+	}
+	if rec.Role == "" && defaults.Role != "" {
+		rec.Role = defaults.Role
+	}
+	if rec.Face == "" && defaults.Face != "" {
+		rec.Face = defaults.Face
+	}
+	if rec.Location == "" && defaults.Location != "" {
+		rec.Location = defaults.Location
+	}
+	if rec.Color == "" && defaults.Color != "" {
+		rec.Color = defaults.Color
+	}
+	if rec.LengthUnit == "" && defaults.LengthUnit != "" {
+		rec.LengthUnit = defaults.LengthUnit
+	}
+	return rec
+}

--- a/pkg/provider/example/import/system_csv_test.go
+++ b/pkg/provider/example/import/system_csv_test.go
@@ -1,0 +1,276 @@
+package import_
+
+import (
+	"testing"
+)
+
+func TestIsSystemCSV(t *testing.T) {
+	tests := []struct {
+		name   string
+		header []string
+		want   bool
+	}{
+		{"has Section column", []string{"Section", "PartNumber", "Name"}, true},
+		{"lowercase section", []string{"section", "partnumber", "name"}, true},
+		{"no Section column", []string{"PartNumber", "Description", "Quantity"}, false},
+		{"empty header", []string{}, false},
+		{"section with spaces", []string{" Section ", "PartNumber"}, true},
+		{"RecordType alias", []string{"RecordType", "PartNumber"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsSystemCSV(tt.header)
+			if got != tt.want {
+				t.Errorf("IsSystemCSV(%v) = %v, want %v", tt.header, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSystemCSV(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		expectErr bool
+		errorMsg  string
+		validate  func(t *testing.T, data *SystemCSV)
+	}{
+		{
+			name: "valid system.csv fixture",
+			path: "../../../../testdata/fixtures/example/system.csv",
+			validate: func(t *testing.T, data *SystemCSV) {
+				if len(data.Roles) != 3 {
+					t.Errorf("expected 3 roles, got %d", len(data.Roles))
+				}
+				if len(data.Racks) != 2 {
+					t.Errorf("expected 2 racks, got %d", len(data.Racks))
+				}
+				if len(data.Devices) != 6 {
+					t.Errorf("expected 6 devices, got %d", len(data.Devices))
+				}
+				if len(data.Modules) != 3 {
+					t.Errorf("expected 3 modules, got %d", len(data.Modules))
+				}
+				if len(data.Connections) != 3 {
+					t.Errorf("expected 3 connections, got %d", len(data.Connections))
+				}
+			},
+		},
+		{
+			name:      "bad path",
+			path:      "nonexistent.csv",
+			expectErr: true,
+			errorMsg:  "failed to open system CSV file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := ParseSystemCSV(tt.path)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errorMsg)
+				}
+				if tt.errorMsg != "" && !contains(err.Error(), tt.errorMsg) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errorMsg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.validate != nil {
+				tt.validate(t, data)
+			}
+		})
+	}
+}
+
+func TestParseSystemCSV_Defaults(t *testing.T) {
+	data, err := ParseSystemCSV("../../../../testdata/fixtures/example/system.csv")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Global _defaults row sets Status=Active
+	if data.Defaults.Status != "Active" {
+		t.Errorf("global defaults Status = %q, want %q", data.Defaults.Status, "Active")
+	}
+
+	// Verify defaults are applied
+	rec := data.ApplyDefaults(SystemRecord{Section: "device", Name: "test"})
+	if rec.Status != "Active" {
+		t.Errorf("applied defaults Status = %q, want %q", rec.Status, "Active")
+	}
+
+	// Explicit value takes precedence
+	rec = data.ApplyDefaults(SystemRecord{Section: "device", Name: "test", Status: "Planned"})
+	if rec.Status != "Planned" {
+		t.Errorf("explicit Status should be preserved, got %q", rec.Status)
+	}
+}
+
+func TestParseSystemCSV_RoleFields(t *testing.T) {
+	data, err := ParseSystemCSV("../../../../testdata/fixtures/example/system.csv")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(data.Roles) < 1 {
+		t.Fatal("expected at least 1 role")
+	}
+
+	role := data.Roles[0]
+	if role.Name != "ComputeNode" {
+		t.Errorf("first role Name = %q, want %q", role.Name, "ComputeNode")
+	}
+	if role.ContentTypes != "dcim.device" {
+		t.Errorf("first role ContentTypes = %q, want %q", role.ContentTypes, "dcim.device")
+	}
+}
+
+func TestParseSystemCSV_DeviceFields(t *testing.T) {
+	data, err := ParseSystemCSV("../../../../testdata/fixtures/example/system.csv")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Find the GH-x3701u34 device
+	var found *SystemRecord
+	for _, d := range data.Devices {
+		if d.Name == "GH-x3701u34" {
+			found = &d
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("device GH-x3701u34 not found")
+	}
+
+	if found.PartNumber != "hpe-xd670" {
+		t.Errorf("PartNumber = %q, want %q", found.PartNumber, "hpe-xd670")
+	}
+	if found.Rack != "x3701" {
+		t.Errorf("Rack = %q, want %q", found.Rack, "x3701")
+	}
+	if found.Position != 34 {
+		t.Errorf("Position = %d, want %d", found.Position, 34)
+	}
+	if found.Face != "front" {
+		t.Errorf("Face = %q, want %q", found.Face, "front")
+	}
+	if found.Role != "ComputeNode" {
+		t.Errorf("Role = %q, want %q", found.Role, "ComputeNode")
+	}
+	if found.Serial != "5UF435KF42" {
+		t.Errorf("Serial = %q, want %q", found.Serial, "5UF435KF42")
+	}
+}
+
+func TestParseSystemCSV_ConnectionFields(t *testing.T) {
+	data, err := ParseSystemCSV("../../../../testdata/fixtures/example/system.csv")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(data.Connections) < 1 {
+		t.Fatal("expected at least 1 connection")
+	}
+
+	conn := data.Connections[0]
+	if conn.ADevice != "GH-x3701u34" {
+		t.Errorf("ADevice = %q, want %q", conn.ADevice, "GH-x3701u34")
+	}
+	if conn.APort != "iLO" {
+		t.Errorf("APort = %q, want %q", conn.APort, "iLO")
+	}
+	if conn.BDevice != "MAN-x3701u48" {
+		t.Errorf("BDevice = %q, want %q", conn.BDevice, "MAN-x3701u48")
+	}
+	if conn.BPort != "1" {
+		t.Errorf("BPort = %q, want %q", conn.BPort, "1")
+	}
+	if conn.PartNumber != "hpe-3m-cat6-stp" {
+		t.Errorf("PartNumber = %q, want %q", conn.PartNumber, "hpe-3m-cat6-stp")
+	}
+	if conn.Color != "blue" {
+		t.Errorf("Color = %q, want %q", conn.Color, "blue")
+	}
+}
+
+func TestNormalizeSystemHeader(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Section", "section"},
+		{"Part Number", "partnumber"},
+		{"part_number", "partnumber"},
+		{"Rack Face", "face"},
+		{"Serial Number", "serial"},
+		{"A Device", "adevice"},
+		{"Content Types", "contenttypes"},
+		{"Module Bay", "bay"},
+		{"U Position", "position"},
+		{"Cable Color", "color"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeSystemHeader(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeSystemHeader(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSystemRow_EmptySection(t *testing.T) {
+	idx := systemColumnIndex{section: 0}
+	_, err := parseSystemRow([]string{""}, idx, 2)
+	if err == nil {
+		t.Fatal("expected error for empty section")
+	}
+	if !contains(err.Error(), "empty Section") {
+		t.Errorf("expected 'empty Section' error, got %q", err.Error())
+	}
+}
+
+func TestParseSystemRow_InvalidQty(t *testing.T) {
+	idx := systemColumnIndex{section: 0, qty: 1, partNumber: -1, name: -1, rack: -1,
+		position: -1, face: -1, role: -1, status: -1, serial: -1,
+		device: -1, bay: -1, aDevice: -1, aPort: -1, bDevice: -1, bPort: -1,
+		color: -1, length: -1, lengthUnit: -1, location: -1, contentTypes: -1}
+	_, err := parseSystemRow([]string{"device", "abc"}, idx, 2)
+	if err == nil {
+		t.Fatal("expected error for invalid qty")
+	}
+}
+
+func TestParseSystemRow_DefaultQty(t *testing.T) {
+	idx := systemColumnIndex{section: 0, qty: -1, partNumber: -1, name: -1, rack: -1,
+		position: -1, face: -1, role: -1, status: -1, serial: -1,
+		device: -1, bay: -1, aDevice: -1, aPort: -1, bDevice: -1, bPort: -1,
+		color: -1, length: -1, lengthUnit: -1, location: -1, contentTypes: -1}
+	rec, err := parseSystemRow([]string{"device"}, idx, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Qty != 1 {
+		t.Errorf("default Qty = %d, want 1", rec.Qty)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/provider/example/init.go
+++ b/pkg/provider/example/init.go
@@ -23,9 +23,26 @@ func init() {
 		return instance
 	})
 
+	// Register the system provider getter with the import package
+	import_.SetSystemProviderGetter(func() interface {
+		SetSystemRecords(data *import_.SystemCSV)
+		ClearSystemRecords()
+		IsSystemImport() bool
+	} {
+		return instance
+	})
+
 	// Register the provider getter with the transform package to break import cycle
 	transform.SetProviderGetter(func() interface {
 		GetRecords() []import_.CsvRecord
+	} {
+		return instance
+	})
+
+	// Register the system provider getter with the transform package
+	transform.SetSystemProviderGetter(func() interface {
+		GetSystemRecords() *import_.SystemCSV
+		IsSystemImport() bool
 	} {
 		return instance
 	})

--- a/pkg/provider/example/provider.go
+++ b/pkg/provider/example/provider.go
@@ -7,6 +7,8 @@ type Example struct {
 	Options *ImportOptions
 	// RawRecords holds all raw CSV records from the import phase
 	RawRecords []import_.CsvRecord
+	// SystemData holds parsed system CSV data (multi-section format)
+	SystemData *import_.SystemCSV
 }
 
 // New creates a new Example provider instance
@@ -27,6 +29,26 @@ func (p *Example) SetRecords(records []import_.CsvRecord) {
 // GetRecords returns the raw records for the transform phase
 func (p *Example) GetRecords() []import_.CsvRecord {
 	return p.RawRecords
+}
+
+// SetSystemRecords stores parsed system CSV data
+func (p *Example) SetSystemRecords(data *import_.SystemCSV) {
+	p.SystemData = data
+}
+
+// GetSystemRecords returns the system CSV data for transform
+func (p *Example) GetSystemRecords() *import_.SystemCSV {
+	return p.SystemData
+}
+
+// ClearSystemRecords resets system CSV data
+func (p *Example) ClearSystemRecords() {
+	p.SystemData = nil
+}
+
+// IsSystemImport returns true if a system CSV was parsed
+func (p *Example) IsSystemImport() bool {
+	return p.SystemData != nil
 }
 
 func (p *Example) Slug() string {

--- a/pkg/provider/example/transform/system.go
+++ b/pkg/provider/example/transform/system.go
@@ -1,0 +1,526 @@
+package transform
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	"github.com/Cray-HPE/cani/pkg/devicetypes/connections"
+	import_ "github.com/Cray-HPE/cani/pkg/provider/example/import"
+	"github.com/google/uuid"
+)
+
+// TransformSystem converts parsed system CSV data into a TransformResult.
+// Uses a 5-pass algorithm: roles → racks → devices → modules → connections.
+func TransformSystem(existing devicetypes.Inventory, data *import_.SystemCSV) (*devicetypes.TransformResult, error) {
+	initInventoryMaps(&existing)
+
+	result := &devicetypes.TransformResult{
+		Locations: make(map[uuid.UUID]*devicetypes.CaniLocationType),
+		Racks:     make(map[uuid.UUID]*devicetypes.CaniRackType),
+		Devices:   make(map[uuid.UUID]*devicetypes.CaniDeviceType),
+		Modules:   make(map[uuid.UUID]*devicetypes.CaniModuleType),
+		Cables:    make(map[uuid.UUID]*devicetypes.CaniCableType),
+	}
+
+	// Pass 0: Roles
+	meta, err := transformRoles(data)
+	if err != nil {
+		return nil, fmt.Errorf("transformRoles: %w", err)
+	}
+	result.Metadata = meta
+
+	// Pass 0b: Locations
+	locationsByName, err := transformSystemLocations(data, result, &existing)
+	if err != nil {
+		return nil, fmt.Errorf("transformSystemLocations: %w", err)
+	}
+
+	// Pass 1: Racks
+	racksByName, err := transformSystemRacks(data, result, &existing, locationsByName)
+	if err != nil {
+		return nil, fmt.Errorf("transformSystemRacks: %w", err)
+	}
+
+	// Pass 2: Devices
+	err = transformSystemDevices(data, result, &existing, racksByName)
+	if err != nil {
+		return nil, fmt.Errorf("transformSystemDevices: %w", err)
+	}
+
+	// Pass 3: Modules
+	err = transformSystemModules(data, result, &existing)
+	if err != nil {
+		return nil, fmt.Errorf("transformSystemModules: %w", err)
+	}
+
+	// Pass 4: Connections
+	err = transformSystemConnections(data, result, &existing)
+	if err != nil {
+		return nil, fmt.Errorf("transformSystemConnections: %w", err)
+	}
+
+	log.Printf("System CSV transformed: %d roles, %d locations, %d racks, %d devices, %d modules, %d cables",
+		len(data.Roles), len(result.Locations), len(result.Racks), len(result.Devices), len(result.Modules), len(result.Cables))
+
+	return result, nil
+}
+
+// transformRoles creates MetadataEntry items from role records.
+func transformRoles(data *import_.SystemCSV) (*devicetypes.InventoryMetadata, error) {
+	if len(data.Roles) == 0 {
+		return nil, nil
+	}
+	meta := &devicetypes.InventoryMetadata{}
+	for _, rec := range data.Roles {
+		rec = data.ApplyDefaults(rec)
+		if rec.Name == "" {
+			return nil, fmt.Errorf("role record missing Name")
+		}
+		var contentTypes []string
+		if rec.ContentTypes != "" {
+			for _, ct := range strings.Split(rec.ContentTypes, ",") {
+				ct = strings.TrimSpace(ct)
+				if ct != "" {
+					contentTypes = append(contentTypes, ct)
+				}
+			}
+		}
+		meta.Roles = append(meta.Roles, devicetypes.MetadataEntry{
+			Name:         rec.Name,
+			ContentTypes: contentTypes,
+		})
+	}
+	return meta, nil
+}
+
+// transformSystemLocations creates locations from system CSV location records.
+// Returns a map of location name → UUID for rack parenting.
+func transformSystemLocations(data *import_.SystemCSV, result *devicetypes.TransformResult, inv *devicetypes.Inventory) (map[string]uuid.UUID, error) {
+	locationsByName := make(map[string]uuid.UUID)
+
+	for _, rec := range data.Locations {
+		rec = data.ApplyDefaults(rec)
+		if rec.Name == "" {
+			return nil, fmt.Errorf("location record missing Name")
+		}
+		if rec.Role == "" {
+			return nil, fmt.Errorf("location %q missing Role (location type: dc, level, section)", rec.Name)
+		}
+
+		id := uuid.New()
+		var contentTypes []string
+		if rec.ContentTypes != "" {
+			for _, ct := range strings.Split(rec.ContentTypes, ",") {
+				ct = strings.TrimSpace(ct)
+				if ct != "" {
+					contentTypes = append(contentTypes, ct)
+				}
+			}
+		}
+
+		loc := &devicetypes.CaniLocationType{
+			ID:           id,
+			Name:         rec.Name,
+			LocationType: rec.Role,
+			ContentTypes: contentTypes,
+			ObjectMeta:   devicetypes.ObjectMeta{Status: rec.Status},
+		}
+
+		// Resolve parent by name
+		if rec.Location != "" {
+			parentID, ok := locationsByName[rec.Location]
+			if !ok {
+				parentID, ok = findLocationByName(inv, rec.Location)
+			}
+			if !ok {
+				return nil, fmt.Errorf("location %q references unknown parent %q", rec.Name, rec.Location)
+			}
+			loc.Parent = parentID
+		}
+
+		result.Locations[id] = loc
+		inv.Locations[id] = loc
+		locationsByName[rec.Name] = id
+	}
+
+	return locationsByName, nil
+}
+
+// findLocationByName searches existing inventory for a location by name.
+func findLocationByName(inv *devicetypes.Inventory, name string) (uuid.UUID, bool) {
+	for id, loc := range inv.Locations {
+		if loc.Name == name {
+			return id, true
+		}
+	}
+	return uuid.Nil, false
+}
+
+// transformSystemRacks creates racks from system CSV rack records.
+// Returns a map of rack name → UUID for device parenting.
+func transformSystemRacks(data *import_.SystemCSV, result *devicetypes.TransformResult, inv *devicetypes.Inventory, locationsByName map[string]uuid.UUID) (map[string]uuid.UUID, error) {
+	racksByName := make(map[string]uuid.UUID)
+
+	for _, rec := range data.Racks {
+		rec = data.ApplyDefaults(rec)
+		if rec.PartNumber == "" {
+			return nil, fmt.Errorf("rack %q missing PartNumber (slug or part number)", rec.Name)
+		}
+
+		// Lookup rack type from library
+		slug := rec.PartNumber
+		uHeight := 48
+		var partNumber, manufacturer, model string
+
+		if rt, ok := devicetypes.GetRackTypeBySlug(rec.PartNumber); ok {
+			slug = rt.Slug
+			uHeight = rt.UHeight
+			partNumber = rt.PartNumber
+			manufacturer = rt.Manufacturer
+			model = rt.Model
+		} else if rt, ok := devicetypes.GetRackTypeByPartNumber(rec.PartNumber); ok {
+			slug = rt.Slug
+			uHeight = rt.UHeight
+			partNumber = rt.PartNumber
+			manufacturer = rt.Manufacturer
+			model = rt.Model
+		}
+
+		for i := 0; i < rec.Qty; i++ {
+			id := uuid.New()
+			name := rec.Name
+			if rec.Qty > 1 && name != "" {
+				name = fmt.Sprintf("%s-%d", name, i+1)
+			}
+
+			rack := &devicetypes.CaniRackType{
+				ID:           id,
+				Name:         name,
+				Slug:         slug,
+				PartNumber:   partNumber,
+				Manufacturer: manufacturer,
+				Model:        model,
+				UHeight:      uHeight,
+				ObjectMeta:   devicetypes.ObjectMeta{Status: rec.Status},
+				Devices:      []uuid.UUID{},
+			}
+
+			// Assign location
+			if rec.Location != "" {
+				locID, ok := locationsByName[rec.Location]
+				if !ok {
+					locID, ok = findLocationByName(inv, rec.Location)
+				}
+				if ok {
+					rack.Location = locID
+				}
+			}
+
+			result.Racks[id] = rack
+			inv.Racks[id] = rack
+			if name != "" {
+				racksByName[name] = id
+			}
+		}
+	}
+
+	return racksByName, nil
+}
+
+// transformSystemDevices creates devices from system CSV device records.
+func transformSystemDevices(data *import_.SystemCSV, result *devicetypes.TransformResult, inv *devicetypes.Inventory, racksByName map[string]uuid.UUID) error {
+	for _, rec := range data.Devices {
+		rec = data.ApplyDefaults(rec)
+		if rec.PartNumber == "" {
+			return fmt.Errorf("device %q missing PartNumber (slug or part number)", rec.Name)
+		}
+
+		for i := 0; i < rec.Qty; i++ {
+			id := uuid.New()
+			name := rec.Name
+			if rec.Qty > 1 && name != "" {
+				name = fmt.Sprintf("%s-%d", name, i+1)
+			}
+
+			device := &devicetypes.CaniDeviceType{
+				ID:         id,
+				Name:       name,
+				Slug:       rec.PartNumber,
+				PartNumber: rec.PartNumber,
+				Serial:     rec.Serial,
+				ObjectMeta: devicetypes.ObjectMeta{
+					Status: rec.Status,
+					Role:   rec.Role,
+				},
+			}
+
+			// Populate from device type library
+			if dt, ok := devicetypes.GetBySlug(rec.PartNumber); ok {
+				populateFromDeviceType(device, &dt)
+			} else if dt, ok := devicetypes.GetByPartNumber(rec.PartNumber); ok {
+				populateFromDeviceType(device, &dt)
+			}
+
+			// Place in rack
+			if rec.Rack != "" {
+				rackID, ok := racksByName[rec.Rack]
+				if !ok {
+					// Try existing inventory
+					rackID, ok = findRackByName(inv, rec.Rack)
+				}
+				if !ok {
+					return fmt.Errorf("device %q references unknown rack %q", name, rec.Rack)
+				}
+				device.Parent = rackID
+				device.Rack = rackID
+
+				if rec.Position > 0 {
+					device.RackPosition = rec.Position
+					face := rec.Face
+					if face == "" {
+						face = devicetypes.FaceFront
+					}
+					device.Face = face
+
+					if rack, ok := inv.Racks[rackID]; ok {
+						height := device.UHeight
+						if height < 1 {
+							height = 1
+						}
+						if !rack.PlaceDevice(id, rec.Position, height, face, device.IsFullDepth) {
+							log.Printf("WARN: device %q cannot fit at U%d in rack %q", name, rec.Position, rec.Rack)
+						}
+					}
+				}
+			}
+
+			result.Devices[id] = device
+			inv.Devices[id] = device
+		}
+	}
+
+	return nil
+}
+
+// transformSystemModules creates modules from system CSV module records.
+func transformSystemModules(data *import_.SystemCSV, result *devicetypes.TransformResult, inv *devicetypes.Inventory) error {
+	for _, rec := range data.Modules {
+		rec = data.ApplyDefaults(rec)
+
+		for i := 0; i < rec.Qty; i++ {
+			id := uuid.New()
+			var parentDevice *devicetypes.CaniDeviceType
+
+			module := &devicetypes.CaniModuleType{
+				ID:         id,
+				Name:       rec.Name,
+				Slug:       rec.PartNumber,
+				PartNumber: rec.PartNumber,
+				Serial:     rec.Serial,
+				ObjectMeta: devicetypes.ObjectMeta{Status: rec.Status},
+			}
+
+			// Populate from module type library
+			if rec.PartNumber != "" {
+				if mt, ok := devicetypes.GetModuleBySlug(rec.PartNumber); ok {
+					module.Slug = mt.Slug
+					module.Manufacturer = mt.Manufacturer
+					module.Model = mt.Model
+					module.Type = mt.Type
+					if mt.PartNumber != "" {
+						module.PartNumber = mt.PartNumber
+					}
+				} else if mt, ok := devicetypes.GetModuleTypeByPartNumber(rec.PartNumber); ok {
+					module.Slug = mt.Slug
+					module.Manufacturer = mt.Manufacturer
+					module.Model = mt.Model
+					module.Type = mt.Type
+					if mt.PartNumber != "" {
+						module.PartNumber = mt.PartNumber
+					}
+				}
+			}
+
+			// Parent to device
+			if rec.Device != "" {
+				dev := inv.FindDeviceByNameOrID(rec.Device)
+				if dev == nil {
+					return fmt.Errorf("module %q references unknown device %q", rec.Name, rec.Device)
+				}
+				parentDevice = dev
+				module.ParentDevice = dev.ID
+			}
+
+			if rec.Bay != "" {
+				module.ModuleBayName = resolveSystemModuleBayName(parentDevice, rec.Bay)
+			}
+
+			if module.Name == "" {
+				module.Name = synthesizeSystemModuleName(module, parentDevice)
+			}
+
+			result.Modules[id] = module
+		}
+	}
+
+	return nil
+}
+
+func resolveSystemModuleBayName(device *devicetypes.CaniDeviceType, requestedBay string) string {
+	if device == nil || requestedBay == "" {
+		return requestedBay
+	}
+
+	for _, bay := range device.ModuleBays {
+		if bay.Name == requestedBay || bay.Position == requestedBay {
+			return bay.Name
+		}
+	}
+
+	return requestedBay
+}
+
+func synthesizeSystemModuleName(module *devicetypes.CaniModuleType, device *devicetypes.CaniDeviceType) string {
+	if module == nil || module.Name != "" || device == nil {
+		return ""
+	}
+
+	lowerSlug := strings.ToLower(module.Slug)
+	if module.Type == devicetypes.TypeGPU || strings.Contains(lowerSlug, "gpu") {
+		if module.ModuleBayName == "" {
+			return ""
+		}
+		return fmt.Sprintf("gpu-%s-%s", device.Name, module.ModuleBayName)
+	}
+
+	if strings.Contains(lowerSlug, "connectx-6") {
+		return fmt.Sprintf("CX6-%s", device.Name)
+	}
+
+	return ""
+}
+
+// transformSystemConnections resolves connection records into cables.
+func transformSystemConnections(data *import_.SystemCSV, result *devicetypes.TransformResult, inv *devicetypes.Inventory) error {
+	if len(data.Connections) == 0 {
+		return nil
+	}
+
+	// Build a ConnectionMap from system CSV connection records
+	cm := &connections.ConnectionMap{
+		Version: "v1",
+	}
+
+	// Determine defaults from _defaults and connection_defaults
+	globalDefaults := data.Defaults
+	sectionDefaults, hasSectionDefaults := data.SectionDefaults["connection"]
+	if globalDefaults.Status != "" || hasSectionDefaults {
+		cd := &connections.CableDefaults{}
+		if globalDefaults.Status != "" {
+			cd.Status = globalDefaults.Status
+		}
+		if hasSectionDefaults {
+			if sectionDefaults.Status != "" {
+				cd.Status = sectionDefaults.Status
+			}
+			if sectionDefaults.Color != "" {
+				cd.Color = sectionDefaults.Color
+			}
+			if sectionDefaults.LengthUnit != "" {
+				cd.LengthUnit = sectionDefaults.LengthUnit
+			}
+		}
+		cm.CableDefaults = cd
+	}
+
+	for _, rec := range data.Connections {
+		rec = data.ApplyDefaults(rec)
+
+		entry := connections.ConnectionEntry{
+			A: connections.Endpoint{Device: rec.ADevice, Port: rec.APort},
+			B: connections.Endpoint{Device: rec.BDevice, Port: rec.BPort},
+		}
+
+		cable := &connections.CableProps{}
+		hasCableProps := false
+
+		if rec.PartNumber != "" {
+			cable.Type = rec.PartNumber
+			hasCableProps = true
+		}
+		if rec.Color != "" {
+			cable.Color = rec.Color
+			hasCableProps = true
+		}
+		if rec.Length != "" {
+			if l, err := strconv.ParseFloat(rec.Length, 64); err == nil {
+				cable.Length = &l
+				hasCableProps = true
+			}
+		}
+		if rec.LengthUnit != "" {
+			cable.LengthUnit = rec.LengthUnit
+			hasCableProps = true
+		}
+		if rec.Status != "" {
+			cable.Status = rec.Status
+			hasCableProps = true
+		}
+
+		if hasCableProps {
+			entry.Cable = cable
+		}
+
+		cm.Connections = append(cm.Connections, entry)
+	}
+
+	// Resolve patterns and device names
+	resolved, errs := connections.ResolveConnectionMap(cm, inv)
+	if len(errs) > 0 {
+		for _, e := range errs {
+			log.Printf("WARN: connection resolution: %v", e)
+		}
+		if len(resolved) == 0 {
+			return fmt.Errorf("no connections resolved; %d errors", len(errs))
+		}
+	}
+
+	// Create cable objects
+	for _, conn := range resolved {
+		cable := devicetypes.NewCable(conn.Cable.Type, conn.Cable.Label)
+		cable.TerminationADevice = conn.ADevice
+		cable.TerminationAPort = conn.APort
+		cable.TerminationBDevice = conn.BDevice
+		cable.TerminationBPort = conn.BPort
+
+		if conn.Cable.Color != "" {
+			cable.Color = conn.Cable.Color
+		}
+		if conn.Cable.Length != nil {
+			cable.Length = conn.Cable.Length
+		}
+		if conn.Cable.LengthUnit != "" {
+			cable.LengthUnit = conn.Cable.LengthUnit
+		}
+		if conn.Cable.Status != "" {
+			cable.Status = conn.Cable.Status
+		}
+
+		result.Cables[cable.ID] = cable
+	}
+
+	return nil
+}
+
+// findRackByName searches the inventory for a rack with the given name.
+func findRackByName(inv *devicetypes.Inventory, name string) (uuid.UUID, bool) {
+	for id, rack := range inv.Racks {
+		if rack.Name == name {
+			return id, true
+		}
+	}
+	return uuid.Nil, false
+}

--- a/pkg/provider/example/transform/system_test.go
+++ b/pkg/provider/example/transform/system_test.go
@@ -1,0 +1,464 @@
+package transform
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	import_ "github.com/Cray-HPE/cani/pkg/provider/example/import"
+	"github.com/google/uuid"
+)
+
+func TestTransformSystem_Roles(t *testing.T) {
+	data := &import_.SystemCSV{
+		SectionDefaults: make(map[string]import_.SystemRecord),
+		Roles: []import_.SystemRecord{
+			{Section: "role", Name: "ComputeNode", ContentTypes: "dcim.device"},
+			{Section: "role", Name: "Gateway", ContentTypes: "dcim.device,dcim.rack"},
+		},
+	}
+
+	result, err := TransformSystem(devicetypes.Inventory{}, data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Metadata == nil {
+		t.Fatal("expected Metadata to be set")
+	}
+	if len(result.Metadata.Roles) != 2 {
+		t.Errorf("expected 2 roles, got %d", len(result.Metadata.Roles))
+	}
+	if result.Metadata.Roles[0].Name != "ComputeNode" {
+		t.Errorf("first role = %q, want %q", result.Metadata.Roles[0].Name, "ComputeNode")
+	}
+	if len(result.Metadata.Roles[1].ContentTypes) != 2 {
+		t.Errorf("Gateway should have 2 content types, got %d", len(result.Metadata.Roles[1].ContentTypes))
+	}
+}
+
+func TestTransformSystem_Racks(t *testing.T) {
+	data := &import_.SystemCSV{
+		SectionDefaults: make(map[string]import_.SystemRecord),
+		Racks: []import_.SystemRecord{
+			{Section: "rack", PartNumber: "hpe-48u-800mmx1200mm-g2-enterprise-shock-rack", Name: "x3701", Qty: 1, Status: "Available"},
+			{Section: "rack", PartNumber: "hpe-48u-800mmx1200mm-g2-enterprise-shock-rack", Name: "x3702", Qty: 1, Status: "Available"},
+		},
+	}
+
+	result, err := TransformSystem(devicetypes.Inventory{}, data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Racks) != 2 {
+		t.Fatalf("expected 2 racks, got %d", len(result.Racks))
+	}
+
+	names := make(map[string]bool)
+	for _, rack := range result.Racks {
+		names[rack.Name] = true
+		if rack.Status != "Available" {
+			t.Errorf("rack %q Status = %q, want %q", rack.Name, rack.Status, "Available")
+		}
+		if rack.UHeight < 1 {
+			t.Errorf("rack %q UHeight = %d, want > 0", rack.Name, rack.UHeight)
+		}
+	}
+	if !names["x3701"] || !names["x3702"] {
+		t.Errorf("expected racks x3701 and x3702, got %v", names)
+	}
+}
+
+func TestTransformSystem_Devices(t *testing.T) {
+	data := &import_.SystemCSV{
+		SectionDefaults: make(map[string]import_.SystemRecord),
+		Racks: []import_.SystemRecord{
+			{Section: "rack", PartNumber: "hpe-48u-800mmx1200mm-g2-enterprise-shock-rack", Name: "x3701", Qty: 1, Status: "Available"},
+		},
+		Devices: []import_.SystemRecord{
+			{Section: "device", PartNumber: "hpe-xd670", Name: "GH-x3701u34", Qty: 1, Rack: "x3701", Position: 34, Face: "front", Role: "ComputeNode", Status: "Active", Serial: "ABC123"},
+		},
+	}
+
+	result, err := TransformSystem(devicetypes.Inventory{}, data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Devices) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(result.Devices))
+	}
+
+	for _, dev := range result.Devices {
+		if dev.Name != "GH-x3701u34" {
+			t.Errorf("Name = %q, want %q", dev.Name, "GH-x3701u34")
+		}
+		if dev.Role != "ComputeNode" {
+			t.Errorf("Role = %q, want %q", dev.Role, "ComputeNode")
+		}
+		if dev.Status != "Active" {
+			t.Errorf("Status = %q, want %q", dev.Status, "Active")
+		}
+		if dev.Serial != "ABC123" {
+			t.Errorf("Serial = %q, want %q", dev.Serial, "ABC123")
+		}
+		if dev.RackPosition != 34 {
+			t.Errorf("RackPosition = %d, want %d", dev.RackPosition, 34)
+		}
+		if dev.Face != "front" {
+			t.Errorf("Face = %q, want %q", dev.Face, "front")
+		}
+		if dev.Parent == uuid.Nil {
+			t.Error("expected Parent to be set to rack UUID")
+		}
+	}
+}
+
+func TestTransformSystem_DeviceUnknownRack(t *testing.T) {
+	data := &import_.SystemCSV{
+		SectionDefaults: make(map[string]import_.SystemRecord),
+		Devices: []import_.SystemRecord{
+			{Section: "device", PartNumber: "hpe-xd670", Name: "node1", Qty: 1, Rack: "nonexistent"},
+		},
+	}
+
+	_, err := TransformSystem(devicetypes.Inventory{}, data)
+	if err == nil {
+		t.Fatal("expected error for unknown rack reference")
+	}
+}
+
+func TestTransformSystem_Modules(t *testing.T) {
+	data := &import_.SystemCSV{
+		SectionDefaults: make(map[string]import_.SystemRecord),
+		Racks: []import_.SystemRecord{
+			{Section: "rack", PartNumber: "hpe-48u-800mmx1200mm-g2-enterprise-shock-rack", Name: "x3701", Qty: 1, Status: "Available"},
+			{Section: "rack", PartNumber: "hpe-48u-800mmx1200mm-g2-enterprise-shock-rack", Name: "x3507", Qty: 1, Status: "Available"},
+		},
+		Devices: []import_.SystemRecord{
+			{Section: "device", PartNumber: "hpe-xd670", Name: "GH-x3701u34", Qty: 1, Rack: "x3701", Position: 34, Face: "front"},
+			{Section: "device", PartNumber: "hpe-proliant-dl380-gen11-8sff", Name: "SERV-x3507u21", Qty: 1, Rack: "x3507", Position: 21, Face: "front"},
+		},
+		Modules: []import_.SystemRecord{
+			{Section: "module", PartNumber: "nvidia-h100-sxm-gpu", Qty: 1, Device: "GH-x3701u34", Bay: "GPU0"},
+			{Section: "module", PartNumber: "nvidia-connectx-6-dx-100gbe-2p-qsfp28", Qty: 1, Device: "SERV-x3507u21", Bay: "PCIe5"},
+		},
+	}
+
+	result, err := TransformSystem(devicetypes.Inventory{}, data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Modules) != 2 {
+		t.Fatalf("expected 2 modules, got %d", len(result.Modules))
+	}
+
+	modsByDevice := make(map[uuid.UUID]*devicetypes.CaniModuleType)
+	for _, mod := range result.Modules {
+		if mod.ParentDevice == uuid.Nil {
+			t.Error("expected ParentDevice to be set")
+		}
+		modsByDevice[mod.ParentDevice] = mod
+	}
+
+	deviceIDs := make(map[string]uuid.UUID)
+	for id, dev := range result.Devices {
+		deviceIDs[dev.Name] = id
+	}
+
+	gpuMod := modsByDevice[deviceIDs["GH-x3701u34"]]
+	if gpuMod == nil {
+		t.Fatal("expected GPU module for GH-x3701u34")
+	}
+	if gpuMod.ModuleBayName != "GPU 0" {
+		t.Errorf("GPU ModuleBayName = %q, want %q", gpuMod.ModuleBayName, "GPU 0")
+	}
+	if gpuMod.Name != "gpu-GH-x3701u34-GPU 0" {
+		t.Errorf("GPU Name = %q, want %q", gpuMod.Name, "gpu-GH-x3701u34-GPU 0")
+	}
+
+	nicMod := modsByDevice[deviceIDs["SERV-x3507u21"]]
+	if nicMod == nil {
+		t.Fatal("expected ConnectX-6 module for SERV-x3507u21")
+	}
+	if nicMod.ModuleBayName != "PCIe5" {
+		t.Errorf("NIC ModuleBayName = %q, want %q", nicMod.ModuleBayName, "PCIe5")
+	}
+	if nicMod.Name != "CX6-SERV-x3507u21" {
+		t.Errorf("NIC Name = %q, want %q", nicMod.Name, "CX6-SERV-x3507u21")
+	}
+}
+
+func TestTransformSystem_ManualParity(t *testing.T) {
+	data := &import_.SystemCSV{
+		Defaults:        import_.SystemRecord{Section: "_defaults", Status: "Active"},
+		SectionDefaults: make(map[string]import_.SystemRecord),
+		Racks: []import_.SystemRecord{
+			{Section: "rack", PartNumber: "hpe-48u-800mmx1200mm-g2-enterprise-shock-rack", Name: "x3701", Qty: 1, Status: "Available"},
+			{Section: "rack", PartNumber: "hpe-48u-800mmx1200mm-g2-enterprise-shock-rack", Name: "x3507", Qty: 1, Status: "Available"},
+		},
+		Devices: []import_.SystemRecord{
+			{Section: "device", PartNumber: "hpe-xd670", Name: "GH-x3701u34", Qty: 1, Rack: "x3701", Position: 34, Face: "front", Role: "ComputeNode"},
+			{Section: "device", PartNumber: "hpe-proliant-dl380-gen11-8sff", Name: "SERV-x3507u21", Qty: 1, Rack: "x3507", Position: 21, Face: "front", Role: "ServiceNode"},
+		},
+		Modules: []import_.SystemRecord{
+			{Section: "module", PartNumber: "nvidia-h100-sxm-gpu", Qty: 1, Device: "GH-x3701u34", Bay: "GPU0"},
+			{Section: "module", PartNumber: "nvidia-connectx-6-dx-100gbe-2p-qsfp28", Qty: 1, Device: "SERV-x3507u21", Bay: "PCIe5"},
+		},
+	}
+
+	imported, err := TransformSystem(devicetypes.Inventory{}, data)
+	if err != nil {
+		t.Fatalf("unexpected import error: %v", err)
+	}
+
+	manual := buildManualParityResult(t)
+
+	importedSnapshot := normalizeSystemParity(imported)
+	manualSnapshot := normalizeSystemParity(manual)
+	if !reflect.DeepEqual(importedSnapshot, manualSnapshot) {
+		t.Fatalf("import/manual parity mismatch\nimported: %#v\nmanual: %#v", importedSnapshot, manualSnapshot)
+	}
+}
+
+type systemParitySnapshot struct {
+	Racks   map[string]rackParitySnapshot
+	Devices map[string]deviceParitySnapshot
+	Modules map[string]moduleParitySnapshot
+}
+
+type rackParitySnapshot struct {
+	Slug    string
+	Status  string
+	UHeight int
+}
+
+type deviceParitySnapshot struct {
+	Slug        string
+	Rack        string
+	RackPos     int
+	Face        string
+	Role        string
+	Status      string
+	UHeight     int
+	IsFullDepth bool
+}
+
+type moduleParitySnapshot struct {
+	Slug         string
+	ParentDevice string
+	ModuleBay    string
+	Status       string
+}
+
+func buildManualParityResult(t *testing.T) *devicetypes.TransformResult {
+	t.Helper()
+
+	rack3701, err := devicetypes.NewRackFromSlug("hpe-48u-800mmx1200mm-g2-enterprise-shock-rack")
+	if err != nil {
+		t.Fatalf("NewRackFromSlug x3701: %v", err)
+	}
+	rack3701.Name = "x3701"
+	rack3701.Status = "Available"
+
+	rack3507, err := devicetypes.NewRackFromSlug("hpe-48u-800mmx1200mm-g2-enterprise-shock-rack")
+	if err != nil {
+		t.Fatalf("NewRackFromSlug x3507: %v", err)
+	}
+	rack3507.Name = "x3507"
+	rack3507.Status = "Available"
+
+	deviceGPU, err := devicetypes.NewDeviceFromSlug("hpe-xd670")
+	if err != nil {
+		t.Fatalf("NewDeviceFromSlug hpe-xd670: %v", err)
+	}
+	deviceGPU.Name = "GH-x3701u34"
+	deviceGPU.Status = "Active"
+	deviceGPU.Role = "ComputeNode"
+	deviceGPU.Rack = rack3701.ID
+	deviceGPU.Parent = rack3701.ID
+	deviceGPU.RackPosition = 34
+	deviceGPU.Face = devicetypes.FaceFront
+	rack3701.Devices = append(rack3701.Devices, deviceGPU.ID)
+	rack3701.PlaceDevice(deviceGPU.ID, deviceGPU.RackPosition, deviceGPU.UHeight, deviceGPU.Face, deviceGPU.IsFullDepth)
+
+	deviceService, err := devicetypes.NewDeviceFromSlug("hpe-proliant-dl380-gen11-8sff")
+	if err != nil {
+		t.Fatalf("NewDeviceFromSlug hpe-proliant-dl380-gen11-8sff: %v", err)
+	}
+	deviceService.Name = "SERV-x3507u21"
+	deviceService.Status = "Active"
+	deviceService.Role = "ServiceNode"
+	deviceService.Rack = rack3507.ID
+	deviceService.Parent = rack3507.ID
+	deviceService.RackPosition = 21
+	deviceService.Face = devicetypes.FaceFront
+	rack3507.Devices = append(rack3507.Devices, deviceService.ID)
+	rack3507.PlaceDevice(deviceService.ID, deviceService.RackPosition, deviceService.UHeight, deviceService.Face, deviceService.IsFullDepth)
+
+	gpuModule, err := devicetypes.NewModuleFromSlug("nvidia-h100-sxm-gpu")
+	if err != nil {
+		t.Fatalf("NewModuleFromSlug nvidia-h100-sxm-gpu: %v", err)
+	}
+	gpuModule.Name = "gpu-GH-x3701u34-GPU 0"
+	gpuModule.ParentDevice = deviceGPU.ID
+	gpuModule.ModuleBayName = "GPU 0"
+	gpuModule.Status = "Active"
+
+	nicModule, err := devicetypes.NewModuleFromSlug("nvidia-connectx-6-dx-100gbe-2p-qsfp28")
+	if err != nil {
+		t.Fatalf("NewModuleFromSlug nvidia-connectx-6-dx-100gbe-2p-qsfp28: %v", err)
+	}
+	nicModule.Name = "CX6-SERV-x3507u21"
+	nicModule.ParentDevice = deviceService.ID
+	nicModule.ModuleBayName = "PCIe5"
+	nicModule.Status = "Active"
+
+	return &devicetypes.TransformResult{
+		Racks: map[uuid.UUID]*devicetypes.CaniRackType{
+			rack3701.ID: rack3701,
+			rack3507.ID: rack3507,
+		},
+		Devices: map[uuid.UUID]*devicetypes.CaniDeviceType{
+			deviceGPU.ID:     deviceGPU,
+			deviceService.ID: deviceService,
+		},
+		Modules: map[uuid.UUID]*devicetypes.CaniModuleType{
+			gpuModule.ID: gpuModule,
+			nicModule.ID: nicModule,
+		},
+	}
+}
+
+func normalizeSystemParity(result *devicetypes.TransformResult) systemParitySnapshot {
+	snapshot := systemParitySnapshot{
+		Racks:   make(map[string]rackParitySnapshot),
+		Devices: make(map[string]deviceParitySnapshot),
+		Modules: make(map[string]moduleParitySnapshot),
+	}
+
+	rackNames := make(map[uuid.UUID]string, len(result.Racks))
+	for id, rack := range result.Racks {
+		if rack == nil {
+			continue
+		}
+		rackNames[id] = rack.Name
+		snapshot.Racks[rack.Name] = rackParitySnapshot{
+			Slug:    rack.Slug,
+			Status:  rack.Status,
+			UHeight: rack.UHeight,
+		}
+	}
+
+	deviceNames := make(map[uuid.UUID]string, len(result.Devices))
+	for id, dev := range result.Devices {
+		if dev == nil {
+			continue
+		}
+		deviceNames[id] = dev.Name
+		snapshot.Devices[dev.Name] = deviceParitySnapshot{
+			Slug:        dev.Slug,
+			Rack:        rackNames[dev.Rack],
+			RackPos:     dev.RackPosition,
+			Face:        dev.Face,
+			Role:        dev.Role,
+			Status:      dev.Status,
+			UHeight:     dev.UHeight,
+			IsFullDepth: dev.IsFullDepth,
+		}
+	}
+
+	for _, mod := range result.Modules {
+		if mod == nil {
+			continue
+		}
+		snapshot.Modules[mod.Name] = moduleParitySnapshot{
+			Slug:         mod.Slug,
+			ParentDevice: deviceNames[mod.ParentDevice],
+			ModuleBay:    mod.ModuleBayName,
+			Status:       mod.Status,
+		}
+	}
+
+	return snapshot
+}
+
+func TestTransformSystem_Defaults(t *testing.T) {
+	data := &import_.SystemCSV{
+		Defaults:        import_.SystemRecord{Section: "_defaults", Status: "Active"},
+		SectionDefaults: make(map[string]import_.SystemRecord),
+		Racks: []import_.SystemRecord{
+			{Section: "rack", PartNumber: "hpe-48u-800mmx1200mm-g2-enterprise-shock-rack", Name: "x3701", Qty: 1},
+		},
+		Devices: []import_.SystemRecord{
+			{Section: "device", PartNumber: "hpe-xd670", Name: "node1", Qty: 1, Rack: "x3701", Position: 10, Face: "front"},
+		},
+	}
+
+	result, err := TransformSystem(devicetypes.Inventory{}, data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Rack should inherit Active status from defaults
+	for _, rack := range result.Racks {
+		if rack.Status != "Active" {
+			t.Errorf("rack Status = %q, want %q (from defaults)", rack.Status, "Active")
+		}
+	}
+
+	// Device should inherit Active status from defaults
+	for _, dev := range result.Devices {
+		if dev.Status != "Active" {
+			t.Errorf("device Status = %q, want %q (from defaults)", dev.Status, "Active")
+		}
+	}
+}
+
+func TestTransformSystem_RackQtyMultiple(t *testing.T) {
+	data := &import_.SystemCSV{
+		SectionDefaults: make(map[string]import_.SystemRecord),
+		Racks: []import_.SystemRecord{
+			{Section: "rack", PartNumber: "hpe-48u-800mmx1200mm-g2-enterprise-shock-rack", Name: "rack", Qty: 3, Status: "Available"},
+		},
+	}
+
+	result, err := TransformSystem(devicetypes.Inventory{}, data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Racks) != 3 {
+		t.Fatalf("expected 3 racks, got %d", len(result.Racks))
+	}
+
+	names := make(map[string]bool)
+	for _, rack := range result.Racks {
+		names[rack.Name] = true
+	}
+	for _, expected := range []string{"rack-1", "rack-2", "rack-3"} {
+		if !names[expected] {
+			t.Errorf("expected rack %q, not found in %v", expected, names)
+		}
+	}
+}
+
+func TestTransformSystem_EmptyData(t *testing.T) {
+	data := &import_.SystemCSV{
+		SectionDefaults: make(map[string]import_.SystemRecord),
+	}
+
+	result, err := TransformSystem(devicetypes.Inventory{}, data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Racks) != 0 {
+		t.Errorf("expected 0 racks, got %d", len(result.Racks))
+	}
+	if len(result.Devices) != 0 {
+		t.Errorf("expected 0 devices, got %d", len(result.Devices))
+	}
+}

--- a/pkg/provider/example/transform/transform.go
+++ b/pkg/provider/example/transform/transform.go
@@ -38,6 +38,20 @@ func SetProviderGetter(getter func() interface {
 	providerGetter = getter
 }
 
+// systemProviderGetter returns the Example singleton for system CSV.
+var systemProviderGetter func() interface {
+	GetSystemRecords() *import_.SystemCSV
+	IsSystemImport() bool
+}
+
+// SetSystemProviderGetter allows the parent package to provide system CSV access.
+func SetSystemProviderGetter(getter func() interface {
+	GetSystemRecords() *import_.SystemCSV
+	IsSystemImport() bool
+}) {
+	systemProviderGetter = getter
+}
+
 // classifiedRecords holds records categorized by type.
 type classifiedRecords struct {
 	racks   []import_.CsvRecord
@@ -93,6 +107,14 @@ func classifyRecords(records []import_.CsvRecord) (*classifiedRecords, error) {
 // Uses three passes: racks first, then devices (with parenting), then cables (with linking).
 // Returns a TransformResult containing all created items.
 func Transform(existing devicetypes.Inventory) (*devicetypes.TransformResult, error) {
+	// Check for system CSV format first
+	if systemProviderGetter != nil {
+		sysProv := systemProviderGetter()
+		if sysProv.IsSystemImport() {
+			return TransformSystem(existing, sysProv.GetSystemRecords())
+		}
+	}
+
 	// Reset rack position tracking for fresh import
 	resetRackPositionStates()
 
@@ -337,10 +359,31 @@ func populateFromDeviceType(device *devicetypes.CaniDeviceType, dt *devicetypes.
 	device.Slug = dt.Slug
 	device.Manufacturer = dt.Manufacturer
 	device.Model = dt.Model
+	if dt.Description != "" {
+		device.Description = dt.Description
+	}
 	if dt.Type != "" {
 		device.Type = dt.Type
 	}
+	if dt.UHeight > 0 {
+		device.UHeight = dt.UHeight
+	}
+	device.IsFullDepth = dt.IsFullDepth
+	if dt.Weight > 0 {
+		device.Weight = dt.Weight
+	}
+	if dt.WeightUnit != "" {
+		device.WeightUnit = dt.WeightUnit
+	}
+	if dt.Comments != "" {
+		device.Comments = dt.Comments
+	}
 	device.Interfaces = dt.Interfaces
+	device.ConsolePorts = dt.ConsolePorts
+	device.PowerPorts = dt.PowerPorts
+	device.ModuleBays = dt.ModuleBays
+	device.DeviceBays = dt.DeviceBays
+	device.Identifications = dt.Identifications
 }
 
 // buildProviderMetadata creates provider metadata from a record.

--- a/pkg/provider/hpcm/export/export.go
+++ b/pkg/provider/hpcm/export/export.go
@@ -1,11 +1,63 @@
 package export
 
-import "github.com/Cray-HPE/cani/pkg/devicetypes"
+import (
+	"encoding/json"
+	"fmt"
+	"os"
 
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+)
+
+type node struct {
+	Name       string              `json:"name"`
+	UUID       string              `json:"uuid,omitempty"`
+	Type       string              `json:"type"`
+	Managed    bool                `json:"managed"`
+	Platform   *platformSettings   `json:"platform,omitempty"`
+	Management *managementSettings `json:"management,omitempty"`
+}
+
+type platformSettings struct {
+	Name string `json:"name,omitempty"`
+}
+
+type managementSettings struct {
+	CardType      string `json:"cardType,omitempty"`
+	CardIpAddress string `json:"cardIpAddress,omitempty"`
+}
+
+// Export writes the inventory devices as an HPCM-compatible JSON array of
+// nodes to stdout. Only devices of type "node" or "switch" are included.
 func Export(existing devicetypes.Inventory) error {
-	// Common patterns:
-	//   - Compare local inventory with external system
-	//   - Create/update/delete resources in external system
-	//   - Report what was created, updated, skipped, or errored
+	var nodes []node
+	for _, dev := range existing.Devices {
+		if dev == nil {
+			continue
+		}
+		n := node{
+			Name:    dev.Name,
+			UUID:    dev.ID.String(),
+			Managed: true,
+		}
+		switch dev.Type {
+		case devicetypes.TypeNode:
+			n.Type = "compute"
+		case devicetypes.TypeSwitch:
+			n.Type = "switch"
+		default:
+			continue
+		}
+		if dev.Model != "" {
+			n.Platform = &platformSettings{Name: dev.Model}
+		}
+		n.Management = &managementSettings{CardType: "iLO6"}
+		nodes = append(nodes, n)
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(nodes); err != nil {
+		return fmt.Errorf("encoding HPCM nodes: %w", err)
+	}
 	return nil
 }

--- a/pkg/provider/redfish/export/export.go
+++ b/pkg/provider/redfish/export/export.go
@@ -1,11 +1,75 @@
 package export
 
-import "github.com/Cray-HPE/cani/pkg/devicetypes"
+import (
+	"encoding/json"
+	"fmt"
+	"os"
 
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+)
+
+type serviceRoot struct {
+	OdataID        string  `json:"@odata.id"`
+	OdataType      string  `json:"@odata.type"`
+	ID             string  `json:"Id"`
+	UUID           string  `json:"UUID"`
+	Product        string  `json:"Product"`
+	Vendor         string  `json:"Vendor"`
+	RedfishVersion string  `json:"RedfishVersion"`
+	Oem            oemData `json:"Oem"`
+}
+
+type oemData struct {
+	Hpe *hpeOem `json:"Hpe,omitempty"`
+}
+
+type hpeOem struct {
+	Manager []hpeManager `json:"Manager,omitempty"`
+}
+
+type hpeManager struct {
+	FQDN        string `json:"FQDN,omitempty"`
+	HostName    string `json:"HostName,omitempty"`
+	ManagerType string `json:"ManagerType,omitempty"`
+}
+
+// Export writes the inventory devices as a Redfish-compatible JSON array of
+// ServiceRoot objects to stdout. Only "node" type devices are exported
+// (Redfish is BMC-discovery, switches are excluded).
 func Export(existing devicetypes.Inventory) error {
-	// Common patterns:
-	//   - Compare local inventory with external system
-	//   - Create/update/delete resources in external system
-	//   - Report what was created, updated, skipped, or errored
+	var roots []serviceRoot
+	for _, dev := range existing.Devices {
+		if dev == nil {
+			continue
+		}
+		if dev.Type != devicetypes.TypeNode {
+			continue
+		}
+		r := serviceRoot{
+			OdataID:        "/redfish/v1",
+			OdataType:      "#ServiceRoot.v1_13_0.ServiceRoot",
+			ID:             "RootService",
+			UUID:           dev.ID.String(),
+			Product:        dev.Model,
+			Vendor:         dev.GetVendor(),
+			RedfishVersion: "1.13.0",
+			Oem: oemData{
+				Hpe: &hpeOem{
+					Manager: []hpeManager{{
+						FQDN:        dev.Name + "-bmc.local",
+						HostName:    dev.Name + "-bmc",
+						ManagerType: "iLO 6",
+					}},
+				},
+			},
+		}
+		roots = append(roots, r)
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(roots); err != nil {
+		return fmt.Errorf("encoding Redfish ServiceRoots: %w", err)
+	}
 	return nil
 }

--- a/spec/functional/cani_spec.sh
+++ b/spec/functional/cani_spec.sh
@@ -43,7 +43,7 @@ Describe 'cani'
     End
 
     Describe 'flags'
-      Parameters:value --config --debug --datastore --types-dirs --types-repos --types-repo-clone --types-repo-pull --strict --version
+      Parameters:value --config --debug --datastore --datastore-path --types-dirs --types-repos --types-repo-clone --types-repo-pull --strict --version
       It "has $1 flag"
         When call bin/cani --help
         The stdout should include "$1"

--- a/spec/functional/import_export_spec.sh
+++ b/spec/functional/import_export_spec.sh
@@ -44,23 +44,23 @@ import_fixture() {
   case "$_ie_provider" in
     example)
       bin/cani alpha import example \
-        --csv "$FIXTURES/example/simple.csv" \
+        --csv "$FIXTURES/matrix/example.csv" \
         --config "$CANI_CONF" --datastore-path "$_ie_ds" ;;
     ochami)
       bin/cani alpha import ochami \
-        --jsonfile "$FIXTURES/ochami/ochami_test_data.json" \
+        --jsonfile "$FIXTURES/matrix/ochami.json" \
         --config "$CANI_CONF" --datastore-path "$_ie_ds" ;;
     redfish)
       bin/cani alpha import redfish \
-        --root "$FIXTURES/redfish/v1/redfish-root.json" \
+        --root "$FIXTURES/matrix/redfish.json" \
         --config "$CANI_CONF" --datastore-path "$_ie_ds" ;;
     hpcm)
       bin/cani alpha import hpcm \
-        --node-json-file "$FIXTURES/hpcm/nodes.json" \
+        --node-json-file "$FIXTURES/matrix/hpcm.json" \
         --config "$CANI_CONF" --datastore-path "$_ie_ds" ;;
     csm)
       bin/cani alpha import csm \
-        --sls-file "$FIXTURES/csm/sls/valid_hardware_networks.json" \
+        --sls-file "$FIXTURES/matrix/csm_sls.json" \
         --ignore-validation \
         --config "$CANI_CONF" --datastore-path "$_ie_ds" ;;
   esac

--- a/spec/functional/import_export_spec.sh
+++ b/spec/functional/import_export_spec.sh
@@ -29,10 +29,11 @@
 # to isolate each test from pre-existing data.
 #
 # Structure:
-#   1. --help         — exits 0 for every provider × operation
-#   2. import         — each provider imports its fixture successfully
-#   3. <src> to <dst> — each import source fans out to all export targets
-#   4. nautobot API   — API-based tests requiring a running Nautobot
+#   1. --help            — exits 0 for every provider × operation
+#   2. import            — each provider imports its fixture successfully
+#   2b. show consistency — show device returns expected counts per provider
+#   3. <src> to <dst>    — each import source fans out to all export targets
+#   4. nautobot API      — API-based tests requiring a running Nautobot
 
 # Unique datastore path per test to avoid interference.
 ie_ds() { echo "/tmp/.cani/ie_test_${1}.json"; }
@@ -150,6 +151,71 @@ Describe 'import from'
     It 'creates datastore'
       The path "$(ie_ds import_csm)" should be file
     End
+  End
+End
+
+# ── 2b. show consistency ──────────────────────────────────────────
+#
+# After importing, run `cani show device` against each provider's
+# datastore and verify:
+#   a) the command exits 0 (inventory is queryable)
+#   b) the device count matches the expected value for each provider
+#
+# This confirms the import pipeline produces deterministic, consistent
+# results that the show layer can consume.
+
+Describe 'show device after import'
+  BeforeAll 'setup_test_env'
+  AfterAll  'teardown_test_env'
+
+  #shellcheck disable=SC2317
+  _setup_show() {
+    import_fixture example "$(ie_ds show_example)" 2>/dev/null
+    import_fixture ochami  "$(ie_ds show_ochami)"  2>/dev/null
+    import_fixture redfish "$(ie_ds show_redfish)" 2>/dev/null
+    import_fixture hpcm    "$(ie_ds show_hpcm)"    2>/dev/null
+    import_fixture csm     "$(ie_ds show_csm)"     2>/dev/null
+  }
+  BeforeAll '_setup_show'
+
+  It 'example reports 6 devices'
+    When call bin/cani alpha show device \
+      --config "$CANI_CONF" \
+      --datastore-path "$(ie_ds show_example)"
+    The status should equal 0
+    The stdout should include 'Total: 6 device(s)'
+  End
+
+  It 'ochami reports 26 devices'
+    When call bin/cani alpha show device \
+      --config "$CANI_CONF" \
+      --datastore-path "$(ie_ds show_ochami)"
+    The status should equal 0
+    The stdout should include 'Total: 26 device(s)'
+  End
+
+  It 'redfish reports 4 devices'
+    When call bin/cani alpha show device \
+      --config "$CANI_CONF" \
+      --datastore-path "$(ie_ds show_redfish)"
+    The status should equal 0
+    The stdout should include 'Total: 4 device(s)'
+  End
+
+  It 'hpcm reports 6 devices'
+    When call bin/cani alpha show device \
+      --config "$CANI_CONF" \
+      --datastore-path "$(ie_ds show_hpcm)"
+    The status should equal 0
+    The stdout should include 'Total: 6 device(s)'
+  End
+
+  It 'csm reports 15 devices'
+    When call bin/cani alpha show device \
+      --config "$CANI_CONF" \
+      --datastore-path "$(ie_ds show_csm)"
+    The status should equal 0
+    The stdout should include 'Total: 15 device(s)'
   End
 End
 

--- a/spec/functional/import_export_spec.sh
+++ b/spec/functional/import_export_spec.sh
@@ -27,259 +27,274 @@
 #
 # Tests import and export across all providers using --datastore-path
 # to isolate each test from pre-existing data.
+#
+# Structure:
+#   1. --help         — exits 0 for every provider × operation
+#   2. import         — each provider imports its fixture successfully
+#   3. <src> to <dst> — each import source fans out to all export targets
+#   4. nautobot API   — API-based tests requiring a running Nautobot
 
-# Unique datastore path per provider to avoid test interference.
+# Unique datastore path per test to avoid interference.
 ie_ds() { echo "/tmp/.cani/ie_test_${1}.json"; }
 
-# ── 1. help flag matrix ────────────────────────────────────────────
+# Import a fixture for the given provider into the given datastore.
+#shellcheck disable=SC2317
+import_fixture() {
+  _ie_provider="$1" _ie_ds="$2"
+  case "$_ie_provider" in
+    example)
+      bin/cani alpha import example \
+        --csv "$FIXTURES/example/simple.csv" \
+        --config "$CANI_CONF" --datastore-path "$_ie_ds" ;;
+    ochami)
+      bin/cani alpha import ochami \
+        --jsonfile "$FIXTURES/ochami/ochami_test_data.json" \
+        --config "$CANI_CONF" --datastore-path "$_ie_ds" ;;
+    redfish)
+      bin/cani alpha import redfish \
+        --root "$FIXTURES/redfish/v1/redfish-root.json" \
+        --config "$CANI_CONF" --datastore-path "$_ie_ds" ;;
+    hpcm)
+      bin/cani alpha import hpcm \
+        --node-json-file "$FIXTURES/hpcm/nodes.json" \
+        --config "$CANI_CONF" --datastore-path "$_ie_ds" ;;
+    csm)
+      bin/cani alpha import csm \
+        --sls-file "$FIXTURES/csm/sls/valid_hardware_networks.json" \
+        --ignore-validation \
+        --config "$CANI_CONF" --datastore-path "$_ie_ds" ;;
+  esac
+}
+
+# ── 1. --help ──────────────────────────────────────────────────────
 #
 # Parameters:matrix produces the cross-product of providers × operations.
 # Every combination must accept --help and exit 0.
 
-Describe 'import/export --help (matrix)'
+Describe '--help'
   Parameters:matrix
     csm hpcm example nautobot ochami redfish
     import export
   End
 
-  It "cani alpha $2 $1 --help exits 0"
+  It "$2 $1 exits 0"
     When call bin/cani alpha "$2" "$1" --help
     The status should equal 0
     The stdout should include 'Usage:'
   End
 End
 
-# ── 2. file-based import ───────────────────────────────────────────
+# ── 2. import ──────────────────────────────────────────────────────
+#
+# Each provider imports its fixture file and produces a datastore.
 
-Describe 'file-based import'
+Describe 'import from'
   BeforeAll 'setup_test_env'
   AfterAll  'teardown_test_env'
 
   Describe 'example (CSV)'
-    It 'imports from a CSV fixture'
-      When call bin/cani alpha import example \
-        --csv "$FIXTURES/example/simple.csv" \
-        --config "$CANI_CONF" \
-        --datastore-path "$(ie_ds example_csv)"
+    It 'succeeds'
+      When call import_fixture example "$(ie_ds import_example)"
       The status should equal 0
       The stderr should include 'Import completed successfully'
     End
 
-    It 'creates the datastore file'
-      The path "$(ie_ds example_csv)" should be file
+    It 'creates datastore'
+      The path "$(ie_ds import_example)" should be file
     End
   End
 
   Describe 'ochami (JSON)'
-    It 'imports from a JSON fixture'
-      When call bin/cani alpha import ochami \
-        --jsonfile "$FIXTURES/ochami/ochami_test_data.json" \
-        --config "$CANI_CONF" \
-        --datastore-path "$(ie_ds ochami)"
+    It 'succeeds'
+      When call import_fixture ochami "$(ie_ds import_ochami)"
       The status should equal 0
       The stderr should include 'Import completed successfully'
     End
 
-    It 'creates the datastore file'
-      The path "$(ie_ds ochami)" should be file
+    It 'creates datastore'
+      The path "$(ie_ds import_ochami)" should be file
     End
   End
 
   Describe 'redfish (JSON)'
-    It 'imports from a ServiceRoot fixture'
-      When call bin/cani alpha import redfish \
-        --root "$FIXTURES/redfish/v1/redfish-root.json" \
-        --config "$CANI_CONF" \
-        --datastore-path "$(ie_ds redfish)"
+    It 'succeeds'
+      When call import_fixture redfish "$(ie_ds import_redfish)"
       The status should equal 0
       The stderr should include 'Import completed successfully'
     End
 
-    It 'creates the datastore file'
-      The path "$(ie_ds redfish)" should be file
+    It 'creates datastore'
+      The path "$(ie_ds import_redfish)" should be file
     End
   End
 
-  Describe 'hpcm (node JSON)'
-    It 'imports from a node JSON fixture'
-      When call bin/cani alpha import hpcm \
-        --node-json-file "$FIXTURES/hpcm/nodes.json" \
-        --config "$CANI_CONF" \
-        --datastore-path "$(ie_ds hpcm)"
+  Describe 'hpcm (JSON)'
+    It 'succeeds'
+      When call import_fixture hpcm "$(ie_ds import_hpcm)"
       The status should equal 0
       The stderr should include 'Import completed successfully'
     End
 
-    It 'creates the datastore file'
-      The path "$(ie_ds hpcm)" should be file
+    It 'creates datastore'
+      The path "$(ie_ds import_hpcm)" should be file
     End
   End
 
-  Describe 'csm (SLS file)'
-    It 'imports from an SLS dumpstate fixture'
-      When call bin/cani alpha import csm \
-        --sls-file "$FIXTURES/csm/sls/valid_hardware_networks.json" \
-        --ignore-validation \
-        --config "$CANI_CONF" \
-        --datastore-path "$(ie_ds csm)"
+  Describe 'csm (SLS)'
+    It 'succeeds'
+      When call import_fixture csm "$(ie_ds import_csm)"
       The status should equal 0
       The stderr should include 'Import completed successfully'
     End
 
-    It 'creates the datastore file'
-      The path "$(ie_ds csm)" should be file
+    It 'creates datastore'
+      The path "$(ie_ds import_csm)" should be file
     End
   End
 End
 
-# ── 3. file-based export ───────────────────────────────────────────
+# ── 3. import → export matrix ─────────────────────────────────────
 #
-# Pre-populate a datastore with the CRUD inventory then export via
-# each provider. Providers that are no-ops (hpcm, redfish) simply
-# verify exit 0. Providers that produce output (example, ochami, csm)
-# also check stdout.
-
-Describe 'file-based export'
-  setup_export_env() {
-    setup_test_env
-    cp "$FIXTURES/cani/crud_inventory.json" "$(ie_ds export_example)"
-    cp "$FIXTURES/cani/crud_inventory.json" "$(ie_ds export_ochami)"
-    cp "$FIXTURES/cani/crud_inventory.json" "$(ie_ds export_redfish)"
-    cp "$FIXTURES/cani/crud_inventory.json" "$(ie_ds export_hpcm)"
-    cp "$FIXTURES/cani/crud_inventory.json" "$(ie_ds export_csm)"
-  }
-
-  BeforeAll 'setup_export_env'
-  AfterAll  'teardown_test_env'
-
-  Describe 'example'
-    It 'exports the inventory'
-      When call bin/cani alpha export example \
-        --config "$CANI_CONF" \
-        --datastore-path "$(ie_ds export_example)"
-      The status should equal 0
-      The stdout should include 'Summary:'
-      The stderr should include 'Export completed successfully'
-    End
-  End
-
-  Describe 'ochami'
-    It 'exports the inventory'
-      When call bin/cani alpha export ochami \
-        --config "$CANI_CONF" \
-        --datastore-path "$(ie_ds export_ochami)"
-      The status should equal 0
-      The stdout should include 'nodes:'
-      The stderr should include 'Export completed successfully'
-    End
-  End
-
-  Describe 'redfish'
-    It 'exports the inventory'
-      When call bin/cani alpha export redfish \
-        --config "$CANI_CONF" \
-        --datastore-path "$(ie_ds export_redfish)"
-      The status should equal 0
-      The stderr should include 'Export completed successfully'
-    End
-  End
-
-  Describe 'hpcm'
-    It 'exports the inventory'
-      When call bin/cani alpha export hpcm \
-        --config "$CANI_CONF" \
-        --datastore-path "$(ie_ds export_hpcm)"
-      The status should equal 0
-      The stderr should include 'Export completed successfully'
-    End
-  End
-
-  Describe 'csm (CSV mode)'
-    It 'exports the inventory as CSV'
-      When call bin/cani alpha export csm \
-        --config "$CANI_CONF" \
-        --datastore-path "$(ie_ds export_csm)"
-      The status should equal 0
-      The stdout should include 'Type,Vlan,Role'
-      The stderr should include 'Export completed successfully'
-    End
-  End
-End
-
-# ── 4. round-trip (import → export) ────────────────────────────────
+# For each file-based import source, import the fixture once, then
+# export through every file-based provider.  This verifies:
+#   a) the import produces a valid provider-agnostic datastore
+#   b) every exporter can consume any datastore
 #
-# Import a fixture, then immediately export. Verifies the full ETL
-# pipeline produces consistent output for file-based providers.
+# Same-provider pairs include additional format assertions.
+# Test names read as: "<source> to <target> succeeds".
 
-Describe 'import → export round-trip'
+Describe 'import from example (CSV)'
   BeforeAll 'setup_test_env'
   AfterAll  'teardown_test_env'
 
-  Describe 'example (CSV → visual export)'
-    It 'imports successfully'
-      When call bin/cani alpha import example \
-        --csv "$FIXTURES/example/simple.csv" \
-        --config "$CANI_CONF" \
-        --datastore-path "$(ie_ds roundtrip_example)"
-      The status should equal 0
-      The stderr should include 'Import completed successfully'
-    End
+  #shellcheck disable=SC2317
+  _setup_example() { import_fixture example "$(ie_ds matrix_example)" 2>/dev/null; }
+  BeforeAll '_setup_example'
 
-    It 'exports the imported data'
-      When call bin/cani alpha export example \
+  Describe 'export to'
+    Parameters:value example ochami redfish hpcm csm
+    It "$1 succeeds"
+      When call bin/cani alpha export "$1" \
         --config "$CANI_CONF" \
-        --datastore-path "$(ie_ds roundtrip_example)"
+        --datastore-path "$(ie_ds matrix_example)"
       The status should equal 0
-      The stdout should include 'Summary:'
+      The stdout should be defined
       The stderr should include 'Export completed successfully'
     End
   End
 
-  Describe 'ochami (JSON → YAML export)'
-    It 'imports successfully'
-      When call bin/cani alpha import ochami \
-        --jsonfile "$FIXTURES/ochami/ochami_test_data.json" \
-        --config "$CANI_CONF" \
-        --datastore-path "$(ie_ds roundtrip_ochami)"
-      The status should equal 0
-      The stderr should include 'Import completed successfully'
-    End
+  It 'to example output includes Summary'
+    When call bin/cani alpha export example \
+      --config "$CANI_CONF" \
+      --datastore-path "$(ie_ds matrix_example)"
+    The stdout should include 'Summary:'
+    The stderr should include 'Export completed successfully'
+  End
+End
 
-    It 'exports the imported data'
-      When call bin/cani alpha export ochami \
+Describe 'import from ochami (JSON)'
+  BeforeAll 'setup_test_env'
+  AfterAll  'teardown_test_env'
+
+  #shellcheck disable=SC2317
+  _setup_ochami() { import_fixture ochami "$(ie_ds matrix_ochami)" 2>/dev/null; }
+  BeforeAll '_setup_ochami'
+
+  Describe 'export to'
+    Parameters:value example ochami redfish hpcm csm
+    It "$1 succeeds"
+      When call bin/cani alpha export "$1" \
         --config "$CANI_CONF" \
-        --datastore-path "$(ie_ds roundtrip_ochami)"
+        --datastore-path "$(ie_ds matrix_ochami)"
       The status should equal 0
-      The stdout should include 'nodes:'
+      The stdout should be defined
       The stderr should include 'Export completed successfully'
     End
   End
 
-  Describe 'csm (SLS file → CSV export)'
-    It 'imports successfully'
-      When call bin/cani alpha import csm \
-        --sls-file "$FIXTURES/csm/sls/valid_hardware_networks.json" \
-        --ignore-validation \
-        --config "$CANI_CONF" \
-        --datastore-path "$(ie_ds roundtrip_csm)"
-      The status should equal 0
-      The stderr should include 'Import completed successfully'
-    End
+  It 'to ochami output includes nodes'
+    When call bin/cani alpha export ochami \
+      --config "$CANI_CONF" \
+      --datastore-path "$(ie_ds matrix_ochami)"
+    The stdout should include 'nodes:'
+    The stderr should include 'Export completed successfully'
+  End
+End
 
-    It 'exports the imported data'
-      When call bin/cani alpha export csm \
+Describe 'import from redfish (JSON)'
+  BeforeAll 'setup_test_env'
+  AfterAll  'teardown_test_env'
+
+  #shellcheck disable=SC2317
+  _setup_redfish() { import_fixture redfish "$(ie_ds matrix_redfish)" 2>/dev/null; }
+  BeforeAll '_setup_redfish'
+
+  Describe 'export to'
+    Parameters:value example ochami redfish hpcm csm
+    It "$1 succeeds"
+      When call bin/cani alpha export "$1" \
         --config "$CANI_CONF" \
-        --datastore-path "$(ie_ds roundtrip_csm)"
+        --datastore-path "$(ie_ds matrix_redfish)"
       The status should equal 0
-      The stdout should include 'Type,Vlan,Role'
+      The stdout should be defined
       The stderr should include 'Export completed successfully'
     End
   End
 End
 
-# ── 5. external service providers ──────────────────────────────────
+Describe 'import from hpcm (JSON)'
+  BeforeAll 'setup_test_env'
+  AfterAll  'teardown_test_env'
+
+  #shellcheck disable=SC2317
+  _setup_hpcm() { import_fixture hpcm "$(ie_ds matrix_hpcm)" 2>/dev/null; }
+  BeforeAll '_setup_hpcm'
+
+  Describe 'export to'
+    Parameters:value example ochami redfish hpcm csm
+    It "$1 succeeds"
+      When call bin/cani alpha export "$1" \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds matrix_hpcm)"
+      The status should equal 0
+      The stdout should be defined
+      The stderr should include 'Export completed successfully'
+    End
+  End
+End
+
+Describe 'import from csm (SLS)'
+  BeforeAll 'setup_test_env'
+  AfterAll  'teardown_test_env'
+
+  #shellcheck disable=SC2317
+  _setup_csm() { import_fixture csm "$(ie_ds matrix_csm)" 2>/dev/null; }
+  BeforeAll '_setup_csm'
+
+  Describe 'export to'
+    Parameters:value example ochami redfish hpcm csm
+    It "$1 succeeds"
+      When call bin/cani alpha export "$1" \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds matrix_csm)"
+      The status should equal 0
+      The stdout should be defined
+      The stderr should include 'Export completed successfully'
+    End
+  End
+
+  It 'to csm output includes CSV headers'
+    When call bin/cani alpha export csm \
+      --config "$CANI_CONF" \
+      --datastore-path "$(ie_ds matrix_csm)"
+    The stdout should include 'Type,Vlan,Role'
+    The stderr should include 'Export completed successfully'
+  End
+End
+
+# ── 4. nautobot API ───────────────────────────────────────────────
 #
-# Nautobot and CSM API-based tests require running services.
+# Nautobot tests require a running API server.
 # Skip when SKIP_EXTERNAL_TESTS is set or when Nautobot is unreachable.
 
 external_tests_disabled() { [ "${SKIP_EXTERNAL_TESTS:-0}" = "1" ]; }
@@ -288,14 +303,14 @@ nautobot_unreachable() {
     "${NAUTOBOT_URL}/status/" >/dev/null 2>&1
 }
 
-Describe 'nautobot import (API)'
+Describe 'nautobot API'
   Skip if 'external tests disabled' external_tests_disabled
   Skip if 'Nautobot is not reachable' nautobot_unreachable
 
   BeforeAll 'setup_nautobot_env'
   AfterAll  'teardown_test_env'
 
-  It 'imports from the Nautobot API'
+  It 'import succeeds'
     When call bin/cani alpha import nautobot \
       --config "$CANI_CONF" \
       --datastore-path "$(ie_ds nautobot)"
@@ -304,28 +319,27 @@ Describe 'nautobot import (API)'
   End
 End
 
-Describe 'nautobot export (API, dry-run)'
+Describe 'nautobot API'
   Skip if 'external tests disabled' external_tests_disabled
   Skip if 'Nautobot is not reachable' nautobot_unreachable
 
-  # Pre-populate the datastore so export has inventory to process,
-  # regardless of whether Nautobot contains data.
-  setup_nautobot_export() {
+  #shellcheck disable=SC2317
+  _setup_nautobot_export() {
     setup_nautobot_env
     cp "$FIXTURES/cani/crud_inventory.json" "$(ie_ds nautobot_export)"
   }
 
-  BeforeAll 'setup_nautobot_export'
+  BeforeAll '_setup_nautobot_export'
   AfterAll  'teardown_test_env'
 
-  It 'connects to Nautobot and processes the export pipeline'
+  It 'export dry-run connects and processes pipeline'
     When call bin/cani alpha export nautobot \
       --dry-run \
       --config "$CANI_CONF" \
       --datastore-path "$(ie_ds nautobot_export)"
     # Exit status may be non-zero due to fixture/schema mismatches with
-    # an empty Nautobot — the functional test verifies connectivity and
-    # pipeline execution, not data correctness.
+    # an empty Nautobot — the test verifies connectivity and pipeline
+    # execution, not data correctness.
     The status should not equal ""
     The stderr should include 'Successfully connected to Nautobot'
     The stderr should include 'Nautobot Sync Summary'

--- a/spec/functional/import_export_spec.sh
+++ b/spec/functional/import_export_spec.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env sh
+#
+# MIT License
+#
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# ── import / export ─────────────────────────────────────────────────
+#
+# Tests import and export across all providers using --datastore-path
+# to isolate each test from pre-existing data.
+
+# Unique datastore path per provider to avoid test interference.
+ie_ds() { echo "/tmp/.cani/ie_test_${1}.json"; }
+
+# ── 1. help flag matrix ────────────────────────────────────────────
+#
+# Parameters:matrix produces the cross-product of providers × operations.
+# Every combination must accept --help and exit 0.
+
+Describe 'import/export --help (matrix)'
+  Parameters:matrix
+    csm hpcm example nautobot ochami redfish
+    import export
+  End
+
+  It "cani alpha $2 $1 --help exits 0"
+    When call bin/cani alpha "$2" "$1" --help
+    The status should equal 0
+    The stdout should include 'Usage:'
+  End
+End
+
+# ── 2. file-based import ───────────────────────────────────────────
+
+Describe 'file-based import'
+  BeforeAll 'setup_test_env'
+  AfterAll  'teardown_test_env'
+
+  Describe 'example (CSV)'
+    It 'imports from a CSV fixture'
+      When call bin/cani alpha import example \
+        --csv "$FIXTURES/example/simple.csv" \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds example_csv)"
+      The status should equal 0
+      The stderr should include 'Import completed successfully'
+    End
+
+    It 'creates the datastore file'
+      The path "$(ie_ds example_csv)" should be file
+    End
+  End
+
+  Describe 'ochami (JSON)'
+    It 'imports from a JSON fixture'
+      When call bin/cani alpha import ochami \
+        --jsonfile "$FIXTURES/ochami/ochami_test_data.json" \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds ochami)"
+      The status should equal 0
+      The stderr should include 'Import completed successfully'
+    End
+
+    It 'creates the datastore file'
+      The path "$(ie_ds ochami)" should be file
+    End
+  End
+
+  Describe 'redfish (JSON)'
+    It 'imports from a ServiceRoot fixture'
+      When call bin/cani alpha import redfish \
+        --root "$FIXTURES/redfish/v1/redfish-root.json" \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds redfish)"
+      The status should equal 0
+      The stderr should include 'Import completed successfully'
+    End
+
+    It 'creates the datastore file'
+      The path "$(ie_ds redfish)" should be file
+    End
+  End
+
+  Describe 'hpcm (node JSON)'
+    It 'imports from a node JSON fixture'
+      When call bin/cani alpha import hpcm \
+        --node-json-file "$FIXTURES/hpcm/nodes.json" \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds hpcm)"
+      The status should equal 0
+      The stderr should include 'Import completed successfully'
+    End
+
+    It 'creates the datastore file'
+      The path "$(ie_ds hpcm)" should be file
+    End
+  End
+
+  Describe 'csm (SLS file)'
+    It 'imports from an SLS dumpstate fixture'
+      When call bin/cani alpha import csm \
+        --sls-file "$FIXTURES/csm/sls/valid_hardware_networks.json" \
+        --ignore-validation \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds csm)"
+      The status should equal 0
+      The stderr should include 'Import completed successfully'
+    End
+
+    It 'creates the datastore file'
+      The path "$(ie_ds csm)" should be file
+    End
+  End
+End
+
+# ── 3. file-based export ───────────────────────────────────────────
+#
+# Pre-populate a datastore with the CRUD inventory then export via
+# each provider. Providers that are no-ops (hpcm, redfish) simply
+# verify exit 0. Providers that produce output (example, ochami, csm)
+# also check stdout.
+
+Describe 'file-based export'
+  setup_export_env() {
+    setup_test_env
+    cp "$FIXTURES/cani/crud_inventory.json" "$(ie_ds export_example)"
+    cp "$FIXTURES/cani/crud_inventory.json" "$(ie_ds export_ochami)"
+    cp "$FIXTURES/cani/crud_inventory.json" "$(ie_ds export_redfish)"
+    cp "$FIXTURES/cani/crud_inventory.json" "$(ie_ds export_hpcm)"
+    cp "$FIXTURES/cani/crud_inventory.json" "$(ie_ds export_csm)"
+  }
+
+  BeforeAll 'setup_export_env'
+  AfterAll  'teardown_test_env'
+
+  Describe 'example'
+    It 'exports the inventory'
+      When call bin/cani alpha export example \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds export_example)"
+      The status should equal 0
+      The stdout should include 'Summary:'
+      The stderr should include 'Export completed successfully'
+    End
+  End
+
+  Describe 'ochami'
+    It 'exports the inventory'
+      When call bin/cani alpha export ochami \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds export_ochami)"
+      The status should equal 0
+      The stdout should include 'nodes:'
+      The stderr should include 'Export completed successfully'
+    End
+  End
+
+  Describe 'redfish'
+    It 'exports the inventory'
+      When call bin/cani alpha export redfish \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds export_redfish)"
+      The status should equal 0
+      The stderr should include 'Export completed successfully'
+    End
+  End
+
+  Describe 'hpcm'
+    It 'exports the inventory'
+      When call bin/cani alpha export hpcm \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds export_hpcm)"
+      The status should equal 0
+      The stderr should include 'Export completed successfully'
+    End
+  End
+
+  Describe 'csm (CSV mode)'
+    It 'exports the inventory as CSV'
+      When call bin/cani alpha export csm \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds export_csm)"
+      The status should equal 0
+      The stdout should include 'Type,Vlan,Role'
+      The stderr should include 'Export completed successfully'
+    End
+  End
+End
+
+# ── 4. round-trip (import → export) ────────────────────────────────
+#
+# Import a fixture, then immediately export. Verifies the full ETL
+# pipeline produces consistent output for file-based providers.
+
+Describe 'import → export round-trip'
+  BeforeAll 'setup_test_env'
+  AfterAll  'teardown_test_env'
+
+  Describe 'example (CSV → visual export)'
+    It 'imports successfully'
+      When call bin/cani alpha import example \
+        --csv "$FIXTURES/example/simple.csv" \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds roundtrip_example)"
+      The status should equal 0
+      The stderr should include 'Import completed successfully'
+    End
+
+    It 'exports the imported data'
+      When call bin/cani alpha export example \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds roundtrip_example)"
+      The status should equal 0
+      The stdout should include 'Summary:'
+      The stderr should include 'Export completed successfully'
+    End
+  End
+
+  Describe 'ochami (JSON → YAML export)'
+    It 'imports successfully'
+      When call bin/cani alpha import ochami \
+        --jsonfile "$FIXTURES/ochami/ochami_test_data.json" \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds roundtrip_ochami)"
+      The status should equal 0
+      The stderr should include 'Import completed successfully'
+    End
+
+    It 'exports the imported data'
+      When call bin/cani alpha export ochami \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds roundtrip_ochami)"
+      The status should equal 0
+      The stdout should include 'nodes:'
+      The stderr should include 'Export completed successfully'
+    End
+  End
+
+  Describe 'csm (SLS file → CSV export)'
+    It 'imports successfully'
+      When call bin/cani alpha import csm \
+        --sls-file "$FIXTURES/csm/sls/valid_hardware_networks.json" \
+        --ignore-validation \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds roundtrip_csm)"
+      The status should equal 0
+      The stderr should include 'Import completed successfully'
+    End
+
+    It 'exports the imported data'
+      When call bin/cani alpha export csm \
+        --config "$CANI_CONF" \
+        --datastore-path "$(ie_ds roundtrip_csm)"
+      The status should equal 0
+      The stdout should include 'Type,Vlan,Role'
+      The stderr should include 'Export completed successfully'
+    End
+  End
+End
+
+# ── 5. external service providers ──────────────────────────────────
+#
+# Nautobot and CSM API-based tests require running services.
+# Skip when SKIP_EXTERNAL_TESTS is set or when Nautobot is unreachable.
+
+external_tests_disabled() { [ "${SKIP_EXTERNAL_TESTS:-0}" = "1" ]; }
+nautobot_unreachable() {
+  ! curl -sf -H "Authorization: Token ${NAUTOBOT_TOKEN}" \
+    "${NAUTOBOT_URL}/status/" >/dev/null 2>&1
+}
+
+Describe 'nautobot import (API)'
+  Skip if 'external tests disabled' external_tests_disabled
+  Skip if 'Nautobot is not reachable' nautobot_unreachable
+
+  BeforeAll 'setup_nautobot_env'
+  AfterAll  'teardown_test_env'
+
+  It 'imports from the Nautobot API'
+    When call bin/cani alpha import nautobot \
+      --config "$CANI_CONF" \
+      --datastore-path "$(ie_ds nautobot)"
+    The status should equal 0
+    The stderr should include 'Import completed successfully'
+  End
+End
+
+Describe 'nautobot export (API, dry-run)'
+  Skip if 'external tests disabled' external_tests_disabled
+  Skip if 'Nautobot is not reachable' nautobot_unreachable
+
+  # Pre-populate the datastore so export has inventory to process,
+  # regardless of whether Nautobot contains data.
+  setup_nautobot_export() {
+    setup_nautobot_env
+    cp "$FIXTURES/cani/crud_inventory.json" "$(ie_ds nautobot_export)"
+  }
+
+  BeforeAll 'setup_nautobot_export'
+  AfterAll  'teardown_test_env'
+
+  It 'connects to Nautobot and processes the export pipeline'
+    When call bin/cani alpha export nautobot \
+      --dry-run \
+      --config "$CANI_CONF" \
+      --datastore-path "$(ie_ds nautobot_export)"
+    # Exit status may be non-zero due to fixture/schema mismatches with
+    # an empty Nautobot — the functional test verifies connectivity and
+    # pipeline execution, not data correctness.
+    The status should not equal ""
+    The stderr should include 'Successfully connected to Nautobot'
+    The stderr should include 'Nautobot Sync Summary'
+  End
+End

--- a/testdata/fixtures/example/system.csv
+++ b/testdata/fixtures/example/system.csv
@@ -1,0 +1,26 @@
+Section,PartNumber,Name,Qty,Rack,Position,Face,Role,Status,Serial,Device,Bay,ADevice,APort,BDevice,BPort,Color,Length,LengthUnit,Location,ContentTypes
+_defaults,,,,,,,,Active,,,,,,,,,,,,
+# Roles
+role,,ComputeNode,,,,,,,,,,,,,,,,,,dcim.device
+role,,ManagementSwitch,,,,,,,,,,,,,,,,,,dcim.device
+role,,HSNSwitch,,,,,,,,,,,,,,,,,,dcim.device
+# Racks
+rack,hpe-48u-800mmx1200mm-g2-enterprise-shock-rack,x3701,1,,,,,Available,,,,,,,,,,,,
+rack,hpe-48u-800mmx1200mm-g2-enterprise-shock-rack,x3702,1,,,,,Available,,,,,,,,,,,,
+# Devices in x3701
+device,hpe-aruba-2930f-48g-4sfp,MAN-x3701u48,1,x3701,48,rear,ManagementSwitch,Active,TW39KM301C,,,,,,,,,,,
+device,nvidia-infiniband-ndr-64-port-osfp-switch,HSNS-x3701u43,1,x3701,43,rear,HSNSwitch,Active,1I033601TL,,,,,,,,,,,
+device,hpe-xd670,GH-x3701u34,1,x3701,34,front,ComputeNode,Active,5UF435KF42,,,,,,,,,,,
+device,hpe-xd670,GH-x3701u26,1,x3701,26,front,ComputeNode,Active,5UF435KF41,,,,,,,,,,,
+# Devices in x3702
+device,hpe-aruba-2930f-48g-4sfp,MAN-x3702u48,1,x3702,48,rear,ManagementSwitch,Active,TW34HKV07C,,,,,,,,,,,
+device,hpe-xd670,GH-x3702u34,1,x3702,34,front,ComputeNode,Active,5UF435KF46,,,,,,,,,,,
+# Modules (GPUs in x3701 nodes)
+module,nvidia-h100-sxm-gpu,,1,,,,,,,GH-x3701u34,GPU0,,,,,,,,,,
+module,nvidia-h100-sxm-gpu,,1,,,,,,,GH-x3701u34,GPU1,,,,,,,,,,
+module,nvidia-h100-sxm-gpu,,1,,,,,,,GH-x3701u26,GPU0,,,,,,,,,,
+# Connections — management
+connection,hpe-3m-cat6-stp,,,,,,,,,,,GH-x3701u34,iLO,MAN-x3701u48,1,blue,3,m,,
+connection,hpe-3m-cat6-stp,,,,,,,,,,,GH-x3701u26,iLO,MAN-x3701u48,2,blue,3,m,,
+# Connections — HSN (with brace expansion)
+connection,hpe-ib-ndr-osfp-dac-cable,,,,,,,,,,,GH-x3701u34,HSN {0..3},HSNS-x3701u43,{1..4},green,2,m,,

--- a/testdata/fixtures/hpcm/nodes.json
+++ b/testdata/fixtures/hpcm/nodes.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "node001",
+    "uuid": "11111111-1111-1111-1111-111111111111",
+    "type": "compute",
+    "managed": true,
+    "platform": {
+      "type": "ProLiant DL380 Gen11",
+      "manufacturer": "HPE"
+    },
+    "management": {
+      "bmcAddress": "10.0.0.1",
+      "bmcType": "iLO6"
+    }
+  },
+  {
+    "name": "node002",
+    "uuid": "22222222-2222-2222-2222-222222222222",
+    "type": "compute",
+    "managed": true,
+    "platform": {
+      "type": "ProLiant DL325 Gen11",
+      "manufacturer": "HPE"
+    },
+    "management": {
+      "bmcAddress": "10.0.0.2",
+      "bmcType": "iLO6"
+    }
+  }
+]

--- a/testdata/fixtures/matrix/README.md
+++ b/testdata/fixtures/matrix/README.md
@@ -1,0 +1,61 @@
+# Matrix Test Fixtures
+
+Reference topology for the import/export provider matrix test.
+
+## Canonical Topology
+
+A single-rack GPU cluster slice exercising compute, service, management, and
+high-speed networking paths.
+
+| Entity        | Count | Slug / Identifier                                |
+|---------------|-------|--------------------------------------------------|
+| Location      | 1     | matrix-site (type: site)                         |
+| Rack          | 1     | hpe-48u-800mmx1200mm-g2-enterprise-shock-rack    |
+| GPU nodes     | 2     | hpe-xd670 (matrix-gpu-01, matrix-gpu-02)         |
+| Service nodes | 2     | hpe-proliant-dl380-gen11-8sff (matrix-serv-01/02)|
+| Mgmt switch   | 1     | hpe-aruba-2930f-48g-4sfp (matrix-mgmt-sw)        |
+| HSN switch    | 1     | nvidia-infiniband-ndr-64-port-osfp-switch        |
+| GPU modules   | 16    | nvidia-h100-sxm-gpu (8 per XD670, GPU0–GPU7)    |
+| CX-7 modules  | 2     | nvidia-connectx-7-ndr-infiniband-osfp-pcie5      |
+| CX-6 modules  | 2     | nvidia-connectx-6-dx-100gbe-2p-qsfp28            |
+| Cables        | 6     | 4× iLO→mgmt-sw, 2× HSN→hsn-sw                   |
+| **Totals**    |       | **6 devices, 20 modules, 6 cables**              |
+
+## Naming Convention
+
+- GPU nodes: matrix-gpu-01, matrix-gpu-02
+- Service nodes: matrix-serv-01, matrix-serv-02
+- Switches: matrix-mgmt-sw, matrix-hsn-sw
+- BMC addresses: 10.0.100.1–.4 (servers only)
+- Serial numbers: SN-GPU-01, SN-GPU-02, SN-SERV-01, SN-SERV-02, etc.
+- UUIDs: 11111111-1111-1111-1111-00000000000{1..6}
+- Xnames (CSM): x9999 cabinet, x9999c0s{1,6,11,13}b0n0, x9999c0w{42,48}
+
+## Cable Connectivity
+
+| # | A-Device:Port           | B-Device:Port       | Type              |
+|---|-------------------------|---------------------|-------------------|
+| 1 | matrix-gpu-01:iLO       | matrix-mgmt-sw:1    | Cat6 management   |
+| 2 | matrix-gpu-02:iLO       | matrix-mgmt-sw:2    | Cat6 management   |
+| 3 | matrix-serv-01:iLO      | matrix-mgmt-sw:3    | Cat6 management   |
+| 4 | matrix-serv-02:iLO      | matrix-mgmt-sw:4    | Cat6 management   |
+| 5 | matrix-gpu-01:HSN 0     | matrix-hsn-sw:1     | NDR InfiniBand    |
+| 6 | matrix-gpu-02:HSN 0     | matrix-hsn-sw:2     | NDR InfiniBand    |
+
+## Per-Provider Representation
+
+- **example.csv**: Full section-based CSV with all entities
+- **ochami.json**: DiscoverySnapshot with flat rawData[] and parent-child via serialNumber
+- **redfish.json**: Array of 4 ServiceRoot objects (servers only; switches not BMC-discovered)
+- **hpcm.json**: Array of 6 node objects (all devices as nodes)
+- **csm_sls.json**: SLS dumpstate with Hardware map + empty Networks
+
+## Expected Entity Counts After Import
+
+| Provider | Devices | Modules | Cables |
+|----------|---------|---------|--------|
+| example  | 6       | 20      | 6      |
+| ochami   | 6       | 20      | 6      |
+| redfish  | 4       | 0       | 0      |
+| hpcm     | 6       | 0       | 0      |
+| csm      | 6       | 0       | 0      |

--- a/testdata/fixtures/matrix/csm_sls.json
+++ b/testdata/fixtures/matrix/csm_sls.json
@@ -1,0 +1,149 @@
+{
+  "Hardware": {
+    "x9999": {
+      "Xname": "x9999",
+      "Type": "comptype_cabinet",
+      "Class": "River",
+      "TypeString": "Cabinet",
+      "ExtraProperties": {
+        "Networks": {
+          "cn": {
+            "HMN": { "CIDR": "10.104.0.0/22", "Gateway": "10.104.0.1", "VLan": 1513 },
+            "NMN": { "CIDR": "10.100.0.0/22", "Gateway": "10.100.0.1", "VLan": 1770 }
+          }
+        }
+      }
+    },
+    "x9999c0": {
+      "Xname": "x9999c0",
+      "Type": "comptype_chassis",
+      "Class": "River",
+      "TypeString": "Chassis",
+      "Parent": "x9999"
+    },
+    "x9999c0s1b0n0": {
+      "Xname": "x9999c0s1b0n0",
+      "Type": "comptype_node",
+      "Class": "River",
+      "TypeString": "Node",
+      "Parent": "x9999c0s1b0",
+      "ExtraProperties": {
+        "Role": "Compute",
+        "NID": 1,
+        "Aliases": ["matrix-gpu-01"]
+      }
+    },
+    "x9999c0s6b0n0": {
+      "Xname": "x9999c0s6b0n0",
+      "Type": "comptype_node",
+      "Class": "River",
+      "TypeString": "Node",
+      "Parent": "x9999c0s6b0",
+      "ExtraProperties": {
+        "Role": "Compute",
+        "NID": 2,
+        "Aliases": ["matrix-gpu-02"]
+      }
+    },
+    "x9999c0s11b0n0": {
+      "Xname": "x9999c0s11b0n0",
+      "Type": "comptype_node",
+      "Class": "River",
+      "TypeString": "Node",
+      "Parent": "x9999c0s11b0",
+      "ExtraProperties": {
+        "Role": "Compute",
+        "SubRole": "Worker",
+        "NID": 3,
+        "Aliases": ["matrix-serv-01"]
+      }
+    },
+    "x9999c0s13b0n0": {
+      "Xname": "x9999c0s13b0n0",
+      "Type": "comptype_node",
+      "Class": "River",
+      "TypeString": "Node",
+      "Parent": "x9999c0s13b0",
+      "ExtraProperties": {
+        "Role": "Compute",
+        "SubRole": "Worker",
+        "NID": 4,
+        "Aliases": ["matrix-serv-02"]
+      }
+    },
+    "x9999c0w48": {
+      "Xname": "x9999c0w48",
+      "Type": "comptype_mgmt_switch",
+      "Class": "River",
+      "TypeString": "MgmtSwitch",
+      "Parent": "x9999c0",
+      "ExtraProperties": {
+        "Aliases": ["matrix-mgmt-sw"],
+        "Brand": "Aruba",
+        "Model": "2930F-48G-4SFP+",
+        "SNMPAuthPassword": "",
+        "SNMPAuthProtocol": "",
+        "SNMPPrivPassword": "",
+        "SNMPPrivProtocol": "",
+        "SNMPUsername": ""
+      }
+    },
+    "x9999c0w42": {
+      "Xname": "x9999c0w42",
+      "Type": "comptype_hsn_switch",
+      "Class": "River",
+      "TypeString": "HSNSwitch",
+      "Parent": "x9999c0",
+      "ExtraProperties": {
+        "Aliases": ["matrix-hsn-sw"],
+        "Brand": "NVIDIA",
+        "Model": "QM9700"
+      }
+    },
+    "x9999c0w48j1": {
+      "Xname": "x9999c0w48j1",
+      "Type": "comptype_mgmt_switch_connector",
+      "Class": "River",
+      "TypeString": "MgmtSwitchConnector",
+      "Parent": "x9999c0w48",
+      "ExtraProperties": {
+        "NodeNics": ["x9999c0s1b0"],
+        "VendorName": "ethernet1/1/1"
+      }
+    },
+    "x9999c0w48j2": {
+      "Xname": "x9999c0w48j2",
+      "Type": "comptype_mgmt_switch_connector",
+      "Class": "River",
+      "TypeString": "MgmtSwitchConnector",
+      "Parent": "x9999c0w48",
+      "ExtraProperties": {
+        "NodeNics": ["x9999c0s6b0"],
+        "VendorName": "ethernet1/1/2"
+      }
+    },
+    "x9999c0w48j3": {
+      "Xname": "x9999c0w48j3",
+      "Type": "comptype_mgmt_switch_connector",
+      "Class": "River",
+      "TypeString": "MgmtSwitchConnector",
+      "Parent": "x9999c0w48",
+      "ExtraProperties": {
+        "NodeNics": ["x9999c0s11b0"],
+        "VendorName": "ethernet1/1/3"
+      }
+    },
+    "x9999c0w48j4": {
+      "Xname": "x9999c0w48j4",
+      "Type": "comptype_mgmt_switch_connector",
+      "Class": "River",
+      "TypeString": "MgmtSwitchConnector",
+      "Parent": "x9999c0w48",
+      "ExtraProperties": {
+        "NodeNics": ["x9999c0s13b0"],
+        "VendorName": "ethernet1/1/4"
+      }
+    }
+  },
+  "Networks": {}
+}

--- a/testdata/fixtures/matrix/example.csv
+++ b/testdata/fixtures/matrix/example.csv
@@ -1,0 +1,52 @@
+Section,PartNumber,Name,Qty,Rack,Position,Face,Role,Status,Serial,Device,Bay,ADevice,APort,BDevice,BPort,Color,Length,LengthUnit,Location,ContentTypes
+_defaults,,,,,,,,Active,,,,,,,,,,,,
+# Roles
+role,,ComputeNode,,,,,,,,,,,,,,,,,,dcim.device
+role,,ServiceNode,,,,,,,,,,,,,,,,,,dcim.device
+role,,ManagementSwitch,,,,,,,,,,,,,,,,,,dcim.device
+role,,HSNSwitch,,,,,,,,,,,,,,,,,,dcim.device
+# Location
+location,,matrix-site,,,,,site,,,,,,,,,,,,,"rack,device,module"
+# Rack
+rack,hpe-48u-800mmx1200mm-g2-enterprise-shock-rack,matrix-rack,1,,,,,Active,,,,,,,,,,,matrix-site,
+# Devices — GPU nodes (XD670, 5U each)
+device,hpe-xd670,matrix-gpu-01,1,matrix-rack,34,front,ComputeNode,Active,SN-GPU-01,,,,,,,,,,,
+device,hpe-xd670,matrix-gpu-02,1,matrix-rack,26,front,ComputeNode,Active,SN-GPU-02,,,,,,,,,,,
+# Devices — Service nodes (DL380 Gen11, 2U each)
+device,hpe-proliant-dl380-gen11-8sff,matrix-serv-01,1,matrix-rack,11,front,ServiceNode,Active,SN-SERV-01,,,,,,,,,,,
+device,hpe-proliant-dl380-gen11-8sff,matrix-serv-02,1,matrix-rack,13,front,ServiceNode,Active,SN-SERV-02,,,,,,,,,,,
+# Devices — Switches
+device,hpe-aruba-2930f-48g-4sfp,matrix-mgmt-sw,1,matrix-rack,48,rear,ManagementSwitch,Active,SN-MGMT-SW,,,,,,,,,,,
+device,nvidia-infiniband-ndr-64-port-osfp-switch,matrix-hsn-sw,1,matrix-rack,42,rear,HSNSwitch,Active,SN-HSN-SW,,,,,,,,,,,
+# Modules — GPUs in matrix-gpu-01
+module,nvidia-h100-sxm-gpu,,1,,,,,,,matrix-gpu-01,GPU0,,,,,,,,,
+module,nvidia-h100-sxm-gpu,,1,,,,,,,matrix-gpu-01,GPU1,,,,,,,,,
+module,nvidia-h100-sxm-gpu,,1,,,,,,,matrix-gpu-01,GPU2,,,,,,,,,
+module,nvidia-h100-sxm-gpu,,1,,,,,,,matrix-gpu-01,GPU3,,,,,,,,,
+module,nvidia-h100-sxm-gpu,,1,,,,,,,matrix-gpu-01,GPU4,,,,,,,,,
+module,nvidia-h100-sxm-gpu,,1,,,,,,,matrix-gpu-01,GPU5,,,,,,,,,
+module,nvidia-h100-sxm-gpu,,1,,,,,,,matrix-gpu-01,GPU6,,,,,,,,,
+module,nvidia-h100-sxm-gpu,,1,,,,,,,matrix-gpu-01,GPU7,,,,,,,,,
+# Modules — GPUs in matrix-gpu-02
+module,nvidia-h100-sxm-gpu,,1,,,,,,,matrix-gpu-02,GPU0,,,,,,,,,
+module,nvidia-h100-sxm-gpu,,1,,,,,,,matrix-gpu-02,GPU1,,,,,,,,,
+module,nvidia-h100-sxm-gpu,,1,,,,,,,matrix-gpu-02,GPU2,,,,,,,,,
+module,nvidia-h100-sxm-gpu,,1,,,,,,,matrix-gpu-02,GPU3,,,,,,,,,
+module,nvidia-h100-sxm-gpu,,1,,,,,,,matrix-gpu-02,GPU4,,,,,,,,,
+module,nvidia-h100-sxm-gpu,,1,,,,,,,matrix-gpu-02,GPU5,,,,,,,,,
+module,nvidia-h100-sxm-gpu,,1,,,,,,,matrix-gpu-02,GPU6,,,,,,,,,
+module,nvidia-h100-sxm-gpu,,1,,,,,,,matrix-gpu-02,GPU7,,,,,,,,,
+# Modules — CX-7 NICs in XD670 nodes
+module,nvidia-connectx-7-ndr-infiniband-osfp-pcie5,,1,,,,,,,matrix-gpu-01,PCIe 9,,,,,,,,,
+module,nvidia-connectx-7-ndr-infiniband-osfp-pcie5,,1,,,,,,,matrix-gpu-02,PCIe 9,,,,,,,,,
+# Modules — CX-6 NICs in DL380 nodes
+module,nvidia-connectx-6-dx-100gbe-2p-qsfp28,,1,,,,,,,matrix-serv-01,PCIe5,,,,,,,,,
+module,nvidia-connectx-6-dx-100gbe-2p-qsfp28,,1,,,,,,,matrix-serv-02,PCIe5,,,,,,,,,
+# Connections — iLO management to mgmt switch
+connection,hpe-3m-cat6-stp,,,,,,,,,,,matrix-gpu-01,iLO,matrix-mgmt-sw,1,blue,3,m,,
+connection,hpe-3m-cat6-stp,,,,,,,,,,,matrix-gpu-02,iLO,matrix-mgmt-sw,2,blue,3,m,,
+connection,hpe-3m-cat6-stp,,,,,,,,,,,matrix-serv-01,iLO,matrix-mgmt-sw,3,blue,3,m,,
+connection,hpe-3m-cat6-stp,,,,,,,,,,,matrix-serv-02,iLO,matrix-mgmt-sw,4,blue,3,m,,
+# Connections — XD670 HSN to InfiniBand switch
+connection,hpe-ib-ndr-osfp-dac-cable,,,,,,,,,,,matrix-gpu-01,HSN 0,matrix-hsn-sw,1,black,2,m,,
+connection,hpe-ib-ndr-osfp-dac-cable,,,,,,,,,,,matrix-gpu-02,HSN 0,matrix-hsn-sw,2,black,2,m,,

--- a/testdata/fixtures/matrix/hpcm.json
+++ b/testdata/fixtures/matrix/hpcm.json
@@ -1,0 +1,80 @@
+[
+  {
+    "name": "matrix-gpu-01",
+    "uuid": "11111111-1111-1111-1111-000000000001",
+    "type": "compute",
+    "managed": true,
+    "platform": {
+      "name": "ProLiant XD670"
+    },
+    "management": {
+      "cardType": "iLO6",
+      "cardIpAddress": "10.0.100.1"
+    }
+  },
+  {
+    "name": "matrix-gpu-02",
+    "uuid": "11111111-1111-1111-1111-000000000002",
+    "type": "compute",
+    "managed": true,
+    "platform": {
+      "name": "ProLiant XD670"
+    },
+    "management": {
+      "cardType": "iLO6",
+      "cardIpAddress": "10.0.100.2"
+    }
+  },
+  {
+    "name": "matrix-serv-01",
+    "uuid": "11111111-1111-1111-1111-000000000003",
+    "type": "compute",
+    "managed": true,
+    "platform": {
+      "name": "ProLiant DL380 Gen11"
+    },
+    "management": {
+      "cardType": "iLO6",
+      "cardIpAddress": "10.0.100.3"
+    }
+  },
+  {
+    "name": "matrix-serv-02",
+    "uuid": "11111111-1111-1111-1111-000000000004",
+    "type": "compute",
+    "managed": true,
+    "platform": {
+      "name": "ProLiant DL380 Gen11"
+    },
+    "management": {
+      "cardType": "iLO6",
+      "cardIpAddress": "10.0.100.4"
+    }
+  },
+  {
+    "name": "matrix-mgmt-sw",
+    "uuid": "11111111-1111-1111-1111-000000000005",
+    "type": "switch",
+    "managed": true,
+    "platform": {
+      "name": "Aruba 2930F 48G 4SFP+"
+    },
+    "management": {
+      "cardType": "switch-mgmt",
+      "cardIpAddress": "10.0.100.10"
+    }
+  },
+  {
+    "name": "matrix-hsn-sw",
+    "uuid": "11111111-1111-1111-1111-000000000006",
+    "type": "switch",
+    "managed": true,
+    "platform": {
+      "name": "InfiniBand NDR 64-port OSFP Managed Switch"
+    },
+    "management": {
+      "cardType": "switch-mgmt",
+      "cardIpAddress": "10.0.100.11"
+    }
+  }
+]

--- a/testdata/fixtures/matrix/ochami.json
+++ b/testdata/fixtures/matrix/ochami.json
@@ -1,0 +1,334 @@
+{
+  "apiVersion": "v1alpha1",
+  "kind": "DiscoverySnapshot",
+  "metadata": {
+    "name": "matrix-test-topology"
+  },
+  "spec": {
+    "rawData": [
+    {
+      "deviceType": "Rack",
+      "serialNumber": "SN-RACK-01",
+      "manufacturer": "HPE",
+      "partNumber": "P9K58A",
+      "parentSerialNumber": "",
+      "properties": {
+        "name": "matrix-rack",
+        "model": "HPE 48U 800mm×1200mm G2 Enterprise Shock Rack"
+      }
+    },
+    {
+      "deviceType": "Node",
+      "serialNumber": "SN-GPU-01",
+      "manufacturer": "HPE",
+      "partNumber": "hpe-xd670",
+      "parentSerialNumber": "SN-RACK-01",
+      "properties": {
+        "name": "matrix-gpu-01",
+        "model": "HPE Cray Supercomputing XD670",
+        "bmc_address": "10.0.100.1",
+        "bmc_fqdn": "matrix-gpu-01-bmc.local"
+      }
+    },
+    {
+      "deviceType": "Node",
+      "serialNumber": "SN-GPU-02",
+      "manufacturer": "HPE",
+      "partNumber": "hpe-xd670",
+      "parentSerialNumber": "SN-RACK-01",
+      "properties": {
+        "name": "matrix-gpu-02",
+        "model": "HPE Cray Supercomputing XD670",
+        "bmc_address": "10.0.100.2",
+        "bmc_fqdn": "matrix-gpu-02-bmc.local"
+      }
+    },
+    {
+      "deviceType": "Node",
+      "serialNumber": "SN-SERV-01",
+      "manufacturer": "HPE",
+      "partNumber": "hpe-proliant-dl380-gen11-8sff",
+      "parentSerialNumber": "SN-RACK-01",
+      "properties": {
+        "name": "matrix-serv-01",
+        "model": "HPE ProLiant DL380 Gen11 8SFF",
+        "bmc_address": "10.0.100.3",
+        "bmc_fqdn": "matrix-serv-01-bmc.local"
+      }
+    },
+    {
+      "deviceType": "Node",
+      "serialNumber": "SN-SERV-02",
+      "manufacturer": "HPE",
+      "partNumber": "hpe-proliant-dl380-gen11-8sff",
+      "parentSerialNumber": "SN-RACK-01",
+      "properties": {
+        "name": "matrix-serv-02",
+        "model": "HPE ProLiant DL380 Gen11 8SFF",
+        "bmc_address": "10.0.100.4",
+        "bmc_fqdn": "matrix-serv-02-bmc.local"
+      }
+    },
+    {
+      "deviceType": "Switch",
+      "serialNumber": "SN-MGMT-SW",
+      "manufacturer": "HPE",
+      "partNumber": "hpe-aruba-2930f-48g-4sfp",
+      "parentSerialNumber": "SN-RACK-01",
+      "properties": {
+        "name": "matrix-mgmt-sw",
+        "model": "HPE Aruba 2930F 48G 4SFP+"
+      }
+    },
+    {
+      "deviceType": "Switch",
+      "serialNumber": "SN-HSN-SW",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-infiniband-ndr-64-port-osfp-switch",
+      "parentSerialNumber": "SN-RACK-01",
+      "properties": {
+        "name": "matrix-hsn-sw",
+        "model": "NVIDIA InfiniBand NDR 64-port OSFP Managed Switch"
+      }
+    },
+    {
+      "deviceType": "GPU",
+      "serialNumber": "SN-GPU-01-G0",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-h100-sxm-gpu",
+      "parentSerialNumber": "SN-GPU-01",
+      "properties": { "bay": "GPU0" }
+    },
+    {
+      "deviceType": "GPU",
+      "serialNumber": "SN-GPU-01-G1",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-h100-sxm-gpu",
+      "parentSerialNumber": "SN-GPU-01",
+      "properties": { "bay": "GPU1" }
+    },
+    {
+      "deviceType": "GPU",
+      "serialNumber": "SN-GPU-01-G2",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-h100-sxm-gpu",
+      "parentSerialNumber": "SN-GPU-01",
+      "properties": { "bay": "GPU2" }
+    },
+    {
+      "deviceType": "GPU",
+      "serialNumber": "SN-GPU-01-G3",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-h100-sxm-gpu",
+      "parentSerialNumber": "SN-GPU-01",
+      "properties": { "bay": "GPU3" }
+    },
+    {
+      "deviceType": "GPU",
+      "serialNumber": "SN-GPU-01-G4",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-h100-sxm-gpu",
+      "parentSerialNumber": "SN-GPU-01",
+      "properties": { "bay": "GPU4" }
+    },
+    {
+      "deviceType": "GPU",
+      "serialNumber": "SN-GPU-01-G5",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-h100-sxm-gpu",
+      "parentSerialNumber": "SN-GPU-01",
+      "properties": { "bay": "GPU5" }
+    },
+    {
+      "deviceType": "GPU",
+      "serialNumber": "SN-GPU-01-G6",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-h100-sxm-gpu",
+      "parentSerialNumber": "SN-GPU-01",
+      "properties": { "bay": "GPU6" }
+    },
+    {
+      "deviceType": "GPU",
+      "serialNumber": "SN-GPU-01-G7",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-h100-sxm-gpu",
+      "parentSerialNumber": "SN-GPU-01",
+      "properties": { "bay": "GPU7" }
+    },
+    {
+      "deviceType": "GPU",
+      "serialNumber": "SN-GPU-02-G0",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-h100-sxm-gpu",
+      "parentSerialNumber": "SN-GPU-02",
+      "properties": { "bay": "GPU0" }
+    },
+    {
+      "deviceType": "GPU",
+      "serialNumber": "SN-GPU-02-G1",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-h100-sxm-gpu",
+      "parentSerialNumber": "SN-GPU-02",
+      "properties": { "bay": "GPU1" }
+    },
+    {
+      "deviceType": "GPU",
+      "serialNumber": "SN-GPU-02-G2",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-h100-sxm-gpu",
+      "parentSerialNumber": "SN-GPU-02",
+      "properties": { "bay": "GPU2" }
+    },
+    {
+      "deviceType": "GPU",
+      "serialNumber": "SN-GPU-02-G3",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-h100-sxm-gpu",
+      "parentSerialNumber": "SN-GPU-02",
+      "properties": { "bay": "GPU3" }
+    },
+    {
+      "deviceType": "GPU",
+      "serialNumber": "SN-GPU-02-G4",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-h100-sxm-gpu",
+      "parentSerialNumber": "SN-GPU-02",
+      "properties": { "bay": "GPU4" }
+    },
+    {
+      "deviceType": "GPU",
+      "serialNumber": "SN-GPU-02-G5",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-h100-sxm-gpu",
+      "parentSerialNumber": "SN-GPU-02",
+      "properties": { "bay": "GPU5" }
+    },
+    {
+      "deviceType": "GPU",
+      "serialNumber": "SN-GPU-02-G6",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-h100-sxm-gpu",
+      "parentSerialNumber": "SN-GPU-02",
+      "properties": { "bay": "GPU6" }
+    },
+    {
+      "deviceType": "GPU",
+      "serialNumber": "SN-GPU-02-G7",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-h100-sxm-gpu",
+      "parentSerialNumber": "SN-GPU-02",
+      "properties": { "bay": "GPU7" }
+    },
+    {
+      "deviceType": "NIC",
+      "serialNumber": "SN-GPU-01-CX7",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-connectx-7-ndr-infiniband-osfp-pcie5",
+      "parentSerialNumber": "SN-GPU-01",
+      "properties": { "bay": "PCIe 9" }
+    },
+    {
+      "deviceType": "NIC",
+      "serialNumber": "SN-GPU-02-CX7",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-connectx-7-ndr-infiniband-osfp-pcie5",
+      "parentSerialNumber": "SN-GPU-02",
+      "properties": { "bay": "PCIe 9" }
+    },
+    {
+      "deviceType": "NIC",
+      "serialNumber": "SN-SERV-01-CX6",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-connectx-6-dx-100gbe-2p-qsfp28",
+      "parentSerialNumber": "SN-SERV-01",
+      "properties": { "bay": "PCIe5" }
+    },
+    {
+      "deviceType": "NIC",
+      "serialNumber": "SN-SERV-02-CX6",
+      "manufacturer": "NVIDIA",
+      "partNumber": "nvidia-connectx-6-dx-100gbe-2p-qsfp28",
+      "parentSerialNumber": "SN-SERV-02",
+      "properties": { "bay": "PCIe5" }
+    },
+    {
+      "deviceType": "Cable",
+      "serialNumber": "SN-CBL-MGMT-01",
+      "manufacturer": "HPE",
+      "partNumber": "hpe-3m-cat6-stp",
+      "parentSerialNumber": "",
+      "properties": {
+        "a_device": "matrix-gpu-01",
+        "a_port": "iLO",
+        "b_device": "matrix-mgmt-sw",
+        "b_port": "1"
+      }
+    },
+    {
+      "deviceType": "Cable",
+      "serialNumber": "SN-CBL-MGMT-02",
+      "manufacturer": "HPE",
+      "partNumber": "hpe-3m-cat6-stp",
+      "parentSerialNumber": "",
+      "properties": {
+        "a_device": "matrix-gpu-02",
+        "a_port": "iLO",
+        "b_device": "matrix-mgmt-sw",
+        "b_port": "2"
+      }
+    },
+    {
+      "deviceType": "Cable",
+      "serialNumber": "SN-CBL-MGMT-03",
+      "manufacturer": "HPE",
+      "partNumber": "hpe-3m-cat6-stp",
+      "parentSerialNumber": "",
+      "properties": {
+        "a_device": "matrix-serv-01",
+        "a_port": "iLO",
+        "b_device": "matrix-mgmt-sw",
+        "b_port": "3"
+      }
+    },
+    {
+      "deviceType": "Cable",
+      "serialNumber": "SN-CBL-MGMT-04",
+      "manufacturer": "HPE",
+      "partNumber": "hpe-3m-cat6-stp",
+      "parentSerialNumber": "",
+      "properties": {
+        "a_device": "matrix-serv-02",
+        "a_port": "iLO",
+        "b_device": "matrix-mgmt-sw",
+        "b_port": "4"
+      }
+    },
+    {
+      "deviceType": "Cable",
+      "serialNumber": "SN-CBL-HSN-01",
+      "manufacturer": "HPE",
+      "partNumber": "hpe-ib-ndr-osfp-dac-cable",
+      "parentSerialNumber": "",
+      "properties": {
+        "a_device": "matrix-gpu-01",
+        "a_port": "HSN 0",
+        "b_device": "matrix-hsn-sw",
+        "b_port": "1"
+      }
+    },
+    {
+      "deviceType": "Cable",
+      "serialNumber": "SN-CBL-HSN-02",
+      "manufacturer": "HPE",
+      "partNumber": "hpe-ib-ndr-osfp-dac-cable",
+      "parentSerialNumber": "",
+      "properties": {
+        "a_device": "matrix-gpu-02",
+        "a_port": "HSN 0",
+        "b_device": "matrix-hsn-sw",
+        "b_port": "2"
+      }
+    }
+    ]
+  }
+}

--- a/testdata/fixtures/matrix/redfish.json
+++ b/testdata/fixtures/matrix/redfish.json
@@ -1,0 +1,110 @@
+[
+  {
+    "@odata.id": "/redfish/v1",
+    "@odata.type": "#ServiceRoot.v1_13_0.ServiceRoot",
+    "Id": "RootService",
+    "UUID": "11111111-1111-1111-1111-000000000001",
+    "Product": "ProLiant XD670",
+    "Vendor": "HPE",
+    "RedfishVersion": "1.13.0",
+    "Oem": {
+      "Hpe": {
+        "Manager": [
+          {
+            "FQDN": "matrix-gpu-01-bmc.local",
+            "HostName": "matrix-gpu-01-bmc",
+            "ManagerType": "iLO 6",
+            "ManagerFirmwareVersion": "1.61",
+            "Status": { "Health": "OK" }
+          }
+        ],
+        "Moniker": {
+          "PRODTAG": "XD670",
+          "SYSFAM": "ProLiant",
+          "VENDNAM": "HPE"
+        }
+      }
+    }
+  },
+  {
+    "@odata.id": "/redfish/v1",
+    "@odata.type": "#ServiceRoot.v1_13_0.ServiceRoot",
+    "Id": "RootService",
+    "UUID": "11111111-1111-1111-1111-000000000002",
+    "Product": "ProLiant XD670",
+    "Vendor": "HPE",
+    "RedfishVersion": "1.13.0",
+    "Oem": {
+      "Hpe": {
+        "Manager": [
+          {
+            "FQDN": "matrix-gpu-02-bmc.local",
+            "HostName": "matrix-gpu-02-bmc",
+            "ManagerType": "iLO 6",
+            "ManagerFirmwareVersion": "1.61",
+            "Status": { "Health": "OK" }
+          }
+        ],
+        "Moniker": {
+          "PRODTAG": "XD670",
+          "SYSFAM": "ProLiant",
+          "VENDNAM": "HPE"
+        }
+      }
+    }
+  },
+  {
+    "@odata.id": "/redfish/v1",
+    "@odata.type": "#ServiceRoot.v1_13_0.ServiceRoot",
+    "Id": "RootService",
+    "UUID": "11111111-1111-1111-1111-000000000003",
+    "Product": "ProLiant DL380 Gen11",
+    "Vendor": "HPE",
+    "RedfishVersion": "1.13.0",
+    "Oem": {
+      "Hpe": {
+        "Manager": [
+          {
+            "FQDN": "matrix-serv-01-bmc.local",
+            "HostName": "matrix-serv-01-bmc",
+            "ManagerType": "iLO 6",
+            "ManagerFirmwareVersion": "1.61",
+            "Status": { "Health": "OK" }
+          }
+        ],
+        "Moniker": {
+          "PRODTAG": "DL380 Gen11",
+          "SYSFAM": "ProLiant",
+          "VENDNAM": "HPE"
+        }
+      }
+    }
+  },
+  {
+    "@odata.id": "/redfish/v1",
+    "@odata.type": "#ServiceRoot.v1_13_0.ServiceRoot",
+    "Id": "RootService",
+    "UUID": "11111111-1111-1111-1111-000000000004",
+    "Product": "ProLiant DL380 Gen11",
+    "Vendor": "HPE",
+    "RedfishVersion": "1.13.0",
+    "Oem": {
+      "Hpe": {
+        "Manager": [
+          {
+            "FQDN": "matrix-serv-02-bmc.local",
+            "HostName": "matrix-serv-02-bmc",
+            "ManagerType": "iLO 6",
+            "ManagerFirmwareVersion": "1.61",
+            "Status": { "Health": "OK" }
+          }
+        ],
+        "Moniker": {
+          "PRODTAG": "DL380 Gen11",
+          "SYSFAM": "ProLiant",
+          "VENDNAM": "HPE"
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->

- Adds a shell-spec test to the functional test suite to validate that the import and export work to and from each of the providers.
- Along with a new flag `datastore-path` to set the canidb.json path for a single command.


# Risks and Mitigations
 
<!-- What is the risk level of this change? -->
- No risk only testing
