### PR TITLE
Gnv2 netapp and fixes

### DIFF
--- a/gnv2.md
+++ b/gnv2.md
@@ -89,6 +89,8 @@ graph TB
         FORGE3507u43L["FORGE-3507u43L<br/>Leaf 8325-32C"]:::leaf
     end
 
+    NAS2["NAS-3502u18<br/>NetApp FAS 8300"]:::server
+    NAS1["NAS-3502u20<br/>NetApp FAS 8300"]:::server
     MAN3507u48["MAN-3507u48<br/>Mgmt Switch"]:::mgmt
 
     %% ── LAYER 1: Management iLO (1GbE, CAT6) ──
@@ -103,6 +105,14 @@ graph TB
     SERV7 -- "iLO → p16" --- FORGE3507u47M
     SERV5 -- "iLO → p17" --- FORGE3507u47M
     SERV5 -- "OCP-p1 → p10" --- MAN3507u48
+    NAS1 -- "s1p1 → p26" --- FORGE3507u44L
+    NAS1 -- "s2p1 → p27" --- FORGE3507u44L
+    NAS2 -- "s1p1 → p24" --- FORGE3507u44L
+    NAS2 -- "s2p1 → p25" --- FORGE3507u44L
+    NAS1 -- "s1p2 → p26" --- FORGE3507u43L
+    NAS1 -- "s2p2 → p27" --- FORGE3507u43L
+    NAS2 -- "s1p2 → p24" --- FORGE3507u43L
+    NAS2 -- "s2p2 → p25" --- FORGE3507u43L
 
     %% ── LAYER 1b: Mgmt switch SFP28 uplinks → leaf pairs (10G DAC) ──
 
@@ -223,6 +233,10 @@ graph TB
 | 1/1/8 | SERV-3507u7 | Port 1 | Server downlink | 100G DAC 3m |
 | 1/1/9 | SERV-3507u5 | Port 1 | Server downlink | 100G DAC 3m |
 | 1/1/10 | FORGE-3507u47M | 49 | Mgmt switch uplink | 10G DAC 3m |
+| 1/1/24 | NAS-3502u18 | s1p1 | Server downlink | ? DAC 20m? |
+| 1/1/25 | NAS-3502u18 | s2p1 | Server downlink | ? DAC 20m? |
+| 1/1/26 | NAS-3502u20 | s1p1 | Server downlink | ? DAC 20m? |
+| 1/1/27 | NAS-3502u20 | s2p1 | Server downlink | ? DAC 20m? |
 | 1/1/28 | FORGE-3507u45S | 1/1/1 | Spine-2 uplink | 100G DAC 3m |
 | 1/1/29 | FORGE-3507u46S | 1/1/1 | Spine-1 uplink | 100G DAC 3m |
 | 1/1/30 | FORGE-3507u43L | 1/1/30 | ISL (VSX) | 100G DAC 3m |
@@ -244,6 +258,10 @@ graph TB
 | 1/1/8 | SERV-3507u7 | Port 2 | Server downlink | 100G DAC 3m |
 | 1/1/9 | SERV-3507u5 | Port 2 | Server downlink | 100G DAC 3m |
 | 1/1/10 | FORGE-3507u47M | 50 | Mgmt switch uplink | 10G DAC 3m |
+| 1/1/24 | NAS-3502u18 | s1p2 | Server downlink | ? DAC 20m? |
+| 1/1/25 | NAS-3502u18 | s2p2 | Server downlink | ? DAC 20m? |
+| 1/1/26 | NAS-3502u20 | s1p2 | Server downlink | ? DAC 20m? |
+| 1/1/27 | NAS-3502u20 | s2p2 | Server downlink | ? DAC 20m? |
 | 1/1/28 | FORGE-3507u45S | 1/1/2 | Spine-2 uplink | 100G DAC 3m |
 | 1/1/29 | FORGE-3507u46S | 1/1/2 | Spine-1 uplink | 100G DAC 3m |
 | 1/1/30 | FORGE-3507u44L | 1/1/30 | ISL (VSX) | 100G DAC 3m |

--- a/gnv2.md
+++ b/gnv2.md
@@ -242,7 +242,7 @@ graph TB
 | 1/1/30 | FORGE-3507u43L | 1/1/30 | ISL (VSX) | 100G DAC 3m |
 | 1/1/31 | FORGE-3507u43L | 1/1/31 | ISL (VSX) | 100G DAC 3m |
 | 1/1/32 | FORGE-3507u43L | 1/1/32 | ISL (VSX) | 100G DAC 3m |
-| mgmt   | FORGE-3701u47M | Port 2 | Management | CAT6 3m |
+| mgmt   | FORGE-3507u37M | Port 2 | Management | CAT6 3m |
 
 ### FORGE-3507u43L — Leaf-2 (Aruba 8325-32C, 32× 100G QSFP28)
 
