### PR TITLE
fix(inventory): reject unresolved cable endpoints

### DIFF
--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -108,6 +108,11 @@ func runExport(cmd *cli.Command, args []string, p provider.Provider) error {
 		return fmt.Errorf("inventory is empty, nothing to export")
 	}
 
+	relationships := inv.VerifyParentChildRelationships()
+	if err := relationships.Err(); err != nil {
+		return fmt.Errorf("inventory relationship preflight failed: %w", err)
+	}
+
 	// Check if the provider implements Exporter
 	exporter, ok := p.(provider.Exporter)
 	if !ok {

--- a/cmd/export/export_test.go
+++ b/cmd/export/export_test.go
@@ -1,0 +1,216 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ *  IN THE SOFTWARE.
+ *
+ */
+package export
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Cray-HPE/cani/internal/cli"
+	"github.com/Cray-HPE/cani/internal/config"
+	"github.com/Cray-HPE/cani/pkg/datastores"
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	"github.com/google/uuid"
+)
+
+type fakeExportProvider struct {
+	exportCalls int
+	exportErr   error
+	mutate      func(*devicetypes.Inventory)
+}
+
+func (provider *fakeExportProvider) Transform(context.Context, devicetypes.Inventory) (*devicetypes.TransformResult, error) {
+	return nil, nil
+}
+
+func (provider *fakeExportProvider) NewProviderCmd(*cli.Command) (*cli.Command, error) {
+	return &cli.Command{}, nil
+}
+
+func (provider *fakeExportProvider) Slug() string {
+	return "fake-export"
+}
+
+func (provider *fakeExportProvider) Export(_ context.Context, _ *cli.Command, _ []string, inventory *devicetypes.Inventory) error {
+	provider.exportCalls++
+	if provider.mutate != nil {
+		provider.mutate(inventory)
+	}
+	return provider.exportErr
+}
+
+func prepareExportTest(t *testing.T, inventory *devicetypes.Inventory) (*cli.Command, string) {
+	t.Helper()
+	directory := t.TempDir()
+	inventoryPath := filepath.Join(directory, "inventory.json")
+	jsonStore := &datastores.JSONStore{Path: inventoryPath}
+	if err := jsonStore.Save(inventory); err != nil {
+		t.Fatalf("writing export test inventory: %v", err)
+	}
+
+	originalConfig := config.Cfg
+	originalDatastore := datastores.Datastore
+	config.Cfg = &config.Config{
+		Path:      filepath.Join(directory, "config.yaml"),
+		Datastore: inventoryPath,
+	}
+	t.Cleanup(func() {
+		config.Cfg = originalConfig
+		datastores.Datastore = originalDatastore
+	})
+
+	root := &cli.Command{Use: "cani"}
+	root.PersistentFlags().String("datastore", "json", "")
+	command := &cli.Command{Use: "fake-export"}
+	root.AddCommand(command)
+	return command, inventoryPath
+}
+
+func connectedExportInventory() (*devicetypes.Inventory, uuid.UUID) {
+	deviceID := uuid.New()
+	interfaceID := uuid.New()
+	cableID := uuid.New()
+	inventory := devicetypes.NewInventory()
+	inventory.Devices[deviceID] = &devicetypes.CaniDeviceType{
+		ID: deviceID, Name: "switch-01",
+		Interfaces: []devicetypes.InterfaceSpec{{ID: interfaceID, Name: "port1"}},
+	}
+	inventory.Cables[cableID] = &devicetypes.CaniCableType{
+		ID:                 cableID,
+		Label:              "uplink",
+		TerminationADevice: deviceID,
+		TerminationAPort:   "port1",
+		TerminationA:       interfaceID,
+	}
+	return inventory, deviceID
+}
+
+// TestRunExportRejectsInvalidCableBeforeProvider verifies relationship
+// preflight aborts export without invoking the provider or rewriting inventory.
+//
+// Why it matters: provider phases may mutate remote objects before reaching
+// cable creation, so endpoint errors must be detected at the command boundary.
+// Inputs: firewall-01 with port1 and a cable naming nonexistent port3.
+// Outputs: a contextual error, zero fake Export calls, and unchanged file bytes.
+// Data choice: a valid device plus missing port reproduces the reported late
+// Nautobot failure without involving provider-specific behavior.
+func TestRunExportRejectsInvalidCableBeforeProvider(t *testing.T) {
+	deviceID := uuid.New()
+	inventory := devicetypes.NewInventory()
+	inventory.Devices[deviceID] = &devicetypes.CaniDeviceType{
+		ID: deviceID, Name: "firewall-01",
+		Interfaces: []devicetypes.InterfaceSpec{{ID: uuid.New(), Name: "port1"}},
+	}
+	inventory.Cables[uuid.New()] = &devicetypes.CaniCableType{
+		Label:              "invalid-uplink",
+		TerminationBDevice: deviceID,
+		TerminationBPort:   "port3",
+	}
+	command, inventoryPath := prepareExportTest(t, inventory)
+	before, err := os.ReadFile(inventoryPath)
+	if err != nil {
+		t.Fatalf("reading inventory before export: %v", err)
+	}
+	provider := &fakeExportProvider{}
+
+	err = runExport(command, nil, provider)
+
+	if err == nil {
+		t.Fatal("expected invalid cable preflight to fail export")
+	}
+	if !strings.Contains(err.Error(), `termination B port "port3" not found on device "firewall-01"`) {
+		t.Errorf("runExport() error = %q, want endpoint context", err)
+	}
+	if provider.exportCalls != 0 {
+		t.Errorf("provider Export calls = %d, want 0", provider.exportCalls)
+	}
+	after, err := os.ReadFile(inventoryPath)
+	if err != nil {
+		t.Fatalf("reading inventory after export: %v", err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Error("invalid export rewrote the inventory datastore")
+	}
+}
+
+// TestRunExportInvokesProviderForValidInventory verifies relationship preflight
+// allows a valid connected inventory through the normal export and save path.
+//
+// Why it matters: fail-fast validation must not block providers from exporting
+// inventory whose endpoint tuples are coherent.
+// Inputs: a device with port1 and a cable resolved to that interface.
+// Outputs: runExport returns nil and invokes the fake exporter exactly once.
+// Data choice: one complete side plus one absent side exercises the selected
+// endpoint completeness policy at the real command boundary.
+func TestRunExportInvokesProviderForValidInventory(t *testing.T) {
+	inventory, _ := connectedExportInventory()
+	command, _ := prepareExportTest(t, inventory)
+	provider := &fakeExportProvider{}
+
+	if err := runExport(command, nil, provider); err != nil {
+		t.Fatalf("runExport() unexpected error: %v", err)
+	}
+	if provider.exportCalls != 1 {
+		t.Errorf("provider Export calls = %d, want 1", provider.exportCalls)
+	}
+}
+
+// TestRunExportPersistsExternalIDAfterProviderError verifies a provider error
+// retains inventory mutations made before the failure.
+//
+// Why it matters: exporters may reconcile objects before a later phase fails;
+// persisting their external IDs prevents duplicate remote objects on retry.
+// Inputs: valid inventory and a fake exporter that stamps an external ID then
+// returns an error. Outputs: export fails but the stamped ID remains on disk.
+// Data choice: a random provider UUID proves the best-effort save preserved the
+// mutation rather than merely rewriting identical inventory.
+func TestRunExportPersistsExternalIDAfterProviderError(t *testing.T) {
+	inventory, deviceID := connectedExportInventory()
+	command, inventoryPath := prepareExportTest(t, inventory)
+	externalID := uuid.New()
+	provider := &fakeExportProvider{
+		exportErr: errors.New("provider failed after reconciliation"),
+		mutate: func(inventory *devicetypes.Inventory) {
+			inventory.Devices[deviceID].ExternalIDs = map[string]uuid.UUID{"fake-export": externalID}
+		},
+	}
+
+	if err := runExport(command, nil, provider); err == nil {
+		t.Fatal("expected provider error to be returned")
+	}
+	reloaded, err := (&datastores.JSONStore{Path: inventoryPath}).Load()
+	if err != nil {
+		t.Fatalf("reloading inventory after provider error: %v", err)
+	}
+	if got := reloaded.Devices[deviceID].ExternalIDs["fake-export"]; got != externalID {
+		t.Errorf("persisted external ID = %s, want %s", got, externalID)
+	}
+}

--- a/cmd/import/import_ipam_test.go
+++ b/cmd/import/import_ipam_test.go
@@ -26,8 +26,10 @@
 package imprt
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/Cray-HPE/cani/internal/config"
 	"github.com/Cray-HPE/cani/pkg/devicetypes"
 	"github.com/google/uuid"
 )
