### PR TITLE
FORGE-214 feat: LAG support, VRF device assignments, standalone interface creation

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -74,6 +74,7 @@ to a specific type; subcommands reject slugs that do not match their type.`,
 	cmd.AddCommand(newVRFCommand())
 	cmd.AddCommand(newPrefixCommand())
 	cmd.AddCommand(newIPCommand())
+	cmd.AddCommand(newInterfaceCommand())
 
 	cmd.PersistentFlags().BoolP("auto", "a", false, "Automatically recommend values for parent hardware")
 	cmd.PersistentFlags().BoolP("accept", "y", false, "Automatically accept recommended values.")

--- a/cmd/add/interface.go
+++ b/cmd/add/interface.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023-2026 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/cmd/add/interface.go
+++ b/cmd/add/interface.go
@@ -81,7 +81,7 @@ func addInterface(cmd *cli.Command, args []string) error {
 	}
 
 	ifaceType, _ := cmd.Flags().GetString("type")
-	if !isValidInterfaceType(ifaceType) {
+	if !devicetypes.IsValidInterfaceType(ifaceType) {
 		return fmt.Errorf("unknown interface type %q", ifaceType)
 	}
 
@@ -188,23 +188,4 @@ func parseTaggedVLANs(strs []string) ([]int, error) {
 		vids = append(vids, vid)
 	}
 	return vids, nil
-}
-
-var validInterfaceTypes = map[string]bool{
-	"1000base-t":        true,
-	"1000base-kx":       true,
-	"10gbase-t":         true,
-	"10gbase-x-sfpp":    true,
-	"25gbase-x-sfp28":   true,
-	"40gbase-x-qsfpp":   true,
-	"100gbase-x-qsfp28": true,
-	"200gbase-x-qsfp56": true,
-	"400gbase-x-qsfpdd": true,
-	"400gbase-x-osfp":   true,
-	"virtual":           true,
-	"lag":               true,
-}
-
-func isValidInterfaceType(t string) bool {
-	return validInterfaceTypes[t]
 }

--- a/cmd/add/interface.go
+++ b/cmd/add/interface.go
@@ -1,0 +1,210 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2023-2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package add
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/Cray-HPE/cani/internal/cli"
+	"github.com/Cray-HPE/cani/internal/util/resolve"
+	"github.com/Cray-HPE/cani/internal/util/store"
+	"github.com/Cray-HPE/cani/pkg/datastores"
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	"github.com/google/uuid"
+)
+
+func newInterfaceCommand() *cli.Command {
+	cmd := &cli.Command{
+		Use:   "interface <name>",
+		Short: "Add an interface to a device.",
+		Long: `Add a standalone interface (e.g. a LAG) to an existing device.
+
+Use this to create interfaces that are not part of a device-type template,
+such as LAG interfaces used to aggregate physical members.
+
+After creating a LAG, assign members with:
+  cani update interface --device <device> --name <member> --lag <lag-name>
+
+Examples:
+  cani alpha add interface lag256 --device switch-01 --type lag
+  cani alpha add interface lag256 --device switch-01 --type lag --mode tagged --tagged-vlan 100,200
+  cani alpha add interface lag256 --device switch-01 --type lag --mode access --untagged-vlan 10`,
+		Args: cli.ExactArgs(1),
+		RunE: addInterface,
+	}
+
+	cmd.Flags().String("device", "", "Device name or UUID (required)")
+	cmd.Flags().String("type", "lag", "Interface type (e.g. lag, virtual, 1000base-t)")
+	cmd.Flags().String("role", "", "Interface role")
+	cmd.Flags().String("label", "", "Interface label")
+	cmd.Flags().String("mac", "", "MAC address (e.g. aa:bb:cc:dd:ee:ff)")
+	cmd.Flags().String("mode", "", "802.1Q mode: access, tagged, or tagged-all")
+	cmd.Flags().Int("untagged-vlan", 0, "Untagged (native) VLAN ID")
+	cmd.Flags().StringSlice("tagged-vlan", nil, "Tagged VLAN IDs (comma-separated or repeatable)")
+	cmd.Flags().String("vrf", "", "VRF name")
+
+	return cmd
+}
+
+func addInterface(cmd *cli.Command, args []string) error {
+	name := args[0]
+
+	deviceRef, _ := cmd.Flags().GetString("device")
+	if deviceRef == "" {
+		return fmt.Errorf("--device is required")
+	}
+
+	ifaceType, _ := cmd.Flags().GetString("type")
+	if !isValidInterfaceType(ifaceType) {
+		return fmt.Errorf("unknown interface type %q", ifaceType)
+	}
+
+	if err := store.Setup(cmd); err != nil {
+		return fmt.Errorf("failed to set device store: %w", err)
+	}
+
+	inventory, err := datastores.Datastore.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load inventory: %w", err)
+	}
+
+	deviceID, err := resolve.Device(inventory, deviceRef)
+	if err != nil {
+		return fmt.Errorf("resolving --device: %w", err)
+	}
+
+	iface := &devicetypes.CaniInterface{
+		ID:            uuid.New(),
+		Name:          name,
+		InterfaceType: devicetypes.InterfacesElemType(ifaceType),
+		DeviceID:      deviceID,
+		ContentType:   "dcim.interface",
+	}
+
+	if cmd.Flags().Changed("role") {
+		iface.Role, _ = cmd.Flags().GetString("role")
+	}
+	if cmd.Flags().Changed("label") {
+		iface.Label, _ = cmd.Flags().GetString("label")
+	}
+	if cmd.Flags().Changed("mac") {
+		mac, _ := cmd.Flags().GetString("mac")
+		normalized, merr := devicetypes.NormalizeMAC(mac)
+		if merr != nil {
+			return merr
+		}
+		iface.MacAddress = normalized
+	}
+	if cmd.Flags().Changed("mode") {
+		mode, _ := cmd.Flags().GetString("mode")
+		normalized, merr := devicetypes.ValidateInterfaceMode(mode)
+		if merr != nil {
+			return merr
+		}
+		iface.Mode = normalized
+	}
+	if cmd.Flags().Changed("untagged-vlan") {
+		vid, _ := cmd.Flags().GetInt("untagged-vlan")
+		if err := devicetypes.ValidateVID(vid); err != nil {
+			return err
+		}
+		iface.UntaggedVLAN = vid
+	}
+	if cmd.Flags().Changed("tagged-vlan") {
+		taggedStrs, _ := cmd.Flags().GetStringSlice("tagged-vlan")
+		vids, verr := parseTaggedVLANs(taggedStrs)
+		if verr != nil {
+			return verr
+		}
+		iface.TaggedVLANs = vids
+	}
+	if cmd.Flags().Changed("vrf") {
+		iface.VRF, _ = cmd.Flags().GetString("vrf")
+	}
+	if cmd.Flags().Changed("status") {
+		iface.Status, _ = cmd.Flags().GetString("status")
+	}
+	tags, _ := cmd.Flags().GetStringArray("tag")
+	if len(tags) > 0 {
+		iface.Tags = tags
+	}
+	if meta := collectProviderMetadata(cmd); len(meta) > 0 {
+		applyProviderMetadataMap(&iface.ProviderMetadata, meta)
+	}
+
+	if err := inventory.AddInterface(iface); err != nil {
+		return fmt.Errorf("failed to add interface: %w", err)
+	}
+
+	if err := datastores.Datastore.Save(inventory); err != nil {
+		return fmt.Errorf("failed to save inventory: %w", err)
+	}
+
+	log.Printf("Added interface %q (type=%s) on device %s (%s)", iface.Name, ifaceType, deviceRef, iface.ID)
+	return nil
+}
+
+// parseTaggedVLANs converts comma-separated or repeated VLAN ID strings to ints.
+func parseTaggedVLANs(strs []string) ([]int, error) {
+	var vids []int
+	for _, s := range strs {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		vid, err := strconv.Atoi(s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid tagged VLAN %q: must be an integer", s)
+		}
+		if err := devicetypes.ValidateVID(vid); err != nil {
+			return nil, err
+		}
+		vids = append(vids, vid)
+	}
+	return vids, nil
+}
+
+var validInterfaceTypes = map[string]bool{
+	"1000base-t":        true,
+	"1000base-kx":       true,
+	"10gbase-t":         true,
+	"10gbase-x-sfpp":    true,
+	"25gbase-x-sfp28":   true,
+	"40gbase-x-qsfpp":   true,
+	"100gbase-x-qsfp28": true,
+	"200gbase-x-qsfp56": true,
+	"400gbase-x-qsfpdd": true,
+	"400gbase-x-osfp":   true,
+	"virtual":           true,
+	"lag":               true,
+}
+
+func isValidInterfaceType(t string) bool {
+	return validInterfaceTypes[t]
+}

--- a/cmd/add/vrf.go
+++ b/cmd/add/vrf.go
@@ -78,7 +78,25 @@ func addVRF(cmd *cli.Command, args []string) error {
 		ID:   uuid.New(),
 		Name: name,
 	}
+	applyVRFFlags(cmd, vrf)
 
+	if err := resolveVRFDevices(cmd, inventory, vrf); err != nil {
+		return err
+	}
+
+	if err := inventory.AddVRF(vrf); err != nil {
+		return fmt.Errorf("failed to add vrf: %w", err)
+	}
+
+	if err := datastores.Datastore.Save(inventory); err != nil {
+		return fmt.Errorf("failed to save inventory: %w", err)
+	}
+
+	log.Printf("Added VRF %q (%s)", vrf.Name, vrf.ID)
+	return nil
+}
+
+func applyVRFFlags(cmd *cli.Command, vrf *devicetypes.CaniVRF) {
 	if cmd.Flags().Changed("rd") {
 		vrf.RD, _ = cmd.Flags().GetString("rd")
 	}
@@ -95,7 +113,9 @@ func addVRF(cmd *cli.Command, args []string) error {
 	if len(tags) > 0 {
 		vrf.Tags = tags
 	}
+}
 
+func resolveVRFDevices(cmd *cli.Command, inventory *devicetypes.Inventory, vrf *devicetypes.CaniVRF) error {
 	deviceRefs, _ := cmd.Flags().GetStringArray("device")
 	for _, ref := range deviceRefs {
 		id, err := resolve.Device(inventory, ref)
@@ -104,15 +124,5 @@ func addVRF(cmd *cli.Command, args []string) error {
 		}
 		vrf.Devices = append(vrf.Devices, id)
 	}
-
-	if err := inventory.AddVRF(vrf); err != nil {
-		return fmt.Errorf("failed to add vrf: %w", err)
-	}
-
-	if err := datastores.Datastore.Save(inventory); err != nil {
-		return fmt.Errorf("failed to save inventory: %w", err)
-	}
-
-	log.Printf("Added VRF %q (%s)", vrf.Name, vrf.ID)
 	return nil
 }

--- a/cmd/show/ipam.go
+++ b/cmd/show/ipam.go
@@ -33,6 +33,41 @@ import (
 	"github.com/Cray-HPE/cani/pkg/visual"
 )
 
+// newVRFShowCommand creates the "show vrf" subcommand.
+func newVRFShowCommand() *cli.Command {
+	return &cli.Command{
+		Use:     "vrf",
+		Aliases: []string{"vrfs"},
+		Short:   "List VRFs in the inventory.",
+		Args:    cli.NoArgs,
+		RunE:    showVRFs,
+	}
+}
+
+func showVRFs(cmd *cli.Command, args []string) error {
+	inv, err := loadInventory(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	vrfs := make([]*devicetypes.CaniVRF, 0, len(inv.VRFs))
+	for _, v := range inv.VRFs {
+		vrfs = append(vrfs, v)
+	}
+	sort.Slice(vrfs, func(i, j int) bool {
+		return vrfs[i].Name < vrfs[j].Name
+	})
+
+	format, _ := cmd.Flags().GetString("format")
+	switch format {
+	case "table":
+		visual.PrintVRFTable(vrfs, inv)
+		return nil
+	default:
+		return marshalAndPrint(vrfs)
+	}
+}
+
 // newVLANShowCommand creates the "show vlan" subcommand.
 func newVLANShowCommand() *cli.Command {
 	return &cli.Command{

--- a/cmd/show/show.go
+++ b/cmd/show/show.go
@@ -98,6 +98,7 @@ func NewCommand() *cli.Command {
 	cmd.AddCommand(newVLANShowCommand())
 	cmd.AddCommand(newPrefixShowCommand())
 	cmd.AddCommand(newIPShowCommand())
+	cmd.AddCommand(newVRFShowCommand())
 
 	return cmd
 }

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -49,6 +49,7 @@ func NewCommand() *cli.Command {
 	cmd.AddCommand(newCableCommand())
 	cmd.AddCommand(newInterfaceCommand())
 	cmd.AddCommand(newOrphansCommand())
+	cmd.AddCommand(newVRFCommand())
 
 	cmd.PersistentFlags().StringArray("set", nil, "Set field value as key=value (repeatable)")
 	cmd.PersistentFlags().StringArray("tag", nil, "Tag(s) to apply to the item (repeatable)")

--- a/cmd/update/vrf.go
+++ b/cmd/update/vrf.go
@@ -23,7 +23,7 @@
  *  OTHER DEALINGS IN THE SOFTWARE.
  *
  */
-package add
+package update
 
 import (
 	"fmt"
@@ -33,37 +33,34 @@ import (
 	"github.com/Cray-HPE/cani/internal/util/resolve"
 	"github.com/Cray-HPE/cani/internal/util/store"
 	"github.com/Cray-HPE/cani/pkg/datastores"
-	"github.com/Cray-HPE/cani/pkg/devicetypes"
 	"github.com/google/uuid"
 )
 
-// newVRFCommand creates the "add vrf" subcommand.
+// newVRFCommand creates the "update vrf" subcommand.
 func newVRFCommand() *cli.Command {
 	cmd := &cli.Command{
-		Use:   "vrf <name>",
-		Short: "Add a VRF to the inventory.",
-		Long: `Add a VRF (virtual routing and forwarding instance) to the inventory.
+		Use:   "vrf <name-or-uuid>",
+		Short: "Update a VRF in the inventory.",
+		Long: `Update a VRF's fields or add devices to it.
 
 Examples:
-  cani alpha add vrf LEGACY --rd 65000:2000 --description "Legacy CSM CMN routing"
-  cani alpha add vrf keepalive --description "VSX keepalive" --device sw-leaf-01 --device sw-spine-01`,
+  cani alpha update vrf keepalive --add-device sw-spine-02
+  cani alpha update vrf LEGACY --description "Updated description"
+  cani alpha update vrf keepalive --remove-device sw-leaf-01`,
 		Args: cli.ExactArgs(1),
-		RunE: addVRF,
+		RunE: updateVRF,
 	}
 
-	cmd.Flags().String("rd", "", "Route distinguisher (RFC 4364, e.g. 65000:100)")
-	cmd.Flags().String("namespace", "", "IPAM namespace (defaults to Global)")
-	cmd.Flags().String(flagDescription, "", "VRF description")
-	cmd.Flags().StringArray("device", nil, "Device name or UUID to assign this VRF to (repeatable)")
+	cmd.Flags().String("description", "", "New description")
+	cmd.Flags().String("rd", "", "Route distinguisher")
+	cmd.Flags().StringArray("add-device", nil, "Add a device to this VRF (name or UUID, repeatable)")
+	cmd.Flags().StringArray("remove-device", nil, "Remove a device from this VRF (name or UUID, repeatable)")
 
 	return cmd
 }
 
-func addVRF(cmd *cli.Command, args []string) error {
-	name := args[0]
-	if name == "" {
-		return fmt.Errorf("VRF name is required")
-	}
+func updateVRF(cmd *cli.Command, args []string) error {
+	ref := args[0]
 
 	if err := store.Setup(cmd); err != nil {
 		return fmt.Errorf("failed to set device store: %w", err)
@@ -74,45 +71,72 @@ func addVRF(cmd *cli.Command, args []string) error {
 		return fmt.Errorf("failed to load inventory: %w", err)
 	}
 
-	vrf := &devicetypes.CaniVRF{
-		ID:   uuid.New(),
-		Name: name,
+	vrf, err := inventory.FindVRFByNameOrID(ref)
+	if err != nil {
+		return err
 	}
 
+	changed := false
+
+	if cmd.Flags().Changed("description") {
+		vrf.Description, _ = cmd.Flags().GetString("description")
+		changed = true
+	}
 	if cmd.Flags().Changed("rd") {
 		vrf.RD, _ = cmd.Flags().GetString("rd")
-	}
-	if cmd.Flags().Changed("namespace") {
-		vrf.Namespace, _ = cmd.Flags().GetString("namespace")
-	}
-	if cmd.Flags().Changed(flagDescription) {
-		vrf.Description, _ = cmd.Flags().GetString(flagDescription)
-	}
-	if cmd.Flags().Changed("status") {
-		vrf.Status, _ = cmd.Flags().GetString("status")
-	}
-	tags, _ := cmd.Flags().GetStringArray("tag")
-	if len(tags) > 0 {
-		vrf.Tags = tags
+		changed = true
 	}
 
-	deviceRefs, _ := cmd.Flags().GetStringArray("device")
-	for _, ref := range deviceRefs {
+	addDevices, _ := cmd.Flags().GetStringArray("add-device")
+	for _, ref := range addDevices {
 		id, err := resolve.Device(inventory, ref)
 		if err != nil {
-			return fmt.Errorf("resolving --device %q: %w", ref, err)
+			return fmt.Errorf("resolving --add-device %q: %w", ref, err)
 		}
-		vrf.Devices = append(vrf.Devices, id)
+		if !containsUUID(vrf.Devices, id) {
+			vrf.Devices = append(vrf.Devices, id)
+			changed = true
+		}
 	}
 
-	if err := inventory.AddVRF(vrf); err != nil {
-		return fmt.Errorf("failed to add vrf: %w", err)
+	removeDevices, _ := cmd.Flags().GetStringArray("remove-device")
+	for _, ref := range removeDevices {
+		id, err := resolve.Device(inventory, ref)
+		if err != nil {
+			return fmt.Errorf("resolving --remove-device %q: %w", ref, err)
+		}
+		if removed := removeUUID(&vrf.Devices, id); removed {
+			changed = true
+		}
+	}
+
+	if !changed {
+		return fmt.Errorf("no changes specified")
 	}
 
 	if err := datastores.Datastore.Save(inventory); err != nil {
 		return fmt.Errorf("failed to save inventory: %w", err)
 	}
 
-	log.Printf("Added VRF %q (%s)", vrf.Name, vrf.ID)
+	log.Printf("Updated VRF %q (%s)", vrf.Name, vrf.ID)
 	return nil
+}
+
+func containsUUID(slice []uuid.UUID, id uuid.UUID) bool {
+	for _, v := range slice {
+		if v == id {
+			return true
+		}
+	}
+	return false
+}
+
+func removeUUID(slice *[]uuid.UUID, id uuid.UUID) bool {
+	for i, v := range *slice {
+		if v == id {
+			*slice = append((*slice)[:i], (*slice)[i+1:]...)
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/datastores/json.go
+++ b/pkg/datastores/json.go
@@ -85,7 +85,8 @@ func (s *JSONStore) Load() (*devicetypes.Inventory, error) {
 		}
 		return s.loadLegacy(data)
 	case devicetypes.SchemaVersionV1Alpha2, devicetypes.SchemaVersionV1Alpha3,
-		devicetypes.SchemaVersionV1Alpha4, devicetypes.CurrentSchemaVersion:
+		devicetypes.SchemaVersionV1Alpha4, devicetypes.SchemaVersionV1Alpha5,
+		devicetypes.CurrentSchemaVersion:
 		return s.loadCurrent(data, schemaVersion)
 	default:
 		return nil, fmt.Errorf("%w %q: this cani release supports %q through %q and will not rewrite the file",
@@ -135,6 +136,7 @@ func (s *JSONStore) loadLegacy(data []byte) (*devicetypes.Inventory, error) {
 	migrateV1Alpha2(data, inventory)
 	migrateV1Alpha3(inventory)
 	migrateV1Alpha4(inventory)
+	migrateV1Alpha5(inventory)
 	relationships := inventory.RebuildDerivedState()
 	if err := relationships.Err(); err != nil {
 		log.Printf("Skipped saving migrated datastore with relationship errors: %v", err)
@@ -201,6 +203,9 @@ func migrateSchemaToCurrent(data []byte, inventory *devicetypes.Inventory) {
 	}
 	if inventory.SchemaVersion == devicetypes.SchemaVersionV1Alpha4 {
 		migrateV1Alpha4(inventory)
+	}
+	if inventory.SchemaVersion == devicetypes.SchemaVersionV1Alpha5 {
+		migrateV1Alpha5(inventory)
 	}
 }
 

--- a/pkg/datastores/json_test.go
+++ b/pkg/datastores/json_test.go
@@ -472,12 +472,12 @@ func TestLoadSkipsMigrationSaveForInvalidRelationships(t *testing.T) {
 // and later saving a newer document could silently destroy data.
 // Inputs: a v1alpha6 document with an unknown top-level field. Outputs: the
 // unsupported-version sentinel and byte-for-byte unchanged source data.
-// Data choice: v1alpha6 is the next generation after the current v1alpha5, and
+// Data choice: v1alpha7 is the next generation after the current v1alpha6, and
 // the unknown object makes any accidental rewrite visible.
 func TestLoadRejectsFutureSchemaWithoutRewrite(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "inventory.json")
-	original := []byte(`{"schemaVersion":"v1alpha6","future":{"keep":true}}`)
+	original := []byte(`{"schemaVersion":"v1alpha7","future":{"keep":true}}`)
 	if err := os.WriteFile(path, original, 0600); err != nil {
 		t.Fatalf("writing future inventory: %v", err)
 	}
@@ -542,7 +542,7 @@ func TestSaveHappyPath(t *testing.T) {
 // Why it matters: callers may pass an inventory obtained outside JSONStore;
 // the persistence boundary must still prevent an older writer from replacing a
 // newer document with a lossy projection.
-// Inputs: an existing file and an Inventory stamped v1alpha6. Outputs: the
+// Inputs: an existing file and an Inventory stamped v1alpha7. Outputs: the
 // unsupported-version sentinel and unchanged existing bytes.
 // Data choice: a pre-existing marker proves rejection happens before directory
 // creation, marshaling, temporary-file creation, or rename.
@@ -555,7 +555,7 @@ func TestSaveRejectsFutureSchemaWithoutRewrite(t *testing.T) {
 	}
 
 	inventory := devicetypes.NewInventory()
-	inventory.SchemaVersion = "v1alpha6"
+	inventory.SchemaVersion = "v1alpha7"
 	store := &JSONStore{Path: path}
 	if err := store.Save(inventory); !errors.Is(err, ErrUnsupportedSchemaVersion) {
 		t.Fatalf("Save() error = %v, want ErrUnsupportedSchemaVersion", err)

--- a/pkg/datastores/migrate_v1alpha5.go
+++ b/pkg/datastores/migrate_v1alpha5.go
@@ -1,0 +1,34 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package datastores
+
+import "github.com/Cray-HPE/cani/pkg/devicetypes"
+
+// migrateV1Alpha5 upgrades a v1alpha5 inventory to v1alpha6 in place.
+// v1alpha6 adds CaniVRF.Devices (VRF-device assignments).
+func migrateV1Alpha5(inv *devicetypes.Inventory) {
+	inv.SchemaVersion = devicetypes.SchemaVersionV1Alpha6
+}

--- a/pkg/devicetypes/NAUTOBOT_MAPPING.md
+++ b/pkg/devicetypes/NAUTOBOT_MAPPING.md
@@ -340,6 +340,7 @@ Imported by `FetchVRFs()` + `MapVRFs()`; exported in Phase 6c by `loadVRFs()` in
 | `RD` | `string` | `VRF.rd` | **Mapped** | Route distinguisher (RFC 4364); mapped when non-empty |
 | `Namespace` | `string` | `VRF.namespace` (FK) | Partial | Get-or-create on export (defaults to `Global`); not resolved on import |
 | `Description` | `string` | `VRF.description` | **Mapped** | Mapped when non-empty |
+| `Devices` | `[]uuid.UUID` | `VRFDeviceAssignment` (M2M) | **Mapped** | Exported via `ensureVRFDeviceAssignment()` in `load_vrfs.go`; not imported |
 | `Status` | `string` | `VRF.status` (FK) | **Mapped** | Resolved by name |
 | `Tags` | `[]string` | `VRF.tags` | **Mapped** | Exported via the shared tag resolver |
 | `CustomFields` | `map[string]any` | `VRF.custom_fields` | Partial | Imported; not sent on export |
@@ -560,7 +561,7 @@ Iterates `inventory.Cables`. For each cable:
 
 ### Phase 6c: VRFs
 
-Implemented in `loadVRFs()` in `load_vrfs.go`. Iterates `inventory.VRFs`. Find-or-create by name; creates the namespace (default `Global`) and resolves status/tags. VRFs are created **before** interface enrichment so interface `VRF` references resolve.
+Implemented in `loadVRFs()` in `load_vrfs.go`. Iterates `inventory.VRFs`. Find-or-create by name; creates the namespace (default `Global`) and resolves status/tags. After creating/skipping the VRF, iterates `vrf.Devices` and calls `ensureVRFDeviceAssignment()` to create `VRFDeviceAssignment` links (find-or-create). VRFs are created **before** interface enrichment so interface `VRF` references resolve.
 
 ### Phase 7: VLANs
 

--- a/pkg/devicetypes/NAUTOBOT_MAPPING.md
+++ b/pkg/devicetypes/NAUTOBOT_MAPPING.md
@@ -340,7 +340,7 @@ Imported by `FetchVRFs()` + `MapVRFs()`; exported in Phase 6c by `loadVRFs()` in
 | `RD` | `string` | `VRF.rd` | **Mapped** | Route distinguisher (RFC 4364); mapped when non-empty |
 | `Namespace` | `string` | `VRF.namespace` (FK) | Partial | Get-or-create on export (defaults to `Global`); not resolved on import |
 | `Description` | `string` | `VRF.description` | **Mapped** | Mapped when non-empty |
-| `Devices` | `[]uuid.UUID` | `VRFDeviceAssignment` (M2M) | **Mapped** | Exported via `ensureVRFDeviceAssignment()` in `load_vrfs.go`; not imported |
+| `Devices` | `[]uuid.UUID` | `VRFDeviceAssignment` (M2M) | Partial | Exported via `ensureVRFDeviceAssignment()` in `load_vrfs.go`; not imported |
 | `Status` | `string` | `VRF.status` (FK) | **Mapped** | Resolved by name |
 | `Tags` | `[]string` | `VRF.tags` | **Mapped** | Exported via the shared tag resolver |
 | `CustomFields` | `map[string]any` | `VRF.custom_fields` | Partial | Imported; not sent on export |

--- a/pkg/devicetypes/component_specs.go
+++ b/pkg/devicetypes/component_specs.go
@@ -137,3 +137,23 @@ const (
 	InterfacesElemTypeVirtual          InterfacesElemType = "virtual"
 	InterfacesElemTypeLag              InterfacesElemType = "lag"
 )
+
+var validInterfaceTypes = map[InterfacesElemType]bool{
+	InterfacesElemTypeA1000BaseT:       true,
+	InterfacesElemTypeA1000BaseKx:      true,
+	InterfacesElemTypeA10GbaseT:        true,
+	InterfacesElemTypeA10GbaseXSfpp:    true,
+	InterfacesElemTypeA25GbaseXSfp28:   true,
+	InterfacesElemTypeA40GbaseXQsfpp:   true,
+	InterfacesElemTypeA100GbaseXQsfp28: true,
+	InterfacesElemTypeA200GbaseXQsfp56: true,
+	InterfacesElemTypeA400GbaseXQsfpdd: true,
+	InterfacesElemTypeA400GbaseXOsfp:   true,
+	InterfacesElemTypeVirtual:          true,
+	InterfacesElemTypeLag:              true,
+}
+
+// IsValidInterfaceType reports whether t is a recognized interface type.
+func IsValidInterfaceType(t string) bool {
+	return validInterfaceTypes[InterfacesElemType(t)]
+}

--- a/pkg/devicetypes/component_specs.go
+++ b/pkg/devicetypes/component_specs.go
@@ -5,20 +5,22 @@ import "github.com/google/uuid"
 // InterfaceSpec defines an interface template in a device/module type.
 // When used in inventory, ID and ConnectedCable are populated.
 type InterfaceSpec struct {
-	ID             uuid.UUID          `yaml:"id,omitempty" json:"id,omitempty"`
-	Name           string             `yaml:"name" json:"name"`
-	Type           InterfacesElemType `yaml:"type" json:"type"`
-	Label          string             `yaml:"label,omitempty" json:"label,omitempty"`
-	Role           string             `yaml:"role,omitempty" json:"role,omitempty"`
-	MacAddress     string             `yaml:"mac_address,omitempty" json:"macAddress,omitempty"`
-	MgmtOnly       *bool              `yaml:"mgmt_only,omitempty" json:"mgmt_only,omitempty"`
-	Tags           []string           `yaml:"tags,omitempty" json:"tags,omitempty"`
-	Lag            string             `yaml:"lag,omitempty" json:"lag,omitempty"`
-	Mode           string             `yaml:"mode,omitempty" json:"mode,omitempty"`
-	UntaggedVLAN   int                `yaml:"untagged_vlan,omitempty" json:"untaggedVlan,omitempty"`
-	TaggedVLANs    []int              `yaml:"tagged_vlans,omitempty" json:"taggedVlans,omitempty"`
-	VRF            string             `yaml:"vrf,omitempty" json:"vrf,omitempty"`
-	ConnectedCable *uuid.UUID         `yaml:"connected_cable,omitempty" json:"connectedCable,omitempty"`
+	ID               uuid.UUID          `yaml:"id,omitempty" json:"id,omitempty"`
+	Name             string             `yaml:"name" json:"name"`
+	Type             InterfacesElemType `yaml:"type" json:"type"`
+	Label            string             `yaml:"label,omitempty" json:"label,omitempty"`
+	Role             string             `yaml:"role,omitempty" json:"role,omitempty"`
+	MacAddress       string             `yaml:"mac_address,omitempty" json:"macAddress,omitempty"`
+	MgmtOnly         *bool              `yaml:"mgmt_only,omitempty" json:"mgmt_only,omitempty"`
+	Tags             []string           `yaml:"tags,omitempty" json:"tags,omitempty"`
+	Lag              string             `yaml:"lag,omitempty" json:"lag,omitempty"`
+	Mode             string             `yaml:"mode,omitempty" json:"mode,omitempty"`
+	UntaggedVLAN     int                `yaml:"untagged_vlan,omitempty" json:"untaggedVlan,omitempty"`
+	TaggedVLANs      []int              `yaml:"tagged_vlans,omitempty" json:"taggedVlans,omitempty"`
+	VRF              string             `yaml:"vrf,omitempty" json:"vrf,omitempty"`
+	ConnectedCable   *uuid.UUID         `yaml:"connected_cable,omitempty" json:"connectedCable,omitempty"`
+	Status           string             `yaml:"status,omitempty" json:"status,omitempty"`
+	ProviderMetadata map[string]any     `yaml:"providerMetadata,omitempty" json:"providerMetadata,omitempty"`
 }
 
 // CaniInterface represents an instantiated interface on a specific device.

--- a/pkg/devicetypes/component_specs_test.go
+++ b/pkg/devicetypes/component_specs_test.go
@@ -409,3 +409,18 @@ func TestDeviceBaySlugRefAllowedTypes(t *testing.T) {
 		t.Errorf("AllowedTypes(nil) = %v, want nil", got)
 	}
 }
+
+func TestIsValidInterfaceType(t *testing.T) {
+	valid := []string{"lag", "virtual", "1000base-t", "100gbase-x-qsfp28", "400gbase-x-osfp"}
+	for _, v := range valid {
+		if !IsValidInterfaceType(v) {
+			t.Errorf("IsValidInterfaceType(%q) = false, want true", v)
+		}
+	}
+	invalid := []string{"", "unknown", "LAG", "10gbase", "fiber"}
+	for _, v := range invalid {
+		if IsValidInterfaceType(v) {
+			t.Errorf("IsValidInterfaceType(%q) = true, want false", v)
+		}
+	}
+}

--- a/pkg/devicetypes/inventory.go
+++ b/pkg/devicetypes/inventory.go
@@ -38,7 +38,8 @@ const (
 	SchemaVersionV1Alpha3 = "v1alpha3"
 	SchemaVersionV1Alpha4 = "v1alpha4"
 	SchemaVersionV1Alpha5 = "v1alpha5"
-	CurrentSchemaVersion  = SchemaVersionV1Alpha5
+	SchemaVersionV1Alpha6 = "v1alpha6"
+	CurrentSchemaVersion  = SchemaVersionV1Alpha6
 )
 
 // Inventory represents the entire inventory of devices, racks, locations, etc.

--- a/pkg/devicetypes/inventory_add_remove.go
+++ b/pkg/devicetypes/inventory_add_remove.go
@@ -173,8 +173,8 @@ func (inv *Inventory) AddInterface(iface *CaniInterface) error {
 	if iface.DeviceID == uuid.Nil {
 		return fmt.Errorf("interface device ID must not be nil")
 	}
-	_, devOK := inv.Devices[iface.DeviceID]
-	_, modOK := inv.Modules[iface.DeviceID]
+	dev, devOK := inv.Devices[iface.DeviceID]
+	mod, modOK := inv.Modules[iface.DeviceID]
 	if !devOK && !modOK {
 		return fmt.Errorf("device or module %s not found", iface.DeviceID)
 	}
@@ -183,6 +183,27 @@ func (inv *Inventory) AddInterface(iface *CaniInterface) error {
 			return fmt.Errorf("interface %q already exists on device %s", iface.Name, iface.DeviceID)
 		}
 	}
+
+	spec := InterfaceSpec{
+		ID:           iface.ID,
+		Name:         iface.Name,
+		Type:         iface.InterfaceType,
+		Label:        iface.Label,
+		Role:         iface.Role,
+		MacAddress:   iface.MacAddress,
+		Tags:         iface.Tags,
+		Lag:          iface.Lag,
+		Mode:         iface.Mode,
+		UntaggedVLAN: iface.UntaggedVLAN,
+		TaggedVLANs:  iface.TaggedVLANs,
+		VRF:          iface.VRF,
+	}
+	if devOK {
+		dev.Interfaces = append(dev.Interfaces, spec)
+	} else {
+		mod.Interfaces = append(mod.Interfaces, spec)
+	}
+
 	inv.Interfaces[iface.ID] = iface
 	return nil
 }

--- a/pkg/devicetypes/inventory_add_remove.go
+++ b/pkg/devicetypes/inventory_add_remove.go
@@ -228,6 +228,11 @@ func (inv *Inventory) AddVRF(vrf *CaniVRF) error {
 	if _, exists := inv.VRFs[vrf.ID]; exists {
 		return fmt.Errorf("vrf %s already exists", vrf.ID)
 	}
+	for _, devID := range vrf.Devices {
+		if _, ok := inv.Devices[devID]; !ok {
+			return fmt.Errorf("device %s not found", devID)
+		}
+	}
 	inv.VRFs[vrf.ID] = vrf
 	return nil
 }

--- a/pkg/devicetypes/inventory_add_remove.go
+++ b/pkg/devicetypes/inventory_add_remove.go
@@ -161,6 +161,32 @@ func (inv *Inventory) RemoveCable(id uuid.UUID) error {
 	return nil
 }
 
+// AddInterface inserts a standalone interface into the inventory.
+// The interface's DeviceID must reference an existing device or module.
+func (inv *Inventory) AddInterface(iface *CaniInterface) error {
+	if iface == nil {
+		return fmt.Errorf("interface must not be nil")
+	}
+	if _, exists := inv.Interfaces[iface.ID]; exists {
+		return fmt.Errorf("interface %s already exists", iface.ID)
+	}
+	if iface.DeviceID == uuid.Nil {
+		return fmt.Errorf("interface device ID must not be nil")
+	}
+	_, devOK := inv.Devices[iface.DeviceID]
+	_, modOK := inv.Modules[iface.DeviceID]
+	if !devOK && !modOK {
+		return fmt.Errorf("device or module %s not found", iface.DeviceID)
+	}
+	for _, existing := range inv.Interfaces {
+		if existing.DeviceID == iface.DeviceID && existing.Name == iface.Name {
+			return fmt.Errorf("interface %q already exists on device %s", iface.Name, iface.DeviceID)
+		}
+	}
+	inv.Interfaces[iface.ID] = iface
+	return nil
+}
+
 // AddVLAN inserts a single VLAN into the inventory.
 func (inv *Inventory) AddVLAN(vlan *CaniVLAN) error {
 	if vlan == nil {

--- a/pkg/devicetypes/inventory_add_remove.go
+++ b/pkg/devicetypes/inventory_add_remove.go
@@ -185,18 +185,20 @@ func (inv *Inventory) AddInterface(iface *CaniInterface) error {
 	}
 
 	spec := InterfaceSpec{
-		ID:           iface.ID,
-		Name:         iface.Name,
-		Type:         iface.InterfaceType,
-		Label:        iface.Label,
-		Role:         iface.Role,
-		MacAddress:   iface.MacAddress,
-		Tags:         iface.Tags,
-		Lag:          iface.Lag,
-		Mode:         iface.Mode,
-		UntaggedVLAN: iface.UntaggedVLAN,
-		TaggedVLANs:  iface.TaggedVLANs,
-		VRF:          iface.VRF,
+		ID:               iface.ID,
+		Name:             iface.Name,
+		Type:             iface.InterfaceType,
+		Label:            iface.Label,
+		Role:             iface.Role,
+		MacAddress:       iface.MacAddress,
+		Tags:             iface.Tags,
+		Lag:              iface.Lag,
+		Mode:             iface.Mode,
+		UntaggedVLAN:     iface.UntaggedVLAN,
+		TaggedVLANs:      iface.TaggedVLANs,
+		VRF:              iface.VRF,
+		Status:           iface.Status,
+		ProviderMetadata: iface.ProviderMetadata,
 	}
 	if devOK {
 		dev.Interfaces = append(dev.Interfaces, spec)

--- a/pkg/devicetypes/inventory_add_remove_test.go
+++ b/pkg/devicetypes/inventory_add_remove_test.go
@@ -479,3 +479,96 @@ func TestRemoveLocationUnlinksFromParent(t *testing.T) {
 		}
 	}
 }
+
+// TestAddInterfaceAppendsToDeviceSpec verifies that AddInterface persists the
+// interface in the device's InterfaceSpec slice so it survives RebuildDerivedState.
+func TestAddInterfaceAppendsToDeviceSpec(t *testing.T) {
+	deviceID := uuid.New()
+	inv := NewInventory()
+	inv.Devices[deviceID] = &CaniDeviceType{
+		ID:   deviceID,
+		Name: "sw-leaf-01",
+		Interfaces: []InterfaceSpec{
+			{ID: uuid.New(), Name: "1/1/1", Type: "100gbase-x-qsfp28"},
+		},
+	}
+	inv.RebuildDerivedState()
+
+	iface := &CaniInterface{
+		ID:            uuid.New(),
+		Name:          "lag26",
+		InterfaceType: "lag",
+		DeviceID:      deviceID,
+	}
+
+	if err := inv.AddInterface(iface); err != nil {
+		t.Fatalf("AddInterface() unexpected error: %v", err)
+	}
+
+	// Verify it's in the flat map
+	if _, ok := inv.Interfaces[iface.ID]; !ok {
+		t.Error("expected interface in Interfaces map")
+	}
+
+	// Verify it's in the device's spec slice
+	dev := inv.Devices[deviceID]
+	found := false
+	for _, spec := range dev.Interfaces {
+		if spec.ID == iface.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected interface appended to device.Interfaces spec slice")
+	}
+
+	// Verify it survives RebuildDerivedState
+	inv.RebuildDerivedState()
+	if _, ok := inv.Interfaces[iface.ID]; !ok {
+		t.Error("interface lost after RebuildDerivedState")
+	}
+}
+
+// TestAddInterfaceAppendsToModuleSpec verifies module-owned interfaces.
+func TestAddInterfaceAppendsToModuleSpec(t *testing.T) {
+	deviceID := uuid.New()
+	modID := uuid.New()
+	inv := NewInventory()
+	inv.Devices[deviceID] = &CaniDeviceType{ID: deviceID, Name: "server-01"}
+	inv.Modules[modID] = &CaniModuleType{
+		ID:           modID,
+		Name:         "nic-01",
+		ParentDevice: deviceID,
+		Interfaces:   []InterfaceSpec{},
+	}
+	inv.RebuildDerivedState()
+
+	iface := &CaniInterface{
+		ID:            uuid.New(),
+		Name:          "eth0",
+		InterfaceType: "1000base-t",
+		DeviceID:      modID,
+	}
+
+	if err := inv.AddInterface(iface); err != nil {
+		t.Fatalf("AddInterface() unexpected error: %v", err)
+	}
+
+	mod := inv.Modules[modID]
+	found := false
+	for _, spec := range mod.Interfaces {
+		if spec.ID == iface.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected interface appended to module.Interfaces spec slice")
+	}
+
+	inv.RebuildDerivedState()
+	if _, ok := inv.Interfaces[iface.ID]; !ok {
+		t.Error("module interface lost after RebuildDerivedState")
+	}
+}

--- a/pkg/devicetypes/inventory_relationships.go
+++ b/pkg/devicetypes/inventory_relationships.go
@@ -729,15 +729,20 @@ func (inv *Inventory) indexInterfaceSpecs(interfaces []InterfaceSpec, deviceID u
 func interfaceInstanceFromSpec(iface *InterfaceSpec, deviceID uuid.UUID) *CaniInterface {
 	mgmtOnly := iface.MgmtOnly != nil && *iface.MgmtOnly
 	role := ResolveInterfaceRole(iface.Role, iface.Name, iface.Type, mgmtOnly)
+	status := iface.Status
+	if status == "" {
+		status = string(StatusActive)
+	}
 	return &CaniInterface{
 		ID:            iface.ID,
 		Name:          iface.Name,
 		InterfaceType: iface.Type,
 		DeviceID:      deviceID,
 		ObjectMeta: ObjectMeta{
-			Status: string(StatusActive),
-			Role:   role,
-			Tags:   append([]string(nil), iface.Tags...),
+			Status:           status,
+			Role:             role,
+			Tags:             append([]string(nil), iface.Tags...),
+			ProviderMetadata: iface.ProviderMetadata,
 		},
 		MgmtOnly:       mgmtOnly,
 		Label:          iface.Label,

--- a/pkg/devicetypes/ipam_test.go
+++ b/pkg/devicetypes/ipam_test.go
@@ -595,6 +595,21 @@ func TestAddVRFWithDevices(t *testing.T) {
 	}
 }
 
+func TestAddVRFRejectsUnknownDevice(t *testing.T) {
+	inv := NewInventory()
+	vrf := &CaniVRF{
+		ID:      uuid.New(),
+		Name:    "bad-ref",
+		Devices: []uuid.UUID{uuid.New()},
+	}
+	if err := inv.AddVRF(vrf); err == nil {
+		t.Error("AddVRF() with non-existent device should return an error")
+	}
+	if _, exists := inv.VRFs[vrf.ID]; exists {
+		t.Error("VRF should not be stored when device validation fails")
+	}
+}
+
 // ---------- FindVRFByNameOrID ----------
 
 func TestFindVRFByNameOrID_ByName(t *testing.T) {

--- a/pkg/devicetypes/ipam_test.go
+++ b/pkg/devicetypes/ipam_test.go
@@ -572,3 +572,72 @@ func TestAddIPAddressErrors(t *testing.T) {
 		t.Error("AddIPAddress(invalid) should return an error")
 	}
 }
+
+// ---------- AddVRF with Devices ----------
+
+func TestAddVRFWithDevices(t *testing.T) {
+	inv := NewInventory()
+	devID := uuid.New()
+	inv.Devices[devID] = &CaniDeviceType{ID: devID, Name: "sw-01"}
+
+	vrf := &CaniVRF{
+		ID:      uuid.New(),
+		Name:    "keepalive",
+		Devices: []uuid.UUID{devID},
+	}
+
+	if err := inv.AddVRF(vrf); err != nil {
+		t.Fatalf("AddVRF() unexpected error: %v", err)
+	}
+	stored := inv.VRFs[vrf.ID]
+	if len(stored.Devices) != 1 || stored.Devices[0] != devID {
+		t.Errorf("VRF devices = %v, want [%s]", stored.Devices, devID)
+	}
+}
+
+// ---------- FindVRFByNameOrID ----------
+
+func TestFindVRFByNameOrID_ByName(t *testing.T) {
+	inv := NewInventory()
+	id := uuid.New()
+	inv.VRFs[id] = &CaniVRF{ID: id, Name: "LEGACY"}
+
+	got, err := inv.FindVRFByNameOrID("LEGACY")
+	if err != nil {
+		t.Fatalf("FindVRFByNameOrID() error: %v", err)
+	}
+	if got.ID != id {
+		t.Errorf("got ID %s, want %s", got.ID, id)
+	}
+}
+
+func TestFindVRFByNameOrID_ByUUID(t *testing.T) {
+	inv := NewInventory()
+	id := uuid.New()
+	inv.VRFs[id] = &CaniVRF{ID: id, Name: "INFRA"}
+
+	got, err := inv.FindVRFByNameOrID(id.String())
+	if err != nil {
+		t.Fatalf("FindVRFByNameOrID() error: %v", err)
+	}
+	if got.Name != "INFRA" {
+		t.Errorf("got Name %q, want INFRA", got.Name)
+	}
+}
+
+func TestFindVRFByNameOrID_CaseInsensitive(t *testing.T) {
+	inv := NewInventory()
+	id := uuid.New()
+	inv.VRFs[id] = &CaniVRF{ID: id, Name: "VRF-EDGE"}
+
+	if _, err := inv.FindVRFByNameOrID("vrf-edge"); err != nil {
+		t.Errorf("case-insensitive lookup failed: %v", err)
+	}
+}
+
+func TestFindVRFByNameOrID_NotFound(t *testing.T) {
+	inv := NewInventory()
+	if _, err := inv.FindVRFByNameOrID("missing"); err == nil {
+		t.Error("expected error for missing VRF")
+	}
+}

--- a/pkg/devicetypes/ipam_vrf.go
+++ b/pkg/devicetypes/ipam_vrf.go
@@ -25,7 +25,12 @@
  */
 package devicetypes
 
-import "github.com/google/uuid"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
 
 // CaniVRF represents a virtual routing and forwarding instance.
 type CaniVRF struct {
@@ -35,6 +40,9 @@ type CaniVRF struct {
 	RD          string    `json:"rd,omitempty" yaml:"rd,omitempty"` // Route distinguisher (RFC 4364)
 	Namespace   string    `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	Description string    `json:"description,omitempty" yaml:"description,omitempty"`
