### PR TITLE
fix(release): wait for all arch RPMs before uploading to release

### DIFF
--- a/.github/actions/prepare-artifacts/action.yml
+++ b/.github/actions/prepare-artifacts/action.yml
@@ -25,6 +25,10 @@ inputs:
   STREAM:
     required: true
     type: string
+  EXPECTED_ARCHES:
+    description: "Number of distinct CPU architectures expected to publish a non-src RPM (matches the Jenkinsfile.github build matrix). The wait loop blocks until this many arches are present so a release is never published with a missing architecture."
+    required: false
+    default: "2"
 runs:
   using: "composite"
   steps:
@@ -36,18 +40,33 @@ runs:
           ORG: hpe
           STREAM: ${{ inputs.STREAM }}
           WAIT: 45
+          EXPECTED_ARCHES: ${{ inputs.EXPECTED_ARCHES }}
+          MAX_ATTEMPTS: 40
       run: |
           sudo apt-get install -y rename
 
-          # Wait for our RPM(s) to finish building and publishing.
+          # Wait for our non-src RPM(s) to finish building and publishing.
+          # Jenkinsfile.github builds one RPM per architecture (x86_64 + aarch64) on independent
+          # agents, so the two arch RPMs can land in Artifactory seconds-to-minutes apart. Block
+          # until EVERY expected architecture is present (not just the first one); otherwise the
+          # release can be published with a missing architecture (see the v0.6.5 incident).
           echo Looking for "vcs.branch=${{ github.ref_name }};rpm.metadata.name=${GITHUB_REPOSITORY#*/}"
-          while ! jf rt s --fail-no-op=true "${REPOSITORY}/${ORG}/${STREAM}/" --props "vcs.branch=${{ github.ref_name }};rpm.metadata.name=${GITHUB_REPOSITORY#*/}" --exclude-props "rpm.metadata.arch=src"; do
-           echo "Waiting for artifacts to be available; retrying in ${WAIT} seconds ... " >&2
+          attempt=0
+          while true; do
+           arches=$(jf rt s "${REPOSITORY}/${ORG}/${STREAM}/" --props "vcs.branch=${{ github.ref_name }};rpm.metadata.name=${GITHUB_REPOSITORY#*/}" --exclude-props "rpm.metadata.arch=src" | jq -r '[.[].props["rpm.metadata.arch"]?[]?] | unique | length')
+           arches=${arches:-0}
+           if [ "${arches}" -ge "${EXPECTED_ARCHES}" ]; then
+             echo "Found all ${EXPECTED_ARCHES} expected architecture(s); proceeding."
+             break
+           fi
+           attempt=$((attempt + 1))
+           if [ "${attempt}" -ge "${MAX_ATTEMPTS}" ]; then
+             echo "ERROR: only ${arches}/${EXPECTED_ARCHES} architecture(s) published after ${MAX_ATTEMPTS} attempts; aborting so a partial release is not created." >&2
+             exit 1
+           fi
+           echo "Found ${arches}/${EXPECTED_ARCHES} architecture(s) so far; retrying in ${WAIT} seconds ... " >&2
            sleep ${WAIT}
           done
-
-          # Give parallel builds a chance incase they published at slightly different times.
-          sleep ${WAIT}
 
           # Make a workspace
           DIR_DOWNLOAD=$(mktemp -d)


### PR DESCRIPTION
The prepare-artifacts action's non-src wait loop exited as soon as the first matching RPM appeared in Artifactory, then slept a fixed 45s before downloading. When the second architecture published more than ~45s later it was missed, so the GitHub release received only one arch. This is why v0.6.5 shipped a single RPM while v0.6.4 happened to get both (the workflow code was identical for both tags).

Block until every expected architecture is present by counting distinct rpm.metadata.arch values (new EXPECTED_ARCHES input, default 2), bounded by MAX_ATTEMPTS so a never-published arch fails the job loudly instead of producing a partial release. Removed the unreliable fixed sleep. The arch-independent src-RPM loop is left unchanged.

# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->



# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