@@ -267,7 +267,7 @@ graph TB
 | 1/1/30 | FORGE-3507u44L | 1/1/30 | ISL (VSX) | 100G DAC 3m |
 | 1/1/31 | FORGE-3507u44L | 1/1/31 | ISL (VSX) | 100G DAC 3m |
 | 1/1/32 | FORGE-3507u44L | 1/1/32 | ISL (VSX) | 100G DAC 3m |
-| mgmt   | FORGE-3701u47M | Port 1 | Management | CAT6 3m |
+| mgmt   | FORGE-3507u37M | Port 1 | Management | CAT6 3m |
 
 ### FORGE-3507u46S — Spine-1 (Aruba 9300-32D, 32× 400G QSFP-DD + 2× 10G SFP+)
 
@@ -279,7 +279,7 @@ graph TB
 | 1/1/4 | FORGE-3701u46L | 1/1/29 | x3701 Leaf downlink | 100G AOC 15m |
 | 1/1/29 | BBR-3508u46 | 1/1/9 | BB Leaf uplink | 100G AOC 15m |
 | 1/1/31 | BBR-3516u46 | 1/1/9 | BB Leaf uplink | 100G AOC 15m |
-| mgmt   | FORGE-3701u47M | Port 4 | Management | CAT6 3m |
+| mgmt   | FORGE-3507u37M | Port 4 | Management | CAT6 3m |
 
 ### FORGE-3507u45S — Spine-2 (Aruba 9300-32D, 32× 400G QSFP-DD + 2× 10G SFP+)
 
@@ -291,7 +291,7 @@ graph TB
 | 1/1/4 | FORGE-3701u46L | 1/1/28 | x3701 Leaf downlink | 100G AOC 15m |
 | 1/1/29 | BBR-3508u46 | 1/1/10 | BB Leaf uplink | 100G AOC 15m |
 | 1/1/31 | BBR-3516u46 | 1/1/10 | BB Leaf uplink | 100G AOC 15m |
-| mgmt   | FORGE-3701u47M | Port 3 | Management | CAT6 3m |
+| mgmt   | FORGE-3507u37M | Port 3 | Management | CAT6 3m |
 
 ### BBR-3508u46 — Router-1 (Aruba 8325-32C 32-PORT 100G QSFP+/QSFP28)
 
@@ -322,7 +322,7 @@ graph TB
 | 1/1/30 | FORGE-3701u45L | 1/1/30 | ISL (VSX) | 100G DAC 3m |
 | 1/1/31 | FORGE-3701u45L | 1/1/31 | ISL (VSX) | 100G DAC 3m |
 | 1/1/32 | FORGE-3701u45L | 1/1/32 | ISL (VSX) | 100G DAC 3m |
-| mgmt   | FORGE-3701u47M | Port 7 | Management | CAT6 3m |
+| mgmt   | FORGE-3507u37M | Port 7 | Management | CAT6 3m |
 
 ### FORGE-3701u45L — Leaf (Aruba 8325-32C, 32× 100G QSFP28)
 
@@ -337,7 +337,7 @@ graph TB
 | 1/1/30 | FORGE-3701u46L | 1/1/30 | ISL (VSX) | 100G DAC 3m |
 | 1/1/31 | FORGE-3701u46L | 1/1/31 | ISL (VSX) | 100G DAC 3m |
 | 1/1/32 | FORGE-3701u46L | 1/1/32 | ISL (VSX) | 100G DAC 3m |
-| mgmt   | FORGE-3701u47M | Port 6 | Management | CAT6 3m |
+| mgmt   | FORGE-3507u37M | Port 6 | Management | CAT6 3m |
 
 ### BBR-3516u46 — BB Leaf (Aruba 8325-32C, 32× 100G QSFP28)
 
@@ -353,7 +353,7 @@ graph TB
 | 1/1/9 | FORGE-3507u46S | 1/1/29 | Spine-1 downlink | 100G AOC 15m |
 | 1/1/10 | FORGE-3507u45S | 1/1/29 | Spine-2 downlink | 100G AOC 15m |
 
-### FORGE-3701u47M — Mgmt (Aruba 6300M, 48× 1G + 4× 25G SFP28)
+### FORGE-3507u37M — Mgmt (Aruba 6300M, 48× 1G + 4× 25G SFP28)
 
 | Port | Remote Device  | Remote Port | Function   | Cable   |
 |------|----------------|-------------|------------|---------|
@@ -395,6 +395,6 @@ graph TB
 | 48 | GH-3701u10 | iLO | Management | CAT6 3m |
 | 49 | FORGE-3507u44L | 1/1/10 | Leaf uplink | 10G DAC 3m |
 | 50 | FORGE-3507u43L | 1/1/10 | Leaf uplink | 10G DAC 3m |
-| mgmt | FORGE-3701u47M | Port 5 | Management | CAT6 3m |
+| mgmt | FORGE-3507u37M | Port 5 | Management | CAT6 3m |
 
 ---


### PR DESCRIPTION
- Includes @bo-quan's NetApp cabling
- Due to x3507 and x3701 being >20m away, x3701's 6300 was moved into x3507