+
+	// Device assignments (Nautobot vrf-device-assignments)
+	Devices []uuid.UUID `json:"devices,omitempty" yaml:"devices,omitempty"`
 
 	// Shared metadata (status, role, tags, tenant, custom fields, external IDs, provider metadata)
 	ObjectMeta `yaml:",inline"`
@@ -46,4 +54,20 @@ func (v *CaniVRF) GetID() uuid.UUID {
 		return uuid.Nil
 	}
 	return v.ID
+}
+
+// FindVRFByNameOrID looks up a VRF by UUID string or exact name (case-insensitive).
+func (inv *Inventory) FindVRFByNameOrID(arg string) (*CaniVRF, error) {
+	if id, err := uuid.Parse(arg); err == nil {
+		if vrf, ok := inv.VRFs[id]; ok {
+			return vrf, nil
+		}
+		return nil, fmt.Errorf("VRF with UUID %q not found", arg)
+	}
+	for _, vrf := range inv.VRFs {
+		if strings.EqualFold(vrf.Name, arg) {
+			return vrf, nil
+		}
+	}
+	return nil, fmt.Errorf("VRF %q not found", arg)
 }

--- a/pkg/devicetypes/schema/inventory.schema.json
+++ b/pkg/devicetypes/schema/inventory.schema.json
@@ -988,6 +988,13 @@
         "description": {
           "type": "string"
         },
