### PR TITLE
feat(schema): gate schema evolution and publish release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,11 +177,43 @@ jobs:
       - name: Upload binary to draft release
         run: gh release upload "${TAG}" cani-*.tar.gz cani-*.tar.gz.sha256 --clobber
 
+  # Attach the inventory schema so consumers can pin a contract to a release
+  # rather than tracking the copy on main.
+  upload_schema:
+    name: Upload inventory schema
+    needs: create_release
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      TAG: ${{ inputs.tag || github.ref_name }}
+      SCHEMA: pkg/devicetypes/schema/inventory.schema.json
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Verify the committed schema matches the tagged source
+        run: |
+          go run ./tools/genschema "${RUNNER_TEMP}/generated.schema.json"
+          cmp "${SCHEMA}" "${RUNNER_TEMP}/generated.schema.json"
+
+      - name: Upload schema to draft release
+        run: |
+          cp "${SCHEMA}" cani-inventory.schema.json
+          sha256sum cani-inventory.schema.json > cani-inventory.schema.json.sha256
+          gh release upload "${TAG}" \
+            cani-inventory.schema.json cani-inventory.schema.json.sha256 --clobber
+
   # Publish the release once all binaries are attached. Single job that owns the
   # draft->published transition and the prerelease/latest designation.
   publish_release:
     name: Publish release
-    needs: [classify, build_binaries]
+    needs: [classify, build_binaries, upload_schema]
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/schema-drift.yml
+++ b/.github/workflows/schema-drift.yml
@@ -1,0 +1,61 @@
+#
+# MIT License
+#
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: Schema Drift Check
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # the compatibility check reads the PR base revision
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: regenerate inventory schema
+        run: make schema
+
+      - name: verify inventory.schema.json is up to date
+        run: |
+          if ! git diff --exit-code -- pkg/devicetypes/schema/inventory.schema.json; then
+            echo "::error::inventory.schema.json is out of date. Run 'make schema' and commit the result."
+            exit 1
+          fi
+
+      # A wire-shape change under an unchanged generation would silently break
+      # every consumer pinned to that generation, so require a bump instead.
+      - name: verify schema evolution is compatible
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git show "${BASE_SHA}:pkg/devicetypes/schema/inventory.schema.json" > "${RUNNER_TEMP}/base.schema.json"
+          go run ./tools/schemadiff --check \
+            "${RUNNER_TEMP}/base.schema.json" \
+            pkg/devicetypes/schema/inventory.schema.json

--- a/Makefile
+++ b/Makefile
@@ -255,6 +255,17 @@ schema: ## Regenerate the inventory JSON Schema artifact
 	go run ./tools/genschema
 	$(OK) "pkg/devicetypes/schema/inventory.schema.json"
 
+SCHEMA_BASE ?= origin/main
+
+.PHONY: schema-check
+schema-check: ## Check schema evolution against SCHEMA_BASE (default: origin/main)
+	$(INFO) "checking inventory schema evolution against $(SCHEMA_BASE)"
+	@base=$$(mktemp); \
+	trap 'rm -f "$$base"' EXIT; \
+	git show $(SCHEMA_BASE):pkg/devicetypes/schema/inventory.schema.json > "$$base" && \
+	go run ./tools/schemadiff --check "$$base" pkg/devicetypes/schema/inventory.schema.json
+	$(OK) "schema evolution is compatible"
+
 .PHONY: nautobot_client
 nautobot_client: ## Regenerate the Nautobot API client
 	$(INFO) "generating Nautobot client"