@@ -78,7 +80,9 @@ func TestMergeTransformResult_MergesIPAM(t *testing.T) {
 	result := ipamResult(vlanID, prefixID, ipID, vrfID)
 
 	ctx := &etlContext{inventory: devicetypes.NewInventory()}
-	mergeTransformResult(ctx, result)
+	if err := mergeTransformResult(ctx, result); err != nil {
+		t.Fatalf("mergeTransformResult() unexpected error: %v", err)
+	}
 
 	if _, ok := ctx.inventory.VLANs[vlanID]; !ok {
 		t.Errorf("VLAN %s was not merged into inventory", vlanID)
@@ -111,8 +115,12 @@ func TestMergeTransformResult_MergesIPAM(t *testing.T) {
 func TestMergeTransformResult_IPAMIdempotent(t *testing.T) {
 	ctx := &etlContext{inventory: devicetypes.NewInventory()}
 
-	mergeTransformResult(ctx, ipamResult(uuid.Nil, uuid.Nil, uuid.Nil, uuid.Nil))
-	mergeTransformResult(ctx, ipamResult(uuid.Nil, uuid.Nil, uuid.Nil, uuid.Nil))
+	if err := mergeTransformResult(ctx, ipamResult(uuid.Nil, uuid.Nil, uuid.Nil, uuid.Nil)); err != nil {
+		t.Fatalf("first mergeTransformResult() unexpected error: %v", err)
+	}
+	if err := mergeTransformResult(ctx, ipamResult(uuid.Nil, uuid.Nil, uuid.Nil, uuid.Nil)); err != nil {
+		t.Fatalf("second mergeTransformResult() unexpected error: %v", err)
+	}
 
 	if got := len(ctx.inventory.VLANs); got != 1 {
 		t.Errorf("VLANs: got %d, want 1 (re-import duplicated)", got)
@@ -125,5 +133,50 @@ func TestMergeTransformResult_IPAMIdempotent(t *testing.T) {
 	}
 	if got := len(ctx.inventory.VRFs); got != 1 {
 		t.Errorf("VRFs: got %d, want 1 (re-import duplicated)", got)
+	}
+}
+
+// TestMergeTransformResultRejectsInvalidCable verifies transformed inventory
+// with an unresolved cable port fails before the import Load phase.
+//
+// Why it matters: import merges in memory before persistence, so propagating
+// this error keeps the existing datastore atomic and prevents partial imports.
+// Inputs: firewall-01 with port1 and an imported cable naming missing port3.
+// Outputs: a contextual relationship error from mergeTransformResult.
+// Data choice: a valid device reference isolates the exact port-resolution
+// defect that previously survived import and failed during provider export.
+func TestMergeTransformResultRejectsInvalidCable(t *testing.T) {
+	originalConfig := config.Cfg
+	config.Cfg = &config.Config{}
+	t.Cleanup(func() { config.Cfg = originalConfig })
+
+	deviceID := uuid.New()
+	cableID := uuid.New()
+	ctx := &etlContext{inventory: devicetypes.NewInventory()}
+	result := &devicetypes.TransformResult{
+		Devices: map[uuid.UUID]*devicetypes.CaniDeviceType{
+			deviceID: {
+				ID: deviceID, Name: "firewall-01",
+				Interfaces: []devicetypes.InterfaceSpec{{ID: uuid.New(), Name: "port1"}},
+			},
+		},
+		Cables: map[uuid.UUID]*devicetypes.CaniCableType{
+			cableID: {
+				ID:                 cableID,
+				Label:              "invalid-uplink",
+				TerminationBDevice: deviceID,
+				TerminationBPort:   "port3",
+			},
+		},
+	}
+
+	err := mergeTransformResult(ctx, result)
+
+	if err == nil {
+		t.Fatal("expected invalid cable relationship to fail transform merge")
+	}
+	want := `termination B port "port3" not found on device "firewall-01"`
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("mergeTransformResult() error = %q, want it to contain %q", err, want)
 	}
 }

--- a/cmd/import/import_phases.go
+++ b/cmd/import/import_phases.go
@@ -106,7 +106,9 @@ func runTransformPhase(ctx *etlContext) error {
 	}
 
 	displayTransformSummary(ctx, result)
-	mergeTransformResult(ctx, result)
+	if err := mergeTransformResult(ctx, result); err != nil {
+		return fmt.Errorf("transform phase: %w", err)
+	}
 
 	if ctx.debug {
 		visual.PrintPhaseComplete(phaseNameTransform, ctx.opts)
@@ -124,8 +126,8 @@ func displayTransformSummary(ctx *etlContext, result *devicetypes.TransformResul
 	}
 }
 
-// mergeTransformResult merges all transformed entities into ctx.inventory.
-func mergeTransformResult(ctx *etlContext, result *devicetypes.TransformResult) {
+// mergeTransformResult merges and validates all transformed entities.
+func mergeTransformResult(ctx *etlContext, result *devicetypes.TransformResult) error {
 	result.EnsureUniqueDeviceNames()
 	mergeMetadata(ctx, result.Metadata)
 	locationRemap := mergeLocations(ctx, result.Locations)
@@ -144,7 +146,11 @@ func mergeTransformResult(ctx *etlContext, result *devicetypes.TransformResult) 
 	// Single verify pass after all merges — avoids duplicate warnings
 	// from per-entity verify calls.
 	log.Printf("Verifying parent-child relationships")
-	ctx.inventory.VerifyParentChildRelationships()
+	relationships := ctx.inventory.VerifyParentChildRelationships()
+	if err := relationships.Err(); err != nil {
+		return fmt.Errorf("relationship validation failed after merge: %w", err)
+	}
+	return nil
 }
 
 // runLoadPhase executes the Load phase of the ETL pipeline.

--- a/docs/inventory_format/overview.md
+++ b/docs/inventory_format/overview.md
@@ -48,6 +48,28 @@ Items reference each other by UUID:
 - A **Cable** has `TerminationA` and `TerminationB` endpoint UUIDs.
 - A **FRU** has a `Device` or `Parent` FK.
 
+### Cable Endpoint Integrity
+
+Each side of an inventory cable is either absent or complete. An absent side
+has an empty device/module UUID, port name, and interface UUID. A populated side
+must contain all three fields:
+
+- `terminationADevice` or `terminationBDevice` identifies a device or module.
+- `terminationAPort` or `terminationBPort` names an interface on that object.
+- `terminationA` or `terminationB` is the UUID of that exact interface.
+
+Relationship rebuilding fills a missing interface UUID when the referenced
+device or module contains the named port. Validation fails if the port cannot be
+resolved, if fields are only partially populated, or if an explicit interface
+UUID belongs to another endpoint. Module-owned interfaces may be referenced
+through the module UUID or found through their parent device.
+
+All command saves validate relationships before writing. Import fails the whole
+operation before its Load phase when transformed inventory is invalid, and
+export performs the same preflight before invoking a provider. Existing files
+remain loadable so operators can inspect and repair invalid data, but migration
+does not automatically rewrite a file while relationship errors remain.
+
 ## Example: Device
 
 ```json

--- a/internal/util/store/store.go
+++ b/internal/util/store/store.go
@@ -31,16 +31,40 @@
 package store
 
 import (
+	"fmt"
+
 	"github.com/Cray-HPE/cani/internal/cli"
 	"github.com/Cray-HPE/cani/pkg/datastores"
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
 )
 
 // datastoreFlag is the persistent root flag that selects the datastore backend.
 const datastoreFlag = "datastore"
 
+type validatingStore struct {
+	datastores.DeviceStore
+}
+
+func (store validatingStore) Save(inventory *devicetypes.Inventory) error {
+	if inventory == nil {
+		return fmt.Errorf("relationship validation failed: inventory is nil")
+	}
+	result := inventory.VerifyParentChildRelationships()
+	if err := result.Err(); err != nil {
+		return fmt.Errorf("relationship validation failed: %w", err)
+	}
+	return store.DeviceStore.Save(inventory)
+}
+
 // Setup resolves the datastore type from the root command's persistent
-// "datastore" flag and selects the matching backend in pkg/datastores.
+// "datastore" flag, selects the matching backend, and wraps command saves with
+// relationship validation. Concrete stores remain pure read/write so migration
+// code can deliberately persist through the raw implementation.
 func Setup(cmd *cli.Command) error {
 	storeType := cmd.Root().PersistentFlags().Lookup(datastoreFlag).Value.String()
-	return datastores.SetDeviceStore(storeType)
+	if err := datastores.SetDeviceStore(storeType); err != nil {
+		return err
+	}
+	datastores.Datastore = validatingStore{DeviceStore: datastores.Datastore}
+	return nil
 }

--- a/internal/util/store/store_test.go
+++ b/internal/util/store/store_test.go
@@ -1,0 +1,173 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ *  IN THE SOFTWARE.
+ *
+ */
+package store
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Cray-HPE/cani/internal/cli"
+	"github.com/Cray-HPE/cani/internal/config"
+	"github.com/Cray-HPE/cani/pkg/datastores"
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	"github.com/google/uuid"
+)
+
+type recordingStore struct {
+	saveCalls int
+}
+
+func (store *recordingStore) Load() (*devicetypes.Inventory, error) {
+	return devicetypes.NewInventory(), nil
+}
+
+func (store *recordingStore) Save(_ *devicetypes.Inventory) error {
+	store.saveCalls++
+	return nil
+}
+
+func useRecordingStore(t *testing.T) (*recordingStore, validatingStore) {
+	t.Helper()
+	original := datastores.Datastore
+	recorder := &recordingStore{}
+	store := validatingStore{DeviceStore: recorder}
+	datastores.Datastore = store
+	t.Cleanup(func() { datastores.Datastore = original })
+	return recorder, store
+}
+
+// TestValidatingStoreRejectsInvalidRelationships verifies validation failure
+// prevents the configured datastore from receiving a save call.
+//
+// Why it matters: every CLI mutation uses this boundary, so invalid cable
+// endpoints must be stopped before durable inventory is changed.
+// Inputs: firewall-01 with port1 and a cable naming missing port3.
+// Outputs: a contextual relationship error and zero datastore saves.
+// Data choice: a valid device with an invalid port isolates cable resolution
+// from datastore behavior and matches the reported regression.
+func TestValidatingStoreRejectsInvalidRelationships(t *testing.T) {
+	recorder, store := useRecordingStore(t)
+	deviceID := uuid.New()
+	inv := devicetypes.NewInventory()
+	inv.Devices[deviceID] = &devicetypes.CaniDeviceType{
+		ID: deviceID, Name: "firewall-01",
+		Interfaces: []devicetypes.InterfaceSpec{{ID: uuid.New(), Name: "port1"}},
+	}
+	inv.Cables[uuid.New()] = &devicetypes.CaniCableType{
+		Label:              "invalid-uplink",
+		TerminationBDevice: deviceID,
+		TerminationBPort:   "port3",
+	}
+
+	err := store.Save(inv)
+
+	if err == nil {
+		t.Fatal("expected invalid relationships to prevent save")
+	}
+	if !strings.Contains(err.Error(), `termination B port "port3" not found on device "firewall-01"`) {
+		t.Errorf("validatingStore.Save() error = %q, want endpoint context", err)
+	}
+	if recorder.saveCalls != 0 {
+		t.Errorf("datastore Save calls = %d, want 0", recorder.saveCalls)
+	}
+}
+
+// TestValidatingStoreResolvesAndPersistsValidRelationships verifies a valid
+// endpoint is rebuilt before exactly one datastore save.
+//
+// Why it matters: validation must retain the existing derivation behavior and
+// must not block correctly connected inventory from being persisted.
+// Inputs: switch-01 with port1 and a cable naming that device and port.
+// Outputs: nil error, one save call, and the resolved interface UUID.
+// Data choice: a zero termination UUID proves validatingStore runs rebuild before
+// deciding whether the inventory is valid.
+func TestValidatingStoreResolvesAndPersistsValidRelationships(t *testing.T) {
+	recorder, store := useRecordingStore(t)
+	deviceID := uuid.New()
+	interfaceID := uuid.New()
+	cableID := uuid.New()
+	inv := devicetypes.NewInventory()
+	inv.Devices[deviceID] = &devicetypes.CaniDeviceType{
+		ID: deviceID, Name: "switch-01",
+		Interfaces: []devicetypes.InterfaceSpec{{ID: interfaceID, Name: "port1"}},
+	}
+	inv.Cables[cableID] = &devicetypes.CaniCableType{
+		ID:                 cableID,
+		Label:              "uplink",
+		TerminationADevice: deviceID,
+		TerminationAPort:   "port1",
+	}
+
+	if err := store.Save(inv); err != nil {
+		t.Fatalf("validatingStore.Save() unexpected error: %v", err)
+	}
+	if recorder.saveCalls != 1 {
+		t.Errorf("datastore Save calls = %d, want 1", recorder.saveCalls)
+	}
+	if inv.Cables[cableID].TerminationA != interfaceID {
+		t.Errorf("TerminationA = %s, want %s", inv.Cables[cableID].TerminationA, interfaceID)
+	}
+}
+
+// TestSetupInstallsSingleValidatingStore verifies Setup decorates the selected
+// backend exactly once on every invocation.
+//
+// Why it matters: command call sites keep using DeviceStore.Save, so Setup must
+// establish the validation boundary without accumulating nested decorators.
+// Inputs: a root command selecting the JSON backend and two Setup calls.
+// Outputs: each call installs one validatingStore around a raw JSONStore.
+// Data choice: repeated setup matches separate command executions in tests and
+// proves backend selection resets the wrapper before decoration.
+func TestSetupInstallsSingleValidatingStore(t *testing.T) {
+	original := datastores.Datastore
+	originalConfig := config.Cfg
+	config.Cfg = &config.Config{Path: t.TempDir() + "/config.yaml", Datastore: "inventory.json"}
+	t.Cleanup(func() {
+		datastores.Datastore = original
+		config.Cfg = originalConfig
+	})
+
+	root := &cli.Command{Use: "cani"}
+	root.PersistentFlags().String("datastore", "json", "")
+	command := &cli.Command{Use: "test"}
+	root.AddCommand(command)
+
+	for range 2 {
+		if err := Setup(command); err != nil {
+			t.Fatalf("Setup() unexpected error: %v", err)
+		}
+		wrapped, ok := datastores.Datastore.(validatingStore)
+		if !ok {
+			t.Fatalf("Datastore = %T, want validatingStore", datastores.Datastore)
+		}
+		if _, nested := wrapped.DeviceStore.(validatingStore); nested {
+			t.Fatal("Setup() nested validatingStore decorators")
+		}
+		if _, ok := wrapped.DeviceStore.(*datastores.JSONStore); !ok {
+			t.Errorf("wrapped datastore = %T, want *datastores.JSONStore", wrapped.DeviceStore)
+		}
+	}
+}

--- a/pkg/datastores/json.go
+++ b/pkg/datastores/json.go
@@ -88,7 +88,11 @@ func (s *JSONStore) loadLegacy(data []byte) (*devicetypes.Inventory, error) {
 	// migrateV1Alpha1 sets Parent on every device, so the v1alpha2->v1alpha3
 	// back-fill is a no-op here; it only advances the schema version.
 	migrateV1Alpha2(data, inventory)
-	inventory.RebuildDerivedState()
+	relationships := inventory.RebuildDerivedState()
+	if err := relationships.Err(); err != nil {
+		log.Printf("Skipped saving migrated datastore with relationship errors: %v", err)
+		return inventory, nil
+	}
 
 	if err := s.Save(inventory); err != nil {
 		return nil, fmt.Errorf("saving migrated datastore: %w", err)
@@ -123,9 +127,13 @@ func (s *JSONStore) loadCurrent(data []byte) (*devicetypes.Inventory, error) {
 	}
 
 	inventory.RebuildProviderKeyIndex()
-	inventory.RebuildDerivedState()
+	relationships := inventory.RebuildDerivedState()
 
 	if metaMigrated || relMigrated {
+		if err := relationships.Err(); err != nil {
+			log.Printf("Skipped saving migrated datastore with relationship errors: %v", err)
+			return inventory, nil
+		}
 		if err := s.Save(inventory); err != nil {
 			return nil, fmt.Errorf("saving migrated datastore: %w", err)
 		}

--- a/pkg/datastores/json_test.go
+++ b/pkg/datastores/json_test.go
@@ -75,6 +75,9 @@ func newCRUDInventory(t *testing.T) (*devicetypes.Inventory, crudFixtureIDs) {
 		Rack:         ids.rackID,
 		RackPosition: 10,
 		Face:         "front",
+		Interfaces: []devicetypes.InterfaceSpec{
+			{ID: uuid.New(), Name: "eth0"},
+		},
 		ObjectMeta: devicetypes.ObjectMeta{
 			Status: string(devicetypes.StatusActive),
 			ProviderMetadata: map[string]any{
@@ -93,7 +96,10 @@ func newCRUDInventory(t *testing.T) (*devicetypes.Inventory, crudFixtureIDs) {
 		Rack:         ids.rackID,
 		RackPosition: 20,
 		Face:         "rear",
-		ObjectMeta:   devicetypes.ObjectMeta{Status: string(devicetypes.StatusActive)},
+		Interfaces: []devicetypes.InterfaceSpec{
+			{ID: uuid.New(), Name: "1/1/1"},
+		},
+		ObjectMeta: devicetypes.ObjectMeta{Status: string(devicetypes.StatusActive)},
 	}
 	if err := inv.AddDevices(map[uuid.UUID]*devicetypes.CaniDeviceType{
 		ids.nodeID:   node,
@@ -403,6 +409,58 @@ func TestLoadInvalidJSON(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "parsing inventory") {
 		t.Fatalf("Load() error = %v, want parsing inventory context", err)
+	}
+}
+
+// TestLoadSkipsMigrationSaveForInvalidRelationships verifies an older-schema
+// datastore is not rewritten when migration exposes an unresolved cable port.
+//
+// Why it matters: automatic migration must not persist relationship-invalid
+// inventory, while tolerant loading still lets operators inspect and repair it.
+// Inputs: a v1alpha2 inventory with firewall-01 port1 and a cable naming port3.
+// Outputs: Load returns the in-memory inventory without changing source bytes.
+// Data choice: v1alpha2 triggers the relationship migration save path, and the
+// valid device plus missing port isolates the new save guard.
+func TestLoadSkipsMigrationSaveForInvalidRelationships(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "inventory.json")
+	deviceID := uuid.New()
+	inventory := devicetypes.NewInventory()
+	inventory.SchemaVersion = devicetypes.SchemaVersionV1Alpha2
+	inventory.Devices[deviceID] = &devicetypes.CaniDeviceType{
+		ID: deviceID, Name: "firewall-01",
+		Interfaces: []devicetypes.InterfaceSpec{{ID: uuid.New(), Name: "port1"}},
+	}
+	inventory.Cables[uuid.New()] = &devicetypes.CaniCableType{
+		Label:              "invalid-uplink",
+		TerminationBDevice: deviceID,
+		TerminationBPort:   "port3",
+	}
+	before, err := json.MarshalIndent(inventory, "", "  ")
+	if err != nil {
+		t.Fatalf("marshalling old-schema inventory: %v", err)
+	}
+	if err := os.WriteFile(path, before, 0600); err != nil {
+		t.Fatalf("writing old-schema inventory: %v", err)
+	}
+
+	loaded, err := (&JSONStore{Path: path}).Load()
+
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("Load() returned nil inventory")
+	}
+	if result := loaded.RebuildDerivedState(); !result.HasErrors() {
+		t.Fatal("expected invalid cable to remain available for repair")
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading datastore after load: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Error("relationship-invalid migration rewrote the datastore")
 	}
 }
 

--- a/pkg/devicetypes/inventory_add_remove.go
+++ b/pkg/devicetypes/inventory_add_remove.go
@@ -89,7 +89,12 @@ func (inv *Inventory) AddCable(cable *CaniCableType) error {
 		return fmt.Errorf("cable %s already exists", cable.ID)
 	}
 	inv.Cables[cable.ID] = cable
-	inv.VerifyParentChildRelationships()
+	result := inv.VerifyParentChildRelationships()
+	if err := result.Err(); err != nil {
+		delete(inv.Cables, cable.ID)
+		inv.RebuildDerivedState()
+		return err
+	}
 	return nil
 }
 
@@ -139,12 +144,10 @@ func (inv *Inventory) RemoveRack(id uuid.UUID) error {
 
 // RemoveModule deletes a module from the inventory.
 func (inv *Inventory) RemoveModule(id uuid.UUID) error {
-	mod, exists := inv.Modules[id]
-	if !exists {
+	if _, exists := inv.Modules[id]; !exists {
 		return fmt.Errorf("module %s not found", id)
 	}
-	// Remove cables referencing this module's parent device
-	_ = mod // module has ParentDevice but cables ref devices, not modules
+	inv.removeCablesForDevice(id)
 	delete(inv.Modules, id)
 	return nil
 }

--- a/pkg/devicetypes/inventory_add_remove_test.go
+++ b/pkg/devicetypes/inventory_add_remove_test.go
@@ -14,6 +14,7 @@ package devicetypes
 // | RemoveCable    | TestRemoveCableValid                         | TestRemoveCableNotFound                         |
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -147,6 +148,76 @@ func TestAddCableDuplicateUUID(t *testing.T) {
 	}
 }
 
+// TestAddCableResolvesValidPort verifies adding a connected cable resolves its
+// endpoint interface UUID before returning success.
+//
+// Why it matters: callers provide stable device and port references while the
+// derived interface UUID is needed for persistence and provider export.
+// Inputs: switch-01 with port1 and a cable naming that device and port.
+// Outputs: AddCable returns nil, stores the cable, and fills TerminationA.
+// Data choice: a single populated side proves the selected absent-or-complete
+// policy without requiring an unrelated second endpoint fixture.
+func TestAddCableResolvesValidPort(t *testing.T) {
+	deviceID := uuid.New()
+	interfaceID := uuid.New()
+	inv := NewInventory()
+	inv.Devices[deviceID] = &CaniDeviceType{
+		ID: deviceID, Name: "switch-01",
+		Interfaces: []InterfaceSpec{{ID: interfaceID, Name: "port1"}},
+	}
+	cable := &CaniCableType{
+		ID:                 uuid.New(),
+		Label:              "uplink",
+		TerminationADevice: deviceID,
+		TerminationAPort:   "port1",
+	}
+
+	if err := inv.AddCable(cable); err != nil {
+		t.Fatalf("AddCable() unexpected error: %v", err)
+	}
+	if cable.TerminationA != interfaceID {
+		t.Errorf("TerminationA = %s, want %s", cable.TerminationA, interfaceID)
+	}
+	if _, exists := inv.Cables[cable.ID]; !exists {
+		t.Error("expected valid cable to remain in inventory")
+	}
+}
+
+// TestAddCableRejectsUnknownPortAndRollsBack verifies invalid cable insertion
+// leaves the inventory unchanged.
+//
+// Why it matters: callers may attempt to save immediately after AddCable, so a
+// rejected relationship must not survive in memory as a latent invalid object.
+// Inputs: firewall-01 with port1 and a cable naming nonexistent port3.
+// Outputs: AddCable returns a contextual error and removes the provisional map
+// entry. Data choice: a valid device isolates rollback around port resolution.
+func TestAddCableRejectsUnknownPortAndRollsBack(t *testing.T) {
+	deviceID := uuid.New()
+	inv := NewInventory()
+	inv.Devices[deviceID] = &CaniDeviceType{
+		ID: deviceID, Name: "firewall-01",
+		Interfaces: []InterfaceSpec{{ID: uuid.New(), Name: "port1"}},
+	}
+	cable := &CaniCableType{
+		ID:                 uuid.New(),
+		Label:              "invalid-uplink",
+		TerminationBDevice: deviceID,
+		TerminationBPort:   "port3",
+	}
+
+	err := inv.AddCable(cable)
+
+	if err == nil {
+		t.Fatal("expected AddCable to reject an unknown port")
+	}
+	if !strings.Contains(err.Error(), `termination B port "port3" not found on device "firewall-01"`) {
+		t.Errorf("AddCable() error = %q, want endpoint context", err)
+	}
+	if _, exists := inv.Cables[cable.ID]; exists {
+		t.Error("invalid cable remained in inventory after AddCable failure")
+	}
+}
+
 // ---------- RemoveLocation ----------
 
 func TestRemoveLocationEmpty(t *testing.T) {
@@ -240,6 +311,33 @@ func TestRemoveModuleNotFound(t *testing.T) {
 	inv := NewInventory()
 	if err := inv.RemoveModule(uuid.New()); err == nil {
 		t.Error("RemoveModule(non-existent) should return an error")
+	}
+}
+
+// TestRemoveModuleDeletesDirectCableReferences verifies module removal cleans
+// cables whose endpoint directly names that module.
+//
+// Why it matters: relationship rebuilding no longer silently prunes dangling
+// cables, so explicit removal must preserve inventory integrity itself.
+// Inputs: one module and one cable whose B endpoint references its UUID.
+// Outputs: both the module and cable are absent after RemoveModule.
+// Data choice: a direct module UUID exercises the reference not covered by the
+// existing parent-device cable cleanup.
+func TestRemoveModuleDeletesDirectCableReferences(t *testing.T) {
+	inv := NewInventory()
+	moduleID := uuid.New()
+	cableID := uuid.New()
+	inv.Modules[moduleID] = &CaniModuleType{ID: moduleID, Name: "nic-01"}
+	inv.Cables[cableID] = &CaniCableType{
+		ID:                 cableID,
+		TerminationBDevice: moduleID,
+	}
+
+	if err := inv.RemoveModule(moduleID); err != nil {
+		t.Fatalf("RemoveModule() unexpected error: %v", err)
+	}
+	if _, exists := inv.Cables[cableID]; exists {
+		t.Error("expected cable referencing removed module to be deleted")
 	}
 }
 

--- a/pkg/devicetypes/inventory_crud.go
+++ b/pkg/devicetypes/inventory_crud.go
@@ -738,6 +738,7 @@ func (inv *Inventory) removeCablesForDevice(id uuid.UUID) {
 func (inv *Inventory) removeModulesForDevice(id uuid.UUID) {
 	for modID, mod := range inv.Modules {
 		if mod != nil && mod.ParentDevice == id {
+			inv.removeCablesForDevice(modID)
 			delete(inv.Modules, modID)
 		}
 	}

--- a/pkg/devicetypes/inventory_crud_test.go
+++ b/pkg/devicetypes/inventory_crud_test.go
@@ -131,6 +131,7 @@ func TestRemoveModulesForDeviceDeletesMatching(t *testing.T) {
 	deviceID := uuid.New()
 	modMatchID := uuid.New()
 	modKeepID := uuid.New()
+	cableID := uuid.New()
 
 	inv.Modules[modMatchID] = &CaniModuleType{
 		ID:           modMatchID,
@@ -142,6 +143,10 @@ func TestRemoveModulesForDeviceDeletesMatching(t *testing.T) {
 		Name:         "mod-keep",
 		ParentDevice: uuid.New(),
 	}
+	inv.Cables[cableID] = &CaniCableType{
+		ID:                 cableID,
+		TerminationADevice: modMatchID,
+	}
 
 	inv.removeModulesForDevice(deviceID)
 
@@ -150,6 +155,9 @@ func TestRemoveModulesForDeviceDeletesMatching(t *testing.T) {
 	}
 	if _, ok := inv.Modules[modKeepID]; !ok {
 		t.Error("unrelated module should remain")
+	}
+	if _, ok := inv.Cables[cableID]; ok {
+		t.Error("cable referencing deleted child module should be deleted")
 	}
 }
 

--- a/pkg/devicetypes/inventory_relationships.go
+++ b/pkg/devicetypes/inventory_relationships.go
@@ -26,6 +26,7 @@
 package devicetypes
 
 import (
+	"errors"
 	"fmt"
 	"log"
 
@@ -46,6 +47,14 @@ type RelationshipResult struct {
 // HasErrors returns true when unresolvable relationship errors exist.
 func (r *RelationshipResult) HasErrors() bool {
 	return len(r.Errors) > 0
+}
+
+// Err returns all unresolvable relationship errors as one error.
+func (r *RelationshipResult) Err() error {
+	if r == nil || len(r.Errors) == 0 {
+		return nil
+	}
+	return errors.Join(r.Errors...)
 }
 
 // HasOrphans returns true when orphaned items were detected.
@@ -501,9 +510,9 @@ func (inv *Inventory) rebuildFruRelationships() *RelationshipResult {
 	return res
 }
 
-// rebuildCableRelationships resolves cable TerminationA/B interface UUIDs
-// from device + port name and removes cables whose device references are
-// invalid (e.g. after a device was removed).
+// rebuildCableRelationships resolves missing cable TerminationA/B interface
+// UUIDs from device + port name. Explicit termination UUIDs are preserved so
+// validateCableRelationships can report contradictory endpoint fields.
 //
 // Must run AFTER rebuildInterfaceRelationships (needs the rebuilt interface
 // index) and BEFORE validateCableRelationships (which validates the resolved
@@ -515,38 +524,23 @@ func (inv *Inventory) rebuildCableRelationships() *RelationshipResult {
 			continue
 		}
 
-		// Remove cables whose device references are invalid.
-		aDeviceOK := cable.TerminationADevice == uuid.Nil || inv.Devices[cable.TerminationADevice] != nil || inv.Modules[cable.TerminationADevice] != nil
-		bDeviceOK := cable.TerminationBDevice == uuid.Nil || inv.Devices[cable.TerminationBDevice] != nil || inv.Modules[cable.TerminationBDevice] != nil
-		if !aDeviceOK || !bDeviceOK {
-			res.Fixed = append(res.Fixed,
-				fmt.Sprintf("cable %q (%s): removed (endpoint device deleted)",
-					cable.Label, cableID))
-			delete(inv.Cables, cableID)
-			continue
-		}
-
 		// Resolve TerminationA interface UUID from device + port name.
-		if cable.TerminationADevice != uuid.Nil && cable.TerminationAPort != "" {
+		if cable.TerminationA == uuid.Nil && cable.TerminationADevice != uuid.Nil && cable.TerminationAPort != "" {
 			if ifaceID := inv.FindInterfaceIDByPort(cable.TerminationADevice, cable.TerminationAPort); ifaceID != uuid.Nil {
-				if cable.TerminationA != ifaceID {
-					cable.TerminationA = ifaceID
-					res.Fixed = append(res.Fixed,
-						fmt.Sprintf("cable %q (%s): resolved termination A interface for port %q",
-							cable.Label, cableID, cable.TerminationAPort))
-				}
+				cable.TerminationA = ifaceID
+				res.Fixed = append(res.Fixed,
+					fmt.Sprintf("cable %q (%s): resolved termination A interface for port %q",
+						cable.Label, cableID, cable.TerminationAPort))
 			}
 		}
 
 		// Resolve TerminationB interface UUID from device + port name.
-		if cable.TerminationBDevice != uuid.Nil && cable.TerminationBPort != "" {
+		if cable.TerminationB == uuid.Nil && cable.TerminationBDevice != uuid.Nil && cable.TerminationBPort != "" {
 			if ifaceID := inv.FindInterfaceIDByPort(cable.TerminationBDevice, cable.TerminationBPort); ifaceID != uuid.Nil {
-				if cable.TerminationB != ifaceID {
-					cable.TerminationB = ifaceID
-					res.Fixed = append(res.Fixed,
-						fmt.Sprintf("cable %q (%s): resolved termination B interface for port %q",
-							cable.Label, cableID, cable.TerminationBPort))
-				}
+				cable.TerminationB = ifaceID
+				res.Fixed = append(res.Fixed,
+					fmt.Sprintf("cable %q (%s): resolved termination B interface for port %q",
+						cable.Label, cableID, cable.TerminationBPort))
 			}
 		}
 	}
@@ -590,8 +584,8 @@ func (inv *Inventory) FindInterfaceIDByPort(deviceID uuid.UUID, portName string)
 	return uuid.Nil
 }
 
-// validateCableRelationships verifies cable termination devices and
-// interface references exist.
+// validateCableRelationships verifies each populated cable endpoint is a
+// coherent device or module, port name, and interface UUID tuple.
 func (inv *Inventory) validateCableRelationships() *RelationshipResult {
 	res := &RelationshipResult{}
 	for id, cable := range inv.Cables {
@@ -599,11 +593,29 @@ func (inv *Inventory) validateCableRelationships() *RelationshipResult {
 			continue
 		}
 		res.merge(inv.validateCableEnd(id, cable, "A",
-			cable.TerminationADevice, cable.TerminationA))
+			cable.TerminationADevice, cable.TerminationAPort, cable.TerminationA))
 		res.merge(inv.validateCableEnd(id, cable, "B",
-			cable.TerminationBDevice, cable.TerminationB))
+			cable.TerminationBDevice, cable.TerminationBPort, cable.TerminationB))
 	}
 	return res
+}
+
+// cableEndpointOwner describes a device or module used by a cable endpoint.
+func (inv *Inventory) cableEndpointOwner(deviceRef uuid.UUID) (string, string, bool) {
+	if device := inv.Devices[deviceRef]; device != nil {
+		return "device", displayEndpointName(device.Name, deviceRef), true
+	}
+	if module := inv.Modules[deviceRef]; module != nil {
+		return "module", displayEndpointName(module.Name, deviceRef), true
+	}
+	return "device or module", deviceRef.String(), false
+}
+
+func displayEndpointName(name string, id uuid.UUID) string {
+	if name != "" {
+		return name
+	}
+	return id.String()
 }
 
 // validateCableEnd checks one end of a cable for reference integrity.
@@ -612,24 +624,57 @@ func (inv *Inventory) validateCableEnd(
 	cable *CaniCableType,
 	side string,
 	deviceRef uuid.UUID,
+	portName string,
 	ifaceRef uuid.UUID,
 ) *RelationshipResult {
 	res := &RelationshipResult{}
-	if deviceRef != uuid.Nil {
-		_, devOK := inv.Devices[deviceRef]
-		_, modOK := inv.Modules[deviceRef]
-		if !devOK && !modOK {
-			res.Errors = append(res.Errors,
-				fmt.Errorf("cable %q (%s): termination %s device %s not found",
-					cable.Label, cableID, side, deviceRef))
-		}
+	if deviceRef == uuid.Nil && portName == "" && ifaceRef == uuid.Nil {
+		return res
 	}
-	if ifaceRef != uuid.Nil {
-		if iface, _ := inv.GetInterfaceByID(ifaceRef); iface == nil {
-			res.Errors = append(res.Errors,
-				fmt.Errorf("cable %q (%s): termination %s interface %s not found",
-					cable.Label, cableID, side, ifaceRef))
-		}
+	if deviceRef == uuid.Nil {
+		res.Errors = append(res.Errors, fmt.Errorf(
+			"cable %q (%s): termination %s device or module is required for populated endpoint",
+			cable.Label, cableID, side))
+		return res
+	}
+
+	ownerKind, ownerName, ownerExists := inv.cableEndpointOwner(deviceRef)
+	if !ownerExists {
+		res.Errors = append(res.Errors, fmt.Errorf(
+			"cable %q (%s): termination %s %s %s not found",
+			cable.Label, cableID, side, ownerKind, ownerName))
+		return res
+	}
+	if portName == "" {
+		res.Errors = append(res.Errors, fmt.Errorf(
+			"cable %q (%s): termination %s port is required for %s %q",
+			cable.Label, cableID, side, ownerKind, ownerName))
+		return res
+	}
+
+	resolvedID := inv.FindInterfaceIDByPort(deviceRef, portName)
+	if resolvedID == uuid.Nil {
+		res.Errors = append(res.Errors, fmt.Errorf(
+			"cable %q (%s): termination %s port %q not found on %s %q",
+			cable.Label, cableID, side, portName, ownerKind, ownerName))
+		return res
+	}
+	if ifaceRef == uuid.Nil {
+		res.Errors = append(res.Errors, fmt.Errorf(
+			"cable %q (%s): termination %s interface is unresolved for port %q on %s %q",
+			cable.Label, cableID, side, portName, ownerKind, ownerName))
+		return res
+	}
+	if iface, _ := inv.GetInterfaceByID(ifaceRef); iface == nil {
+		res.Errors = append(res.Errors, fmt.Errorf(
+			"cable %q (%s): termination %s interface %s not found for port %q on %s %q",
+			cable.Label, cableID, side, ifaceRef, portName, ownerKind, ownerName))
+		return res
+	}
+	if ifaceRef != resolvedID {
+		res.Errors = append(res.Errors, fmt.Errorf(
+			"cable %q (%s): termination %s interface %s does not match port %q on %s %q (expected %s)",
+			cable.Label, cableID, side, ifaceRef, portName, ownerKind, ownerName, resolvedID))
 	}
 	return res
 }

--- a/pkg/devicetypes/inventory_relationships_test.go
+++ b/pkg/devicetypes/inventory_relationships_test.go
@@ -494,8 +494,10 @@ func TestValidateCableRelationshipsHappyPath(t *testing.T) {
 	inv.Cables[cableID] = &CaniCableType{
 		Label:              "cable-1",
 		TerminationADevice: devA,
+		TerminationAPort:   "eth0",
 		TerminationA:       ifaceA,
 		TerminationBDevice: devB,
+		TerminationBPort:   "eth0",
 		TerminationB:       ifaceB,
 	}
 
@@ -521,6 +523,47 @@ func TestValidateCableRelationshipsMissingDevice(t *testing.T) {
 	}
 }
 
+// TestVerifyCableRelationshipsRejectsUnknownPort verifies a populated cable
+// endpoint fails relationship validation when its named port is not present.
+//
+// Why it matters: unresolved cable ports must stop persistence and export before
+// providers reconcile unrelated inventory objects.
+// Inputs: firewall-01 with ports port1 and port2, and a cable whose B endpoint
+// names port3. Outputs: an error identifying the cable, side, device, and port.
+// Data choice: port3 is plausible but absent, matching the reported regression
+// while keeping the device reference itself valid.
+func TestVerifyCableRelationshipsRejectsUnknownPort(t *testing.T) {
+	deviceID := uuid.New()
+	cableID := uuid.New()
+	inv := NewInventory()
+	inv.Devices[deviceID] = &CaniDeviceType{
+		ID:   deviceID,
+		Name: "firewall-01",
+		Interfaces: []InterfaceSpec{
+			{ID: uuid.New(), Name: "port1"},
+			{ID: uuid.New(), Name: "port2"},
+		},
+	}
+	inv.Cables[cableID] = &CaniCableType{
+		ID:                 cableID,
+		Label:              "firewall-uplink",
+		TerminationBDevice: deviceID,
+		TerminationBPort:   "port3",
+	}
+
+	result := inv.VerifyParentChildRelationships()
+
+	if !result.HasErrors() {
+		t.Fatal("expected unresolved termination B port to fail validation")
+	}
+	want := fmt.Sprintf(
+		"cable %q (%s): termination B port %q not found on device %q",
+		"firewall-uplink", cableID, "port3", "firewall-01")
+	if !strings.Contains(result.Errors[0].Error(), want) {
+		t.Errorf("relationship error = %q, want it to contain %q", result.Errors[0], want)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // validateCableEnd
 // ---------------------------------------------------------------------------
@@ -540,7 +583,7 @@ func TestValidateCableEndHappyPath(t *testing.T) {
 	inv.Interfaces[ifaceID] = &CaniInterface{ID: ifaceID, DeviceID: devID}
 	cable := &CaniCableType{Label: "c1"}
 
-	res := inv.validateCableEnd(cableID, cable, "A", devID, ifaceID)
+	res := inv.validateCableEnd(cableID, cable, "A", devID, "eth0", ifaceID)
 	if res.HasErrors() {
 		t.Fatalf("unexpected errors: %v", res.Errors)
 	}
@@ -554,12 +597,208 @@ func TestValidateCableEndMissingDeviceAndInterface(t *testing.T) {
 
 	inv := NewInventory()
 
-	res := inv.validateCableEnd(cableID, cable, "B", missingDev, missingIface)
+	res := inv.validateCableEnd(cableID, cable, "B", missingDev, "eth0", missingIface)
 	if !res.HasErrors() {
 		t.Fatal("expected errors for missing device and interface")
 	}
-	if len(res.Errors) != 2 {
-		t.Fatalf("expected 2 errors (device + interface), got %d", len(res.Errors))
+	if len(res.Errors) != 1 {
+		t.Fatalf("expected owner lookup to fail first, got %d errors", len(res.Errors))
+	}
+}
+
+// TestValidateCableEndRejectsUnresolvedInterface verifies strict endpoint
+// validation rejects a valid device and port whose interface UUID is zero.
+//
+// Why it matters: relationship rebuilding normally fills this UUID, so a zero
+// value after resolution signals an endpoint that cannot be safely persisted.
+// Inputs: firewall-01 and its port1 with a zero endpoint interface UUID.
+// Outputs: an error naming the unresolved interface, port, and device.
+// Data choice: a real port isolates the zero-UUID invariant from port lookup
+// failure, which has its own regression test.
+func TestValidateCableEndRejectsUnresolvedInterface(t *testing.T) {
+	deviceID := uuid.New()
+	interfaceID := uuid.New()
+	cableID := uuid.New()
+	inv := NewInventory()
+	inv.Devices[deviceID] = &CaniDeviceType{
+		ID:   deviceID,
+		Name: "firewall-01",
+		Interfaces: []InterfaceSpec{
+			{ID: interfaceID, Name: "port1"},
+		},
+	}
+	inv.rebuildInterfaceRelationships()
+
+	result := inv.validateCableEnd(
+		cableID,
+		&CaniCableType{Label: "firewall-uplink"},
+		"A",
+		deviceID,
+		"port1",
+		uuid.Nil,
+	)
+
+	if !result.HasErrors() {
+		t.Fatal("expected zero interface UUID to fail endpoint validation")
+	}
+	if !strings.Contains(result.Errors[0].Error(),
+		`termination A interface is unresolved for port "port1" on device "firewall-01"`) {
+		t.Errorf("unexpected relationship error: %v", result.Errors[0])
+	}
+}
+
+// TestValidateCableEndRejectsIncompleteFields verifies every partially
+// populated endpoint shape fails strict relationship validation.
+//
+// Why it matters: device, port, and interface fields describe one endpoint and
+// must not be persisted independently because providers cannot reconcile them.
+// Inputs: five incomplete combinations of a known device, port, and interface.
+// Outputs: each combination produces an error identifying its missing field.
+// Data choice: the cases cover every nonempty proper subset except device+port,
+// whose zero-interface behavior is asserted separately above.
+func TestValidateCableEndRejectsIncompleteFields(t *testing.T) {
+	deviceID := uuid.New()
+	interfaceID := uuid.New()
+	inv := NewInventory()
+	inv.Devices[deviceID] = &CaniDeviceType{
+		ID:   deviceID,
+		Name: "switch-01",
+		Interfaces: []InterfaceSpec{
+			{ID: interfaceID, Name: "eth0"},
+		},
+	}
+	inv.rebuildInterfaceRelationships()
+
+	testCases := []struct {
+		name       string
+		deviceRef  uuid.UUID
+		portName   string
+		ifaceRef   uuid.UUID
+		wantDetail string
+	}{
+		{name: "device only", deviceRef: deviceID, wantDetail: "port is required"},
+		{name: "port only", portName: "eth0", wantDetail: "device or module is required"},
+		{name: "interface only", ifaceRef: interfaceID, wantDetail: "device or module is required"},
+		{name: "device and interface", deviceRef: deviceID, ifaceRef: interfaceID, wantDetail: "port is required"},
+		{name: "port and interface", portName: "eth0", ifaceRef: interfaceID, wantDetail: "device or module is required"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := inv.validateCableEnd(
+				uuid.New(),
+				&CaniCableType{Label: "partial"},
+				"A",
+				testCase.deviceRef,
+				testCase.portName,
+				testCase.ifaceRef,
+			)
+
+			if !result.HasErrors() {
+				t.Fatal("expected incomplete endpoint to fail validation")
+			}
+			if !strings.Contains(result.Errors[0].Error(), testCase.wantDetail) {
+				t.Errorf("relationship error = %q, want detail %q", result.Errors[0], testCase.wantDetail)
+			}
+		})
+	}
+}
+
+// TestVerifyCableRelationshipsRejectsInterfaceOnDifferentDevice verifies an
+// explicit interface UUID must match the endpoint device and port.
+//
+// Why it matters: accepting an interface from another device produces a cable
+// topology that cannot be represented correctly by downstream providers.
+// Inputs: two devices with distinct port1 UUIDs and a cable declaring device A
+// while carrying device B's interface UUID. Outputs: a mismatch error, with the
+// contradictory UUID preserved for diagnosis.
+// Data choice: identical port names ensure UUID ownership, not a name typo,
+// distinguishes the invalid endpoint.
+func TestVerifyCableRelationshipsRejectsInterfaceOnDifferentDevice(t *testing.T) {
+	deviceAID := uuid.New()
+	deviceBID := uuid.New()
+	interfaceAID := uuid.New()
+	interfaceBID := uuid.New()
+	cableID := uuid.New()
+	inv := NewInventory()
+	inv.Devices[deviceAID] = &CaniDeviceType{
+		ID: deviceAID, Name: "switch-a",
+		Interfaces: []InterfaceSpec{{ID: interfaceAID, Name: "port1"}},
+	}
+	inv.Devices[deviceBID] = &CaniDeviceType{
+		ID: deviceBID, Name: "switch-b",
+		Interfaces: []InterfaceSpec{{ID: interfaceBID, Name: "port1"}},
+	}
+	inv.Cables[cableID] = &CaniCableType{
+		ID:                 cableID,
+		Label:              "crossed",
+		TerminationADevice: deviceAID,
+		TerminationAPort:   "port1",
+		TerminationA:       interfaceBID,
+	}
+
+	result := inv.VerifyParentChildRelationships()
+
+	if !result.HasErrors() {
+		t.Fatal("expected interface from another device to fail validation")
+	}
+	if inv.Cables[cableID].TerminationA != interfaceBID {
+		t.Errorf("TerminationA was overwritten: got %s, want %s", inv.Cables[cableID].TerminationA, interfaceBID)
+	}
+	if !strings.Contains(result.Errors[0].Error(), "does not match port") {
+		t.Errorf("unexpected relationship error: %v", result.Errors[0])
+	}
+}
+
+// TestVerifyCableRelationshipsAcceptsModuleInterfaces verifies cable endpoints
+// can resolve an interface owned by a child module.
+//
+// Why it matters: connectable module ports are part of the portable inventory
+// model and must remain valid under strict endpoint ownership checks.
+// Inputs: a module-owned mgmt0 port referenced once through its parent device
+// and once through the module UUID. Outputs: both terminations resolve without
+// relationship errors.
+// Data choice: the two references exercise both module fallback and direct
+// module lookup paths in FindInterfaceIDByPort.
+func TestVerifyCableRelationshipsAcceptsModuleInterfaces(t *testing.T) {
+	deviceID := uuid.New()
+	moduleID := uuid.New()
+	interfaceID := uuid.New()
+	parentCableID := uuid.New()
+	directCableID := uuid.New()
+	inv := NewInventory()
+	inv.Devices[deviceID] = &CaniDeviceType{ID: deviceID, Name: "server-01"}
+	inv.Modules[moduleID] = &CaniModuleType{
+		ID:           moduleID,
+		Name:         "nic-01",
+		ParentDevice: deviceID,
+		Interfaces: []InterfaceSpec{
+			{ID: interfaceID, Name: "mgmt0"},
+		},
+	}
+	inv.Cables[parentCableID] = &CaniCableType{
+		ID:                 parentCableID,
+		Label:              "parent-reference",
+		TerminationADevice: deviceID,
+		TerminationAPort:   "mgmt0",
+	}
+	inv.Cables[directCableID] = &CaniCableType{
+		ID:                 directCableID,
+		Label:              "module-reference",
+		TerminationBDevice: moduleID,
+		TerminationBPort:   "mgmt0",
+	}
+
+	result := inv.VerifyParentChildRelationships()
+
+	if result.HasErrors() {
+		t.Fatalf("unexpected module endpoint errors: %v", result.Errors)
+	}
+	if inv.Cables[parentCableID].TerminationA != interfaceID {
+		t.Errorf("parent-device module lookup = %s, want %s", inv.Cables[parentCableID].TerminationA, interfaceID)
+	}
+	if inv.Cables[directCableID].TerminationB != interfaceID {
+		t.Errorf("direct module lookup = %s, want %s", inv.Cables[directCableID].TerminationB, interfaceID)
 	}
 }
 
@@ -957,19 +1196,16 @@ func TestValidateModuleRelationshipsNilAndNoParent(t *testing.T) {
 	}
 }
 
-// TestRebuildCableRelationships verifies rebuildCableRelationships removes cables
-// whose endpoint devices were deleted and resolves termination interface UUIDs
-// from device + port names.
+// TestRebuildCableRelationships verifies rebuildCableRelationships preserves
+// invalid cables for diagnosis and resolves valid interface UUIDs from ports.
 //
-// Why it matters: after devices are removed or re-imported, cable terminations
-// must be re-resolved or pruned so the topology stays consistent; stale cables
-// would otherwise reference non-existent endpoints.
+// Why it matters: rebuild must not hide malformed imported endpoints by deleting
+// them before strict validation can stop persistence or export.
 // Inputs: an inventory with a device that has an "eth0" interface plus a cable
 // whose A-side names that device/port and whose B-side references a deleted
-// device. Outputs: the stale cable removed and, for a second valid cable, the
-// A-side TerminationA UUID resolved to the interface ID. Data choice: combining
-// a delete case and a resolve case in one inventory exercises both the prune
-// branch and the port-resolution branch of the loop.
+// device. Outputs: the stale cable remains and fails validation, while a second
+// cable resolves its A-side interface. Data choice: the paired cases distinguish
+// non-destructive rebuild behavior from successful derivation.
 func TestRebuildCableRelationships(t *testing.T) {
 	inv := NewInventory()
 	devID := uuid.New()
@@ -998,14 +1234,17 @@ func TestRebuildCableRelationships(t *testing.T) {
 
 	res := inv.rebuildCableRelationships()
 
-	if _, ok := inv.Cables[staleID]; ok {
-		t.Error("expected stale cable to be removed")
+	if _, ok := inv.Cables[staleID]; !ok {
+		t.Error("expected stale cable to remain available for validation")
 	}
 	if inv.Cables[resolveID].TerminationA != ethID {
 		t.Errorf("TerminationA = %v, want resolved %v", inv.Cables[resolveID].TerminationA, ethID)
 	}
-	if len(res.Fixed) == 0 {
-		t.Error("expected Fixed entries for prune + resolve")
+	if len(res.Fixed) != 1 {
+		t.Errorf("Fixed entries = %d, want only the resolved endpoint", len(res.Fixed))
+	}
+	if validation := inv.validateCableRelationships(); !validation.HasErrors() {
+		t.Error("expected preserved stale cable to fail validation")
 	}
 }
 

--- a/spec/integration/example_transform_parity_spec.sh
+++ b/spec/integration/example_transform_parity_spec.sh
@@ -167,7 +167,7 @@ Describe 'INTEGRATION: example transform parity'
   It 'transforms example DCIM CSV interface metadata and expanded connections'
     When call example_system_transform_summary
     The status should equal 0
-    The output should include 'counts=racks:2,devices:6,modules:3,cables:6,interfaces:184'
+    The output should include 'counts=racks:2,devices:6,modules:3,cables:4,interfaces:184'
     The output should include 'roles=ComputeNode,ManagementSwitch,HSNSwitch'
     The output should include 'device_gh=hpe-xd670|ComputeNode|34|front|aa:bb:cc:dd:ee:01'
     The output should include 'device_man=hpe-aruba-2930f-48g-4sfp|ManagementSwitch|48|rear'
@@ -175,7 +175,7 @@ Describe 'INTEGRATION: example transform parity'
     The output should include 'hpe-3m-cat6-stp|blue|3|m|iLO|1:1'
     The output should include 'hpe-3m-cat6-stp|blue|3|m|iLO|2:1'
     The output should include 'hpe-ib-ndr-osfp-dac-cable|green|2|m|HSN 0|1:1'
-    The output should include 'hpe-ib-ndr-osfp-dac-cable|green|2|m|HSN 3|4:1'
+    The output should include 'hpe-ib-ndr-osfp-dac-cable|green|2|m|HSN 1|2:1'
   End
 
 End

--- a/testdata/fixtures/example/dcim.csv
+++ b/testdata/fixtures/example/dcim.csv
@@ -32,4 +32,4 @@ interface,,iLO,,,,,,,,GH-x3701u26,,,,,,,,,,,aa:bb:cc:dd:ee:02
 connection,hpe-3m-cat6-stp,,,,,,,,,,,GH-x3701u34,iLO,MAN-x3701u48,1,blue,3,m,,
 connection,hpe-3m-cat6-stp,,,,,,,,,,,GH-x3701u26,iLO,MAN-x3701u48,2,blue,3,m,,
 # Connections — HSN (with brace expansion)
-connection,hpe-ib-ndr-osfp-dac-cable,,,,,,,,,,,GH-x3701u34,HSN {0..3},HSNS-x3701u43,{1..4},green,2,m,,
+connection,hpe-ib-ndr-osfp-dac-cable,,,,,,,,,,,GH-x3701u34,HSN {0..1},HSNS-x3701u43,{1..2},green,2,m,,


### PR DESCRIPTION
Validate cable device, port, and interface references before saving or exporting inventory. Abort invalid imports before persistence and prevent provider mutations when export preflight fails.

Preserve invalid migrated inventories for repair and add regression coverage for direct, incomplete, cross-device, and module-owned endpoints.

closes #234

# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->



# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