+        "devices": {
+          "items": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "type": "array"
+        },
         "externalIDs": {
           "additionalProperties": {
             "format": "uuid",

--- a/pkg/devicetypes/schema/inventory.schema.json
+++ b/pkg/devicetypes/schema/inventory.schema.json
@@ -1151,7 +1151,14 @@
         "name": {
           "type": "string"
         },
+        "providerMetadata": {
+          "additionalProperties": {},
+          "type": "object"
+        },
         "role": {
+          "type": "string"
+        },
+        "status": {
           "type": "string"
         },
         "taggedVlans": {

--- a/pkg/devicetypes/schema/inventory.schema.json
+++ b/pkg/devicetypes/schema/inventory.schema.json
@@ -1351,7 +1351,7 @@
       "type": "object"
     },
     "schemaVersion": {
-      "const": "v1alpha5",
+      "const": "v1alpha6",
       "type": "string"
     },
     "vlans": {
@@ -1378,5 +1378,5 @@
   ],
   "title": "cani inventory datastore",
   "type": "object",
-  "x-cani-schema-version": "v1alpha5"
+  "x-cani-schema-version": "v1alpha6"
 }

--- a/pkg/provider/nautobot/export/load.go
+++ b/pkg/provider/nautobot/export/load.go
@@ -67,34 +67,36 @@ const (
 
 // LoadResult contains the results of a Load operation
 type LoadResult struct {
-	Created              []string       // Names of devices created
-	Updated              []string       // Names of devices updated (merged)
-	Skipped              []string       // Names of devices skipped (already exist, no --merge)
-	Errors               []string       // Error messages
-	Conflicts            []ConflictInfo // Detailed conflict information
-	LocationsCreated     []string       // Names of locations created
-	LocationsSkipped     []string       // Names of locations skipped (already exist)
-	RacksCreated         []string       // Names of racks created
-	RacksSkipped         int            // Number of racks skipped (already exist)
-	IfacesCreated        int            // Number of interfaces created
-	IfacesSkipped        int            // Number of interfaces skipped (already exist)
-	ModulesCreated       int            // Number of modules created
-	ModulesSkipped       int            // Number of modules skipped (already exist)
-	FrusCreated          int            // Number of FRUs (inventory items) created
-	FrusSkipped          int            // Number of FRUs skipped (already exist)
-	CablesCreated        int            // Number of cables created
-	CablesSkipped        int            // Number of cables skipped (already exist in Nautobot)
-	CablesConflicted     int            // Number of cables skipped (an endpoint interface is already cabled)
-	VLANsCreated         int            // Number of VLANs created
-	VLANsSkipped         int            // Number of VLANs skipped (already exist)
-	VRFsCreated          int            // Number of VRFs created
-	VRFsSkipped          int            // Number of VRFs skipped (already exist)
-	PrefixesCreated      int            // Number of prefixes created
-	PrefixesSkipped      int            // Number of prefixes skipped (already exist)
-	IPAddressesCreated   int            // Number of IP addresses created
-	IPAddressesSkipped   int            // Number of IP addresses skipped (already exist)
-	RelationshipsCreated int            // Number of relationship associations created
-	RelationshipsSkipped int            // Number of relationship associations skipped (already exist)
+	Created                     []string       // Names of devices created
+	Updated                     []string       // Names of devices updated (merged)
+	Skipped                     []string       // Names of devices skipped (already exist, no --merge)
+	Errors                      []string       // Error messages
+	Conflicts                   []ConflictInfo // Detailed conflict information
+	LocationsCreated            []string       // Names of locations created
+	LocationsSkipped            []string       // Names of locations skipped (already exist)
+	RacksCreated                []string       // Names of racks created
+	RacksSkipped                int            // Number of racks skipped (already exist)
+	IfacesCreated               int            // Number of interfaces created
+	IfacesSkipped               int            // Number of interfaces skipped (already exist)
+	ModulesCreated              int            // Number of modules created
+	ModulesSkipped              int            // Number of modules skipped (already exist)
+	FrusCreated                 int            // Number of FRUs (inventory items) created
+	FrusSkipped                 int            // Number of FRUs skipped (already exist)
+	CablesCreated               int            // Number of cables created
+	CablesSkipped               int            // Number of cables skipped (already exist in Nautobot)
+	CablesConflicted            int            // Number of cables skipped (an endpoint interface is already cabled)
+	VLANsCreated                int            // Number of VLANs created
+	VLANsSkipped                int            // Number of VLANs skipped (already exist)
+	VRFsCreated                 int            // Number of VRFs created
+	VRFsSkipped                 int            // Number of VRFs skipped (already exist)
+	VRFDeviceAssignmentsCreated int            // Number of VRF-device assignments created
+	VRFDeviceAssignmentsSkipped int            // Number of VRF-device assignments skipped
+	PrefixesCreated             int            // Number of prefixes created
+	PrefixesSkipped             int            // Number of prefixes skipped (already exist)
+	IPAddressesCreated          int            // Number of IP addresses created
+	IPAddressesSkipped          int            // Number of IP addresses skipped (already exist)
+	RelationshipsCreated        int            // Number of relationship associations created
+	RelationshipsSkipped        int            // Number of relationship associations skipped (already exist)
 }
 
 // ConflictInfo contains information about a device conflict

--- a/pkg/provider/nautobot/export/load_vrfs.go
+++ b/pkg/provider/nautobot/export/load_vrfs.go
@@ -61,17 +61,32 @@ func (e *Exporter) loadVRFs(ctx context.Context, inventory *devicetypes.Inventor
 			e.Cache.CacheVRF(vrf.Name, &CachedItem{ID: existingID, Name: vrf.Name})
 			setExternalID(&vrf.ExternalIDs, "nautobot", existingID)
 			result.VRFsSkipped++
-			continue
+		} else {
+			nautobotID, err := e.createVRF(ctx, vrf)
+			if err != nil {
+				result.Errors = append(result.Errors, fmt.Sprintf("vrf %s: create error: %v", vrf.Name, err))
+				continue
+			}
+			e.Cache.CacheVRF(vrf.Name, &CachedItem{ID: nautobotID, Name: vrf.Name})
+			setExternalID(&vrf.ExternalIDs, "nautobot", nautobotID)
+			result.VRFsCreated++
 		}
 
-		nautobotID, err := e.createVRF(ctx, vrf)
-		if err != nil {
-			result.Errors = append(result.Errors, fmt.Sprintf("vrf %s: create error: %v", vrf.Name, err))
-			continue
+		// Create VRF-device assignments for explicitly listed devices.
+		for _, devID := range vrf.Devices {
+			dev, ok := inventory.Devices[devID]
+			if !ok || dev == nil {
+				continue
+			}
+			nautobotDevID, ok := dev.ExternalIDs[externalIDKeyNautobot]
+			if !ok || nautobotDevID == uuid.Nil {
+				continue
+			}
+			if err := e.ensureVRFDeviceAssignment(ctx, nautobotDevID, vrf.Name); err != nil {
+				result.Errors = append(result.Errors,
+					fmt.Sprintf("vrf %s: device assignment %s: %v", vrf.Name, dev.Name, err))
+			}
 		}
-		e.Cache.CacheVRF(vrf.Name, &CachedItem{ID: nautobotID, Name: vrf.Name})
-		setExternalID(&vrf.ExternalIDs, "nautobot", nautobotID)
-		result.VRFsCreated++
 	}
 
 	clog.Info("  VRFs created: %d", result.VRFsCreated)

--- a/pkg/provider/nautobot/export/load_vrfs.go
+++ b/pkg/provider/nautobot/export/load_vrfs.go
@@ -73,24 +73,38 @@ func (e *Exporter) loadVRFs(ctx context.Context, inventory *devicetypes.Inventor
 		}
 
 		// Create VRF-device assignments for explicitly listed devices.
-		for _, devID := range vrf.Devices {
-			dev, ok := inventory.Devices[devID]
-			if !ok || dev == nil {
-				continue
-			}
-			nautobotDevID, ok := dev.ExternalIDs[externalIDKeyNautobot]
-			if !ok || nautobotDevID == uuid.Nil {
-				continue
-			}
-			if err := e.ensureVRFDeviceAssignment(ctx, nautobotDevID, vrf.Name); err != nil {
-				result.Errors = append(result.Errors,
-					fmt.Sprintf("vrf %s: device assignment %s: %v", vrf.Name, dev.Name, err))
-			}
-		}
+		e.loadVRFDeviceAssignments(ctx, vrf, inventory, result)
 	}
 
 	clog.Info("  VRFs created: %d", result.VRFsCreated)
 	return nil
+}
+
+// loadVRFDeviceAssignments links a VRF to each device the operator listed.
+func (e *Exporter) loadVRFDeviceAssignments(
+	ctx context.Context, vrf *devicetypes.CaniVRF,
+	inventory *devicetypes.Inventory, result *LoadResult,
+) {
+	for _, devID := range vrf.Devices {
+		dev, ok := inventory.Devices[devID]
+		if !ok || dev == nil {
+			clog.Skipped("  VRF %s: device %s not found in inventory", vrf.Name, devID)
+			result.VRFDeviceAssignmentsSkipped++
+			continue
+		}
+		nautobotDevID, ok := dev.ExternalIDs[externalIDKeyNautobot]
+		if !ok || nautobotDevID == uuid.Nil {
+			clog.Skipped("  VRF %s: device %q not in Nautobot; assignment skipped", vrf.Name, dev.Name)
+			result.VRFDeviceAssignmentsSkipped++
+			continue
+		}
+		if err := e.ensureVRFDeviceAssignment(ctx, nautobotDevID, vrf.Name); err != nil {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("vrf %s: device assignment %s: %v", vrf.Name, dev.Name, err))
+			continue
+		}
+		result.VRFDeviceAssignmentsCreated++
+	}
 }
 
 // findVRF returns the Nautobot ID of an existing VRF with the given name, or