--- a/pkg/devicetypes/schema/diff.go
+++ b/pkg/devicetypes/schema/diff.go
@@ -1,0 +1,298 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"sort"
+	"strings"
+)
+
+// SemanticDiff summarizes compatibility-relevant changes between two
+// generated inventory schemas.
+type SemanticDiff struct {
+	FromVersion string
+	ToVersion   string
+	ToDigest    string
+	WireChanged bool
+	Breaking    []string
+	Compatible  []string
+}
+
+type propertyContract struct {
+	required    bool
+	constraints string
+}
+
+// Compare reports property and constraint changes without being distracted by
+// JSON object ordering or descriptive metadata.
+func Compare(oldData, newData []byte) (SemanticDiff, error) {
+	oldDoc, err := decodeSchema(oldData)
+	if err != nil {
+		return SemanticDiff{}, fmt.Errorf("decoding old schema: %w", err)
+	}
+	newDoc, err := decodeSchema(newData)
+	if err != nil {
+		return SemanticDiff{}, fmt.Errorf("decoding new schema: %w", err)
+	}
+
+	report := SemanticDiff{
+		FromVersion: schemaGeneration(oldDoc),
+		ToVersion:   schemaGeneration(newDoc),
+		ToDigest:    stringValue(newDoc["x-cani-schema-digest"]),
+	}
+	if report.FromVersion != report.ToVersion {
+		report.Breaking = append(report.Breaking, fmt.Sprintf(
+			"schema generation changed from `%s` to `%s`", report.FromVersion, report.ToVersion))
+	}
+
+	oldProperties := map[string]propertyContract{}
+	newProperties := map[string]propertyContract{}
+	collectProperties(oldDoc, "", oldProperties)
+	collectProperties(newDoc, "", newProperties)
+	report.WireChanged = !maps.Equal(wireProperties(oldProperties), wireProperties(newProperties))
+	compareProperties(&report, oldProperties, newProperties)
+	sort.Strings(report.Breaking)
+	sort.Strings(report.Compatible)
+	return report, nil
+}
+
+// ValidateEvolution rejects wire-shape changes that retain the same schema
+// generation. Generation-only corrections and annotation changes are allowed.
+func ValidateEvolution(oldData, newData []byte) error {
+	report, err := Compare(oldData, newData)
+	if err != nil {
+		return err
+	}
+	if report.WireChanged && report.FromVersion == report.ToVersion {
+		return fmt.Errorf("inventory wire schema changed without a generation bump from %s", report.FromVersion)
+	}
+	return nil
+}
+
+func wireProperties(properties map[string]propertyContract) map[string]propertyContract {
+	wire := make(map[string]propertyContract, len(properties))
+	for path, contract := range properties {
+		if path != "/schemaVersion" {
+			wire[path] = contract
+		}
+	}
+	return wire
+}
+
+// Markdown renders a release-note section from a semantic diff.
+func (d SemanticDiff) Markdown() string {
+	var out strings.Builder
+	out.WriteString("## Inventory schema contract\n\n")
+	fmt.Fprintf(&out, "Generation: `%s` -> `%s`\n\n", d.FromVersion, d.ToVersion)
+	if d.ToDigest != "" {
+		fmt.Fprintf(&out, "Schema digest: `%s`\n\n", d.ToDigest)
+	}
+	out.WriteString("Cani does not preserve unknown JSON fields. Reader-compatible additions are safe for older readers only; older writers must not rewrite newer generations.\n\n")
+	writeChanges(&out, "Migration-required changes", d.Breaking)
+	writeChanges(&out, "Reader-compatible additions", d.Compatible)
+	return out.String()
+}
+
+func decodeSchema(data []byte) (map[string]any, error) {
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, err
+	}
+	return doc, nil
+}
+
+func schemaGeneration(doc map[string]any) string {
+	if version := stringValue(doc["x-cani-schema-version"]); version != "" {
+		return version
+	}
+	properties, _ := doc["properties"].(map[string]any)
+	versionSchema, _ := properties["schemaVersion"].(map[string]any)
+	if version := stringValue(versionSchema["const"]); version != "" {
+		return version
+	}
+	return "unknown"
+}
+
+func collectProperties(node map[string]any, path string, out map[string]propertyContract) {
+	required := requiredNames(node["required"])
+	if properties, ok := node["properties"].(map[string]any); ok {
+		for name, value := range properties {
+			property, ok := value.(map[string]any)
+			if !ok {
+				continue
+			}
+			propertyPath := joinPointer(path, name)
+			out[propertyPath] = propertyContract{
+				required:    required[name],
+				constraints: semanticJSON(property),
+			}
+			collectProperties(property, propertyPath, out)
+		}
+	}
+	collectDefinitions(node, path, out)
+	collectNestedSchema(node, "items", path, out)
+	collectNestedSchema(node, "additionalProperties", path, out)
+}
+
+func collectDefinitions(node map[string]any, path string, out map[string]propertyContract) {
+	definitions, ok := node["$defs"].(map[string]any)
+	if !ok {
+		return
+	}
+	defsPath := joinPointer(path, "$defs")
+	for name, value := range definitions {
+		definition, ok := value.(map[string]any)
+		if ok {
+			collectProperties(definition, joinPointer(defsPath, name), out)
+		}
+	}
+}
+
+func collectNestedSchema(node map[string]any, key, path string, out map[string]propertyContract) {
+	nested, ok := node[key].(map[string]any)
+	if ok {
+		collectProperties(nested, joinPointer(path, key), out)
+	}
+}
+
+func compareProperties(report *SemanticDiff, oldProperties, newProperties map[string]propertyContract) {
+	paths := map[string]bool{}
+	for path := range oldProperties {
+		paths[path] = true
+	}
+	for path := range newProperties {
+		paths[path] = true
+	}
+	for path := range paths {
+		compareProperty(report, path, oldProperties, newProperties)
+	}
+}
+
+func compareProperty(report *SemanticDiff, path string, oldProperties, newProperties map[string]propertyContract) {
+	oldProperty, hadOld := oldProperties[path]
+	newProperty, hasNew := newProperties[path]
+	switch {
+	case !hasNew:
+		report.Breaking = append(report.Breaking, fmt.Sprintf("removed property `%s`", path))
+	case !hadOld && newProperty.required:
+		report.Breaking = append(report.Breaking, fmt.Sprintf("added required property `%s`", path))
+	case !hadOld:
+		report.Compatible = append(report.Compatible, fmt.Sprintf("added optional property `%s`", path))
+	default:
+		compareExistingProperty(report, path, oldProperty, newProperty)
+	}
+}
+
+func compareExistingProperty(report *SemanticDiff, path string, oldProperty, newProperty propertyContract) {
+	if oldProperty.required != newProperty.required {
+		if newProperty.required {
+			report.Breaking = append(report.Breaking, fmt.Sprintf("made property `%s` required", path))
+		} else {
+			report.Compatible = append(report.Compatible, fmt.Sprintf("made property `%s` optional", path))
+		}
+	}
+	if oldProperty.constraints != newProperty.constraints {
+		report.Breaking = append(report.Breaking, fmt.Sprintf(
+			"changed constraints for `%s` from `%s` to `%s`",
+			path, oldProperty.constraints, newProperty.constraints))
+	}
+}
+
+func semanticJSON(value any) string {
+	normalized := semanticValue(value)
+	data, _ := json.Marshal(normalized)
+	return string(data)
+}
+
+func semanticValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := map[string]any{}
+		for key, child := range typed {
+			if !ignoredSemanticKey(key) {
+				out[key] = semanticValue(child)
+			}
+		}
+		return out
+	case []any:
+		out := make([]any, len(typed))
+		for i, child := range typed {
+			out[i] = semanticValue(child)
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func ignoredSemanticKey(key string) bool {
+	switch key {
+	case "$defs", "$id", "$comment", "description", "title", "default",
+		"examples", "properties", "required", "x-cani-schema-digest",
+		"x-cani-schema-version":
+		return true
+	default:
+		return false
+	}
+}
+
+func requiredNames(value any) map[string]bool {
+	out := map[string]bool{}
+	items, _ := value.([]any)
+	for _, item := range items {
+		if name := stringValue(item); name != "" {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+func joinPointer(path, token string) string {
+	token = strings.ReplaceAll(token, "~", "~0")
+	token = strings.ReplaceAll(token, "/", "~1")
+	return path + "/" + token
+}
+
+func stringValue(value any) string {
+	text, _ := value.(string)
+	return text
+}
+
+func writeChanges(out *strings.Builder, heading string, changes []string) {
+	fmt.Fprintf(out, "### %s\n\n", heading)
+	if len(changes) == 0 {
+		out.WriteString("- None.\n\n")
+		return
+	}
+	for _, change := range changes {
+		fmt.Fprintf(out, "- %s.\n", change)
+	}
+	out.WriteString("\n")
+}

--- a/pkg/devicetypes/schema/diff_test.go
+++ b/pkg/devicetypes/schema/diff_test.go
@@ -1,0 +1,194 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+package schema
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// TestCompareClassifiesCompatibility verifies semantic changes are grouped by
+// their effect on readers and migration requirements.
+//
+// Why it matters: release notes must distinguish optional additions from data
+// loss risks instead of presenting consumers with an undifferentiated JSON diff.
+// Inputs: compact v1alpha3 and v1alpha4 schemas with added, removed, required,
+// and type-changed properties. Outputs: deterministic breaking and compatible lists.
+// Data choice: one property per classification makes a missing or inverted rule
+// visible without relying on the much larger generated inventory schema.
+func TestCompareClassifiesCompatibility(t *testing.T) {
+	oldSchema := []byte(`{
+		"x-cani-schema-version":"v1alpha3",
+		"properties":{
+			"changed":{"type":"string"},
+			"removed":{"type":"boolean"},
+			"stable":{"type":"string","description":"old text"}
+		}
+	}`)
+	newSchema := []byte(`{
+		"x-cani-schema-version":"v1alpha4",
+		"x-cani-schema-digest":"sha256:abc",
+		"required":["requiredNew"],
+		"properties":{
+			"added":{"type":"number"},
+			"changed":{"type":"integer"},
+			"requiredNew":{"type":"string"},
+			"stable":{"type":"string","description":"new text"}
+		}
+	}`)
+
+	report, err := Compare(oldSchema, newSchema)
+	if err != nil {
+		t.Fatalf("Compare() returned unexpected error: %v", err)
+	}
+
+	wantBreaking := []string{
+		"added required property `/requiredNew`",
+		"changed constraints for `/changed` from `{\"type\":\"string\"}` to `{\"type\":\"integer\"}`",
+		"removed property `/removed`",
+		"schema generation changed from `v1alpha3` to `v1alpha4`",
+	}
+	if !slices.Equal(report.Breaking, wantBreaking) {
+		t.Errorf("Breaking = %#v, want %#v", report.Breaking, wantBreaking)
+	}
+	wantCompatible := []string{"added optional property `/added`"}
+	if !slices.Equal(report.Compatible, wantCompatible) {
+		t.Errorf("Compatible = %#v, want %#v", report.Compatible, wantCompatible)
+	}
+	if report.ToDigest != "sha256:abc" {
+		t.Errorf("ToDigest = %q, want sha256:abc", report.ToDigest)
+	}
+	if !report.WireChanged {
+		t.Error("WireChanged = false, want true")
+	}
+}
+
+// TestValidateEvolutionRequiresGenerationBump verifies a serialized shape
+// change cannot retain the same generation.
+//
+// Why it matters: regenerating the golden schema alone must not permit another
+// release to silently change the writer contract under an existing label.
+// Inputs: two v1alpha4 schemas where the latter adds one optional property.
+// Outputs: an error directing the contributor to bump the generation.
+// Data choice: an optional addition is accepted by older readers but dropped by
+// older writers, making it the least obvious change that still needs a bump.
+func TestValidateEvolutionRequiresGenerationBump(t *testing.T) {
+	oldSchema := []byte(`{"x-cani-schema-version":"v1alpha4","properties":{"stable":{"type":"string"}}}`)
+	newSchema := []byte(`{"x-cani-schema-version":"v1alpha4","properties":{"stable":{"type":"string"},"added":{"type":"string"}}}`)
+
+	err := ValidateEvolution(oldSchema, newSchema)
+
+	if err == nil || !strings.Contains(err.Error(), "without a generation bump") {
+		t.Fatalf("ValidateEvolution() error = %v, want generation-bump context", err)
+	}
+}
+
+// TestValidateEvolutionAllowsGenerationAndAnnotationChanges verifies valid
+// evolution and documentation-only edits pass the gate.
+//
+// Why it matters: enforcement must prevent contract drift without blocking a
+// deliberate generation change or harmless schema documentation maintenance.
+// Inputs: a generation change with an added field and a same-generation title
+// change. Outputs: nil for both comparisons.
+// Data choice: the two cases distinguish wire contract identity from generated
+// artifact byte identity.
+func TestValidateEvolutionAllowsGenerationAndAnnotationChanges(t *testing.T) {
+	cases := []struct {
+		name string
+		old  []byte
+		new  []byte
+	}{
+		{
+			name: "generation bump",
+			old:  []byte(`{"x-cani-schema-version":"v1alpha3","properties":{"stable":{"type":"string"}}}`),
+			new:  []byte(`{"x-cani-schema-version":"v1alpha4","properties":{"stable":{"type":"string"},"added":{"type":"string"}}}`),
+		},
+		{
+			name: "annotation only",
+			old:  []byte(`{"x-cani-schema-version":"v1alpha4","title":"old","properties":{"stable":{"type":"string"}}}`),
+			new:  []byte(`{"x-cani-schema-version":"v1alpha4","title":"new","properties":{"stable":{"type":"string"}}}`),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateEvolution(tc.old, tc.new); err != nil {
+				t.Fatalf("ValidateEvolution() error = %v", err)
+			}
+		})
+	}
+}
+
+// TestSemanticDiffMarkdownDocumentsWriterRisk verifies release-note rendering
+// includes the compatibility warning and both change categories.
+//
+// Why it matters: an optional field is not forward-compatible when an older
+// writer drops unknown data, so the generated notes must not overstate safety.
+// Inputs: a report with one breaking and one compatible change. Outputs: Markdown
+// containing the generation, digest, warning, headings, and both entries.
+// Data choice: short sentinel descriptions keep the assertion focused on report
+// structure rather than the property comparison algorithm covered separately.
+func TestSemanticDiffMarkdownDocumentsWriterRisk(t *testing.T) {
+	report := SemanticDiff{
+		FromVersion: "v1alpha3",
+		ToVersion:   "v1alpha4",
+		ToDigest:    "sha256:abc",
+		Breaking:    []string{"breaking sentinel"},
+		Compatible:  []string{"compatible sentinel"},
+	}
+
+	markdown := report.Markdown()
+	for _, want := range []string{
+		"Generation: `v1alpha3` -> `v1alpha4`",
+		"Schema digest: `sha256:abc`",
+		"older writers must not rewrite newer generations",
+		"### Migration-required changes",
+		"- breaking sentinel.",
+		"### Reader-compatible additions",
+		"- compatible sentinel.",
+	} {
+		if !strings.Contains(markdown, want) {
+			t.Errorf("Markdown() missing %q:\n%s", want, markdown)
+		}
+	}
+}
+
+// TestCompareRejectsInvalidSchema verifies malformed input is reported with
+// which side of the comparison failed.
+//
+// Why it matters: release automation must fail visibly instead of publishing an
+// empty or misleading compatibility report when a schema artifact is corrupt.
+// Inputs: malformed old JSON and a valid empty new schema. Outputs: an error with
+// old-schema decoding context.
+// Data choice: the malformed opening brace reaches JSON decoding immediately and
+// isolates error attribution from semantic comparison.
+func TestCompareRejectsInvalidSchema(t *testing.T) {
+	_, err := Compare([]byte(`{"broken"`), []byte(`{}`))
+	if err == nil || !strings.Contains(err.Error(), "decoding old schema") {
+		t.Fatalf("Compare() error = %v, want old schema decoding context", err)
+	}
+}

--- a/tools/schemadiff/main.go
+++ b/tools/schemadiff/main.go
@@ -1,0 +1,71 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Cray-HPE/cani/pkg/devicetypes/schema"
+)
+
+func main() {
+	args := os.Args[1:]
+	check := false
+	if len(args) > 0 && args[0] == "--check" {
+		check = true
+		args = args[1:]
+	}
+	if len(args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s [--check] OLD_SCHEMA NEW_SCHEMA\n", os.Args[0])
+		os.Exit(2)
+	}
+
+	oldData, err := os.ReadFile(args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reading old schema: %v\n", err)
+		os.Exit(1)
+	}
+	newData, err := os.ReadFile(args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reading new schema: %v\n", err)
+		os.Exit(1)
+	}
+
+	report, err := schema.Compare(oldData, newData)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "comparing schemas: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Print(report.Markdown())
+	if check {
+		if err := schema.ValidateEvolution(oldData, newData); err != nil {
+			fmt.Fprintf(os.Stderr, "invalid schema evolution: %v\n", err)
+			os.Exit(1)
+		}
+	}
+}


### PR DESCRIPTION
The committed inventory schema could not drift from the Go structs (the golden test already covered that), but its generation stamp could still lie: removing or retyping a field and running `make schema` left CI green under an unchanged v1alpha5. Consumers pinned to a generation had no way to detect the break.

Add a semantic diff that fingerprints each property by JSON pointer, ignores annotation-only keys (description, title, examples, default), and classifies changes as migration-required or reader-compatible. ValidateEvolution rejects a wire-shape change that keeps the same generation, so a bump becomes mandatory.

Wire it up three ways:
- tools/schemadiff for local and CI use
- schema-drift.yml regenerates the artifact and, on pull requests, compares against the base revision
- release.yml attaches the schema and its checksum to each release so consumers can pin a contract instead of tracking main

The diff engine and tool are taken from the fix-schema-problems branch; the datastore migration machinery on that branch is left out of scope.