--- a/pkg/provider/nautobot/export/lookup_custom_fields.go
+++ b/pkg/provider/nautobot/export/lookup_custom_fields.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/Cray-HPE/cani/pkg/devicetypes"
 	nautobotapi "github.com/Cray-HPE/cani/pkg/nautobot"
@@ -123,6 +124,11 @@ func (e *Exporter) ensureCustomField(ctx context.Context, def devicetypes.Custom
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("failed to create custom field: %w", err)
 	}
+	// Handle "already exists" conflict: re-fetch by listing all and matching key.
+	if createResp.StatusCode() == http.StatusBadRequest &&
+		strings.Contains(string(createResp.Body), "already exists") {
+		return e.fetchCustomFieldByKey(ctx, def.Key)
+	}
 	if createResp.StatusCode() != http.StatusCreated {
 		return uuid.Nil, fmt.Errorf("failed to create custom field: status %d: %s",
 			createResp.StatusCode(), string(createResp.Body))
@@ -202,4 +208,36 @@ func (e *Exporter) ensureCustomFieldChoices(ctx context.Context, cfID uuid.UUID,
 	}
 
 	return nil
+}
+
+// fetchCustomFieldByKey paginates through all custom fields to find one by exact key.
+func (e *Exporter) fetchCustomFieldByKey(ctx context.Context, key string) (uuid.UUID, error) {
+	limit := 50
+	offset := 0
+	for {
+		resp, err := e.Client.ExtrasCustomFieldsListWithResponse(ctx,
+			&nautobotapi.ExtrasCustomFieldsListParams{
+				Limit:  &limit,
+				Offset: &offset,
+			},
+		)
+		if err != nil {
+			return uuid.Nil, fmt.Errorf("failed to list custom fields: %w", err)
+		}
+		if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+			return uuid.Nil, fmt.Errorf("failed to list custom fields: status %d", resp.StatusCode())
+		}
+		for _, cf := range resp.JSON200.Results {
+			if cf.Key != nil && *cf.Key == key {
+				id := toUUID(cf.Id)
+				clog.Skipped("Custom field %q already exists (ID: %s)", key, id)
+				return id, nil
+			}
+		}
+		if resp.JSON200.Next == nil || *resp.JSON200.Next == "" {
+			break
+		}
+		offset += limit
+	}
+	return uuid.Nil, fmt.Errorf("custom field %q exists but could not be found", key)
 }

--- a/pkg/visual/table_ipam.go
+++ b/pkg/visual/table_ipam.go
@@ -184,3 +184,27 @@ func resolvePrefixCIDR(id [16]byte, inv *devicetypes.Inventory) string {
 	}
 	return ""
 }
+
+// PrintVRFTable renders VRFs as a fixed-width table.
+func PrintVRFTable(vrfs []*devicetypes.CaniVRF, inv *devicetypes.Inventory) {
+	header := Col("NAME", ColName) + "  " +
+		Col("RD", ColRole) + "  " +
+		Col("DEVICES", ColCount) + "  " +
+		Col("DESCRIPTION", ColDNS)
+	sep := Col(strings.Repeat("-", ColName), ColName) + "  " +
+		Col(strings.Repeat("-", ColRole), ColRole) + "  " +
+		Col(strings.Repeat("-", ColCount), ColCount) + "  " +
+		Col(strings.Repeat("-", ColDNS), ColDNS)
+
+	fmt.Println(header)
+	fmt.Println(sep)
+	for _, v := range vrfs {
+		fmt.Println(
+			Col(v.Name, ColName) + "  " +
+				Col(v.RD, ColRole) + "  " +
+				Col(strconv.Itoa(len(v.Devices)), ColCount) + "  " +
+				Col(v.Description, ColDNS),
+		)
+	}
+	fmt.Printf("\nTotal: %d VRF(s)\n", len(vrfs))
+}

--- a/spec/integration/datastores_parity_spec.sh
+++ b/spec/integration/datastores_parity_spec.sh
@@ -135,7 +135,7 @@ PY
 #shellcheck disable=SC2317
 future_schema_rejection_summary() {
   setup_test_env
-  _future_original='{"schemaVersion":"v1alpha6","future":{"keep":true}}'
+  _future_original='{"schemaVersion":"v1alpha7","future":{"keep":true}}'
   _future_stderr=$(mktemp)
   printf '%s' "$_future_original" >"$CANI_DS"
 
@@ -207,7 +207,7 @@ Describe 'INTEGRATION: datastores ShellSpec parity'
   It 'rejects a future inventory generation without rewriting it'
     When call future_schema_rejection_summary
     The status should equal 0
-    The stderr should include 'unsupported inventory schema version "v1alpha6"'
+    The stderr should include 'unsupported inventory schema version "v1alpha7"'
     The output should include 'exit_code=1'
     The output should include 'unchanged=True'
     The output should include 'backup_exists=False'

--- a/spec/integration/migrate_v1alpha1_datastore_spec.sh
+++ b/spec/integration/migrate_v1alpha1_datastore_spec.sh
@@ -74,18 +74,18 @@ PY
 
 Describe 'INTEGRATION:'
 
-It 'migrates a v1alpha1 datastore to v1alpha5'
+It 'migrates a v1alpha1 datastore to v1alpha6'
 	BeforeCall 'setup_datastore_migration_env canitestdb_v1alpha1.json'
 	When call bin/cani alpha show --config "$CANI_CONF"
 	The status should equal 0
 	The stdout should be present
 	The stderr should include 'creating default config'
-	The stderr should include 'Migrated datastore from v1alpha1 to v1alpha5'
+	The stderr should include 'Migrated datastore from v1alpha1 to v1alpha6'
 	The file "$CANI_CONF" should be exist
 	The file "$CANI_DS" should be exist
 	The file "$CANI_DS.canisave" should be exist
 	The contents of file "$CANI_DS" should include '"schemaVersion"'
-	The contents of file "$CANI_DS" should include '"v1alpha5"'
+	The contents of file "$CANI_DS" should include '"v1alpha6"'
 	The contents of file "$CANI_DS" should include '"devices"'
 	The contents of file "$CANI_DS" should include '"locations"'
 	The contents of file "$CANI_DS" should include '"racks"'
@@ -93,12 +93,12 @@ It 'migrates a v1alpha1 datastore to v1alpha5'
 	The contents of file "$CANI_DS" should not include '"v1alpha1"'
 End
 
-It 'migrates released v1alpha3 additions to v1alpha5 without loss'
+It 'migrates released v1alpha3 additions to v1alpha6 without loss'
 	When call v1alpha3_migration_summary
 	The status should equal 0
-	The stderr should include 'Migrated datastore from v1alpha3 to v1alpha5'
+	The stderr should include 'Migrated datastore from v1alpha3 to v1alpha6'
 	The output should include 'backup_matches=True'
-	The output should include 'schema=v1alpha5'
+	The output should include 'schema=v1alpha6'
 	The output should include 'device_fields=True'
 	The output should include 'interface_spec_fields=True'
 	The output should include 'interface_fields=True'

--- a/spec/integration/visual_parity_spec.sh
+++ b/spec/integration/visual_parity_spec.sh
@@ -34,7 +34,7 @@ import json
 import os
 
 inventory = {
-    "schemaVersion": "v1alpha5",
+    "schemaVersion": "v1alpha6",
     "locations": {},
     "racks": {
         "00000000-0000-0000-0001-000000000001": {

--- a/testdata/fixtures/cani/crud_inventory.json
+++ b/testdata/fixtures/cani/crud_inventory.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "v1alpha5",
+  "schemaVersion": "v1alpha6",
   "locations": {
     "0249b742-abc6-4326-b521-de2e758d3216": {
       "id": "0249b742-abc6-4326-b521-de2e758d3216",

--- a/testdata/fixtures/cani/spine_leaf_inventory.json
+++ b/testdata/fixtures/cani/spine_leaf_inventory.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "v1alpha5",
+  "schemaVersion": "v1alpha6",
   "locations": {
     "a0000001-0000-0000-0000-000000000001": {
       "id": "a0000001-0000-0000-0000-000000000001",


### PR DESCRIPTION
## Summary

Adds LAG/virtual interface support and VRF-device assignment management to cani.

### New commands
- `cani alpha add interface` — create standalone interfaces (LAG, virtual) on devices
- `cani alpha update vrf` — add/remove device assignments, update description/RD
- `cani alpha show vrf` — list VRFs with device counts

### Model changes
- `CaniVRF.Devices []uuid.UUID` — explicit VRF-device assignments (exported as Nautobot `VRFDeviceAssignment`)
- `Inventory.AddInterface()` — persists to both flat map and device spec slice (survives `RebuildDerivedState`)
- `AddVRF()` validates device references exist before inserting
- Schema bumped to **v1alpha6** (additive, backward-compatible)

### Nautobot export
- `loadVRFs()` creates `VRFDeviceAssignment` links via `ensureVRFDeviceAssignment()`
- `ensureCustomField()` handles "already exists" race with paginated re-fetch

### Code quality (review fixes)
- `IsValidInterfaceType()` extracted to `pkg/devicetypes` (single source of truth)
- `NAUTOBOT_MAPPING.md` updated with `Devices` field + Phase 6c documentation
- Tests added for `IsValidInterfaceType`, `AddVRF` rejection path

## Testing
- Run of `make test` passed.
- Executed a version of `gnv2_inventory.sh` that included LAG interface creation, assigning LAG members, creating VRFs, and assigning devices to VRFs.
- Ran through some `cani` commands to eyeball `canidb.json`.
- Exported to local Nautobot and verified that lag interfaces were created on specified leaf switches and members were correct.  Verified that VRFs were created and assigned to switch devices as expected. Verified that VRFs were assigned to interfaces defined in `canidb.json`.

Some of the `cani` cmd output:

```
cani % bin/cani alpha show interface lag256

NAME                            TYPE             ROLE            DEVICE                LABEL                      MAC                 CONNECTED
------------------------------  ---------------  --------------  --------------------  -------------------------  ------------------  ------------
lag256                          lag                              FORGE-3507u44L                                   -                   -

Total: 1 interface(s)
studenym@HPE-GTGX4VXJ00 cani % bin/cani alpha show interface -o json | jq '.[] | select(.interfaceType == "lag")'

{
  "id": "a73a85cd-5c93-469d-a5be-216853831e39",
  "name": "lag151",
  "interfaceType": "lag",
  "deviceId": "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
  "status": "Active",
  "tags": [
    "multi-chassis"
  ],
  "mode": "tagged",
  "untaggedVlan": 1,
  "taggedVlans": [
    1,
    2000
  ]
}
{
  "id": "9e78525b-b679-4ed5-86f7-050217011d41",
  "name": "lag151",
  "interfaceType": "lag",
  "deviceId": "001943bd-c027-44fc-aa07-f20500994387",
  "status": "Active",
  "tags": [
    "multi-chassis"
  ],
  "mode": "tagged",
  "untaggedVlan": 1,
  "taggedVlans": [
    1,
    2000
  ]
}
{
  "id": "681953cf-d122-4923-9b70-47ba95f1aa3e",
  "name": "lag256",
  "interfaceType": "lag",
  "deviceId": "001943bd-c027-44fc-aa07-f20500994387",
  "status": "Active",
  "mode": "tagged-all"
}
{
  "id": "c531750d-361d-4b71-a606-4f01916d2bee",
  "name": "lag256",
  "interfaceType": "lag",
  "deviceId": "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
  "status": "Active",
  "mode": "tagged-all"
}
{
  "id": "85ad70ea-11e1-47f8-aa17-e31279732765",
  "name": "lag26",
  "interfaceType": "lag",
  "deviceId": "001943bd-c027-44fc-aa07-f20500994387",
  "status": "Active",
  "tags": [
    "multi-chassis"
  ],
  "mode": "tagged",
  "untaggedVlan": 2000,
  "taggedVlans": [
    1,
    2000
  ]
}
{
  "id": "6d16f304-d1ef-4a86-b196-d326b2671db5",
  "name": "lag26",
  "interfaceType": "lag",
  "deviceId": "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
  "status": "Active",
  "tags": [
    "multi-chassis"
  ],
  "mode": "tagged",
  "untaggedVlan": 2000,
  "taggedVlans": [
    1,
    2000
  ]
}
{
  "id": "0a319bac-dfcb-4d49-bd85-5db20d69f634",
  "name": "lag27",
  "interfaceType": "lag",
  "deviceId": "001943bd-c027-44fc-aa07-f20500994387",
  "status": "Active",
  "tags": [
    "multi-chassis"
  ],
  "mode": "tagged",
  "untaggedVlan": 2000,
  "taggedVlans": [
    1,
    2000
  ]
}
{
  "id": "da6bdd4a-a43b-4015-8022-dd067f408a78",
  "name": "lag27",
  "interfaceType": "lag",
  "deviceId": "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
  "status": "Active",
  "tags": [
    "multi-chassis"
  ],
  "mode": "tagged",
  "untaggedVlan": 2000,
  "taggedVlans": [
    1,
    2000
  ]
}
{
  "id": "8619a872-356a-49fe-85dd-0500b3eeb301",
  "name": "lag44",
  "interfaceType": "lag",
  "deviceId": "001943bd-c027-44fc-aa07-f20500994387",
  "status": "Active",
  "tags": [
    "multi-chassis"
  ],
  "mode": "tagged",
  "untaggedVlan": 2000,
  "taggedVlans": [
    1,
    2000
  ]
}
{
  "id": "e2dd10b9-66f3-4329-8d06-951110c50b3c",
  "name": "lag44",
  "interfaceType": "lag",
  "deviceId": "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
  "status": "Active",
  "tags": [
    "multi-chassis"
  ],
  "mode": "tagged",
  "untaggedVlan": 2000,
  "taggedVlans": [
    1,
    2000
  ]
}
{
  "id": "bf9b6b74-cb13-4759-a638-c579f262d46a",
  "name": "lag45",
  "interfaceType": "lag",
  "deviceId": "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
  "status": "Active",
  "tags": [
    "multi-chassis"
  ],
  "mode": "tagged",
  "untaggedVlan": 2000,
  "taggedVlans": [
    1,
    2000
  ]
}
{
  "id": "f8857c9f-ef9d-4bc3-928f-893593c32627",
  "name": "lag45",
  "interfaceType": "lag",
  "deviceId": "001943bd-c027-44fc-aa07-f20500994387",
  "status": "Active",
  "tags": [
    "multi-chassis"
  ],
  "mode": "tagged",
  "untaggedVlan": 2000,
  "taggedVlans": [
    1,
    2000
  ]
}
{
  "id": "76553d09-a661-4431-b150-1879a4f2cb41",
  "name": "lag46",
  "interfaceType": "lag",
  "deviceId": "001943bd-c027-44fc-aa07-f20500994387",
  "status": "Active",
  "tags": [
    "multi-chassis"
  ],
  "mode": "tagged",
  "untaggedVlan": 2000,
  "taggedVlans": [
    1,
    2000
  ]
}
{
  "id": "f1bb50eb-4147-4c2b-afef-016602b4c2b8",
  "name": "lag46",
  "interfaceType": "lag",
  "deviceId": "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
  "status": "Active",
  "tags": [
    "multi-chassis"
  ],
  "mode": "tagged",
  "untaggedVlan": 2000,
  "taggedVlans": [
    1,
    2000
  ]
}
{
  "id": "c8b532a1-004d-4898-9f7a-a3e5c04b577e",
  "name": "lag47",
  "interfaceType": "lag",
  "deviceId": "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
  "status": "Active",
  "tags": [
    "multi-chassis"
  ],
  "mode": "tagged",
  "untaggedVlan": 2000,
  "taggedVlans": [
    1,
    2000
  ]
}
{
  "id": "552e736e-9e65-46bb-9eef-d66093e729d7",
  "name": "lag47",
  "interfaceType": "lag",
  "deviceId": "001943bd-c027-44fc-aa07-f20500994387",
  "status": "Active",
  "tags": [
    "multi-chassis"
  ],
  "mode": "tagged",
  "untaggedVlan": 2000,
  "taggedVlans": [
    1,
    2000
  ]
}
studenym@HPE-GTGX4VXJ00 cani %
bin/cani alpha update interface --device "FORGE-3507u44L" -L

Interfaces for FORGE-3507u44L (a180568b-1f7f-4f8a-8ecf-9e5f52d31625):
  NAME                 TYPE                     ROLE                 SOURCE
  ----                 ----                     ----                 ------
  1/1/1                100gbase-x-qsfp28        UplinkInterface      device
  1/1/2                100gbase-x-qsfp28        UplinkInterface      device
  1/1/3                100gbase-x-qsfp28        UplinkInterface      device
  1/1/4                100gbase-x-qsfp28        UplinkInterface      device
  1/1/5                100gbase-x-qsfp28        UplinkInterface      device
  1/1/6                100gbase-x-qsfp28        UplinkInterface      device
  1/1/7                100gbase-x-qsfp28        UplinkInterface      device
  1/1/8                100gbase-x-qsfp28        UplinkInterface      device
  1/1/9                100gbase-x-qsfp28        UplinkInterface      device
  1/1/10               100gbase-x-qsfp28        UplinkInterface      device
  1/1/11               100gbase-x-qsfp28        UplinkInterface      device
  1/1/12               100gbase-x-qsfp28        UplinkInterface      device
  1/1/13               100gbase-x-qsfp28        UplinkInterface      device
  1/1/14               100gbase-x-qsfp28        UplinkInterface      device
  1/1/15               100gbase-x-qsfp28        UplinkInterface      device
  1/1/16               100gbase-x-qsfp28        UplinkInterface      device
  1/1/17               100gbase-x-qsfp28        UplinkInterface      device
  1/1/18               100gbase-x-qsfp28        UplinkInterface      device
  1/1/19               100gbase-x-qsfp28        UplinkInterface      device
  1/1/20               100gbase-x-qsfp28        UplinkInterface      device
  1/1/21               100gbase-x-qsfp28        UplinkInterface      device
  1/1/22               100gbase-x-qsfp28        UplinkInterface      device
  1/1/23               100gbase-x-qsfp28        UplinkInterface      device
  1/1/24               100gbase-x-qsfp28        UplinkInterface      device
  1/1/25               100gbase-x-qsfp28        EdgeExternalUplink   device
  1/1/26               100gbase-x-qsfp28        UplinkInterface      device
  1/1/27               100gbase-x-qsfp28        UplinkInterface      device
  1/1/28               100gbase-x-qsfp28        UplinkInterface      device
  1/1/29               100gbase-x-qsfp28        UplinkInterface      device
  1/1/30               100gbase-x-qsfp28        UplinkInterface      device
  1/1/31               100gbase-x-qsfp28        UplinkInterface      device
  1/1/32               100gbase-x-qsfp28        UplinkInterface      device
  mgmt                 1000base-t               ManagementInterface  device
  loopback0            virtual                  -                    device
  loopback1            virtual                  -                    device
  1/1/48               virtual                  -                    device
  vlan3                virtual                  -                    device
  vlan9                virtual                  -                    device
  vlan10               virtual                  -                    device
  vlan2000             virtual                  -                    device
  lag26                lag                      -                    device
  lag27                lag                      -                    device
  lag44                lag                      -                    device
  lag45                lag                      -                    device
  lag46                lag                      -                    device
  lag47                lag                      -                    device
  lag151               lag                      -                    device
  lag256               lag                      -                    device
studenym@HPE-GTGX4VXJ00 cani % bin/cani alpha show interface -o json | jq '.[] | select(.lag == "lag26")'

{
  "id": "b59073d5-45f8-4dc9-ac8d-1d313609ad5c",
  "name": "1/1/26",
  "interfaceType": "100gbase-x-qsfp28",
  "deviceId": "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
  "status": "Active",
  "role": "UplinkInterface",
  "lag": "lag26"
}
{
  "id": "244aec0b-5f71-42cd-8f8f-2c88a0474ab1",
  "name": "1/1/26",
  "interfaceType": "100gbase-x-qsfp28",
  "deviceId": "001943bd-c027-44fc-aa07-f20500994387",
  "status": "Active",
  "role": "UplinkInterface",
  "lag": "lag26"
}
studenym@HPE-GTGX4VXJ00 cani % bin/cani alpha show interface -o json | jq '.[] | select(.lag == "lag256")'

{
  "id": "2bd88d20-1d3f-4df3-8302-f9ef2624c929",
  "name": "1/1/31",
  "interfaceType": "100gbase-x-qsfp28",
  "deviceId": "001943bd-c027-44fc-aa07-f20500994387",
  "status": "Active",
  "role": "UplinkInterface",
  "lag": "lag256"
}
{
  "id": "4a2d9a63-b5f2-4d11-b53e-88b8eaf80f08",
  "name": "1/1/31",
  "interfaceType": "100gbase-x-qsfp28",
  "deviceId": "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
  "status": "Active",
  "role": "UplinkInterface",
  "lag": "lag256"
}
{
  "id": "878a572f-4af5-45b4-90a3-7737f6a07547",
  "name": "1/1/32",
  "interfaceType": "100gbase-x-qsfp28",
  "deviceId": "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
  "status": "Active",
  "role": "UplinkInterface",
  "lag": "lag256"
}
{
  "id": "8903d17e-5a77-4156-9f11-1608ac99312e",
  "name": "1/1/32",
  "interfaceType": "100gbase-x-qsfp28",
  "deviceId": "001943bd-c027-44fc-aa07-f20500994387",
  "status": "Active",
  "role": "UplinkInterface",
  "lag": "lag256"
}
studenym@HPE-GTGX4VXJ00 cani % bin/cani alpha show vrf
NAME                            RD              DEVICES   DESCRIPTION
------------------------------  --------------  --------  ------------------------------
INFRA                           65000:3         2         Harvester management network
LEGACY                                          2         Legacy CSM CMN routing
VRF-EDGE                                        2         Edge/external-facing routing
keepalive                                       4         VSX keepalive

Total: 4 VRF(s)
studenym@HPE-GTGX4VXJ00 cani % bin/cani alpha show vrf -o json
[
  {
    "id": "a5ee0b94-12ee-48db-9f71-d13457ab1f00",
    "name": "INFRA",
    "rd": "65000:3",
    "description": "Harvester management network",
    "devices": [
      "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
      "001943bd-c027-44fc-aa07-f20500994387"
    ],
    "status": ""
  },
  {
    "id": "e114e55d-2ecc-4363-b133-a1536b9f3dfd",
    "name": "LEGACY",
    "description": "Legacy CSM CMN routing",
    "devices": [
      "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
      "001943bd-c027-44fc-aa07-f20500994387"
    ],
    "status": ""
  },
  {
    "id": "82f8f35a-5f68-4b2e-898e-4f572aeff122",
    "name": "VRF-EDGE",
    "description": "Edge/external-facing routing",
    "devices": [
      "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
      "001943bd-c027-44fc-aa07-f20500994387"
    ],
    "status": ""
  },
  {
    "id": "5c234fe9-0313-45a3-ad36-e2509bb1e205",
    "name": "keepalive",
    "description": "VSX keepalive",
    "devices": [
      "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
      "001943bd-c027-44fc-aa07-f20500994387",
      "d058d3ff-4c7a-4482-8b70-d6a103407363",
      "479a3529-2e42-4ed8-ab6e-34dc668fc7af"
    ],
    "status": ""
  }
]
studenym@HPE-GTGX4VXJ00 cani % bin/cani alpha show vrf -o json | jq '.[] | select(.name == "keepalive")'

{
  "id": "5c234fe9-0313-45a3-ad36-e2509bb1e205",
  "name": "keepalive",
  "description": "VSX keepalive",
  "devices": [
    "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
    "001943bd-c027-44fc-aa07-f20500994387",
    "d058d3ff-4c7a-4482-8b70-d6a103407363",
    "479a3529-2e42-4ed8-ab6e-34dc668fc7af"
  ],
  "status": ""
}
studenym@HPE-GTGX4VXJ00 cani % bin/cani alpha show interface -o json | jq '.[] | select(.vrf == "keepalive")'

{
  "id": "9810ab8f-a0db-4466-bcf0-5316c7b2db76",
  "name": "1/1/48",
  "interfaceType": "virtual",
  "deviceId": "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
  "status": "Active",
  "vrf": "keepalive"
}
{
  "id": "e47ed6bc-5159-4a9c-a863-068d18bff5ea",
  "name": "1/1/48",
  "interfaceType": "virtual",
  "deviceId": "001943bd-c027-44fc-aa07-f20500994387",
  "status": "Active",
  "vrf": "keepalive"
}
studenym@HPE-GTGX4VXJ00 cani % bin/cani alpha show interface -o json | jq '.[] | select(.vrf == "INFRA")'

{
  "id": "a0bbe7f7-ebfe-4d74-bef0-0ee9963b27be",
  "name": "vlan3",
  "interfaceType": "virtual",
  "deviceId": "a180568b-1f7f-4f8a-8ecf-9e5f52d31625",
  "status": "Active",
  "vrf": "INFRA"
}
{
  "id": "ce9a1fa7-1df1-4a5b-a336-be33a4e3b361",
  "name": "vlan3",
  "interfaceType": "virtual",
  "deviceId": "001943bd-c027-44fc-aa07-f20500994387",
  "status": "Active",
  "vrf": "INFRA"
}
```