### PR TITLE
feat(dev): add tiered test targets and a preflight doctor for contrib…

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,22 +1,142 @@
-# Tests
+# Contributing
 
-Install [shellspec](https://shellspec.info) and run `make test`.
+## Quick start
 
-This builds the binary and then runs it under several scenarios to determine that the correct output is seen.
+```shell
+git clone https://github.com/Cray-HPE/cani.git && cd cani
+make hooks        # enable local commit-message validation
+make spec-setup   # install shellspec into .tools/ (no sudo)
+make doctor       # check prerequisites, print a fix for anything missing
+make test-fast    # unit + functional tests; no Docker, no Python
+```
 
-## Writing Tests
+`make doctor` is the source of truth for prerequisites. It prints a table of what is present, what is
+missing, and the exact command that fixes each gap. Run it with `TIER=int` to also require everything the
+integration tests need.
 
-If you add a new command, create a new `spec/something_spec.sh` that follows the format of the other files.  Each flag and different output should be accounted for in the tests.  If you need to test for something, but it is not ready yet, add a Todo-style test:
+## Prerequisites
+
+| Tool | Needed for | Install |
+| --- | --- | --- |
+| Go (see `go.mod`) | everything | <https://go.dev/dl/> |
+| shellspec >= 0.28.1 | functional + integration tests | `make spec-setup` |
+| GNU sed (`gsed`) | functional tests on macOS only | `brew install gnu-sed` |
+| Docker + Compose v2 | integration tests | <https://docs.docker.com/get-docker/> |
+| Python 3.12 + `virtualenv` | integration tests (legacy CSM tavern assertions) | `pip3 install virtualenv`, then `make venv` |
+| `jq`, `curl`, `openssl` | integration tests and cert generation | your package manager |
+
+The CSM simulator images come from `artifactory.algol60.net`, which is HPE-internal. Run
+`docker login artifactory.algol60.net` before `make csm-up`. The Nautobot simulator uses public images and
+needs no login.
+
+## Test tiers
+
+Pick the smallest tier that covers your change. Each tier builds on the one above it.
+
+| Tier | Command | Requires | Proves |
+| --- | --- | --- | --- |
+| Unit | `make utest` | Go | Package-level logic, in-process |
+| Functional | `make ftest` | shellspec | The CLI contract: exit codes, stdout/stderr, flags, help text |
+| Fast | `make test-fast` | Go + shellspec | Unit + functional. The daily loop. **No Docker, no Python.** |
+| Integration | `make itest` | simulators + `venv` | End-to-end workflows against live CSM/Nautobot APIs |
+| Everything | `make test` | all of the above | What CI approximates |
+| Edge | `make etest` | `venv` | Boundary cases. Excluded from `make test` (slow, EOL CSM) |
+
+`make test` stands the simulators up for you. To run the integration tier by hand:
+
+```shell
+make sim-up      # CSM on :8443, Nautobot on :8081
+make itest
+make sim-down
+```
+
+### External-service tests
+
+Tests that need a live Nautobot or CSM API are **skipped by default**, so a fresh clone is green without any
+simulator running. Opt in once the simulators are up:
+
+```shell
+RUN_EXTERNAL_TESTS=1 make itest
+```
+
+Setting `SKIP_EXTERNAL_TESTS` explicitly overrides both defaults, which is how CI pins the behaviour. Tests
+also skip themselves individually when the service they need is unreachable, so opting in on a machine where
+only one simulator is running is safe.
+
+## Writing tests
+
+Go unit tests live beside the code in `*_test.go`. Everything that exercises the compiled binary is a
+shellspec file under `spec/`. See [docs/development/testing.md](../docs/development/testing.md) for the
+shellspec primer: spec anatomy, the shared helpers, fixtures, and how to run a single example.
+
+Where a new test belongs:
+
+- `spec/functional/` — the command runs against local fixtures only. No network, no services.
+- `spec/integration/` — the command needs a live CSM or Nautobot API.
+
+If you add a new command, add a `spec/functional/<name>_spec.sh` that follows the shape of its neighbours.
+Each flag and each distinct output should be accounted for. If you need a placeholder for behaviour that is
+not ready yet, add a Todo-style test:
 
 ```shell
 It 'is a Todo'
 End
 ```
 
-This will let it show up as a tests in `# TODO` format, while still allowing the suite to pass.
+It reports as `# TODO` while still letting the suite pass:
 
 ```
 not ok 54 - is a Todo # TODO Not yet implemented
 ```
 
-You can add fixtures to `testdata/fixtures/` as needed to support checking the output of your commands.
+Add fixtures under `testdata/fixtures/` as needed.
+
+### When integration coverage is required
+
+Functional tests prove a command parses its flags and prints the right thing. They cannot prove it wrote the
+right thing to a provider. Add or extend a `spec/integration/` spec whenever you:
+
+- **add a command or a flag** that reads from or writes to a provider
+- **add a provider**, which needs round-trip coverage: import → modify → export → re-import for idempotency
+- **modify an existing provider**, including its API client, field mapping, or translation logic
+
+A change to shared code that every provider goes through — the datastore, the inventory schema, CRUD
+plumbing — needs integration coverage for at least one provider, because that is the only place the
+end-to-end contract is exercised.
+
+Assert against the provider's API from inside the spec, using `curl` and the helpers in
+`spec/spec_helper.sh`. **Do not add tavern files.** They are deprecated, cover CSM only, and are kept purely
+for backwards compatibility. Guard anything that talks to a live service so the suite stays green when the
+simulators are down; see the testing primer for the `Skip if` pattern.
+
+## Before you open a pull request
+
+```shell
+make fmt vet
+make lint          # golangci-lint; install once with make install-lint
+make lint-size     # 300-line budget for non-test Go files
+make test-fast
+```
+
+Conventions enforced in CI:
+
+- **Conventional commits.** Commit subjects and the PR title are validated. `make hooks` catches this locally
+  before you push.
+- **File size.** Non-test Go files stay under 300 lines. `tools/file_size_baseline.txt` is a ratchet: files
+  already over budget may shrink but not grow.
+- **Layering.** `cmd/` contains no provider-specific logic. Provider code belongs in `pkg/provider/<name>/`
+  and hooks into commands through the interfaces in `internal/provider/`. See [AGENTS.md](../AGENTS.md).
+- **License headers.** New files carry the MIT header used throughout the repo.
+- **Shell scripts** must pass `shellcheck`.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `shellspec: command not found` | not installed | `make spec-setup` (the make targets put `.tools/bin` on `PATH` themselves) |
+| `sed: unknown option` on macOS | BSD sed lacks GNU address ranges | `brew install gnu-sed` |
+| `unauthorized` pulling `cray-sls` or `cray-smd` | not logged in to the HPE registry | `docker login artifactory.algol60.net` |
+| Port 8081 or 8443 already in use | a simulator is still running | `make sim-down` |
+| Integration tests fail on stale inventory | leftover state in the shared test dir | `rm -rf /tmp/.cani` |
+| Nautobot tests skip unexpectedly | external tests are opt-in | `make sim-up`, then `RUN_EXTERNAL_TESTS=1 make itest` |
+| A commit is rejected locally | conventional-commit hook | match `type(scope): subject`, e.g. `fix(export): handle empty rack` |

--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,8 @@ testdata/fixtures/csm/simulator/nginx/certs/
 hms-simulation-environment/
 shellspec/
 
+# locally installed dev tooling (make spec-setup)
+.tools/
+
 # ggshield cache
 .cache_ggshield

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,8 @@ go_ldflags += -X $(MODULE)/cmd.BuildDate=$(BUILDTIME)
 # ──────────────────────────────────────────────────────────────────────────────
 
 BIN_DIR         := $(CURDIR)/bin
+TOOLS_DIR       := $(CURDIR)/.tools
+TOOLS_BIN       := $(TOOLS_DIR)/bin
 BUILD_DIR       ?= $(CURDIR)/dist/rpmbuild
 TEST_OUTPUT_DIR ?= $(CURDIR)/build/results
 SPEC_FILE       ?= $(NAME).spec
@@ -189,13 +191,36 @@ lint: ## Run static analysis (requires: make install-lint)
 	$(OK) "linted"
 
 # ──────────────────────────────────────────────────────────────────────────────
+#  Developer environment
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Which test tier `make doctor` treats as required: unit, func, int (or all).
+TIER ?= func
+
+.PHONY: doctor
+doctor: ## Check prerequisites for a test tier (TIER=unit|func|int|all)
+	@./tools/doctor.sh $(TIER)
+
+.PHONY: hooks
+hooks: ## Enable the repo git hooks (validates conventional commits locally)
+	$(INFO) "enabling git hooks"
+	git config core.hooksPath .githooks
+	$(OK) "git hooks enabled (.githooks)"
+
+# ──────────────────────────────────────────────────────────────────────────────
 #  Testing
 # ──────────────────────────────────────────────────────────────────────────────
 
 .PHONY: test
-# Run all tests unit + functional + integration (edge disabled-see below)
-test: bin schema spec-setup venv csm-up nautobot-up utest ftest itest # etest
+# Run every tier: unit + functional + integration (edge disabled-see below).
+# Stands the simulators up itself, so external-service tests are opted in here.
+test: export RUN_EXTERNAL_TESTS := 1
+test: bin schema spec-setup venv sim-up utest ftest itest # etest
 	$(OK) "all tests passed"
+
+.PHONY: test-fast
+test-fast: utest ftest ## Run unit + functional tests (no Docker, no Python)
+	$(OK) "fast tests passed"
 
 .PHONY: utest
 utest: bin ## Run unit tests
@@ -204,22 +229,22 @@ utest: bin ## Run unit tests
 	$(OK) "unit tests passed"
 
 .PHONY: ftest
-ftest: bin ## Run functional tests
+ftest: bin ## Run functional tests (shellspec; no external services)
 	$(INFO) "running functional tests"
-	shellspec ./spec/functional -f tap
+	PATH="$(TOOLS_BIN):$$PATH" shellspec ./spec/functional -f tap
 	$(OK) "functional tests passed"
 
 .PHONY: itest
-itest: bin venv ## Run integration tests
+itest: bin venv ## Run integration tests (needs simulators: make sim-up)
 	$(INFO) "running integration tests"
-	. venv/bin/activate && ./spec/support/bin/cani_integrate.sh integration
+	. venv/bin/activate && PATH="$(TOOLS_BIN):$$PATH" ./spec/support/bin/cani_integrate.sh integration
 	$(OK) "integration tests passed"
 
 .PHONY: etest
 # disabled in make test due to EOL CSM and slow nature, but can be run independently with `make etest`
 etest: bin venv ## Run edge-case tests
 	$(INFO) "running edge tests"
-	SKIP_EXTERNAL_TESTS=1 ./spec/support/bin/cani_integrate.sh edge
+	SKIP_EXTERNAL_TESTS=1 PATH="$(TOOLS_BIN):$$PATH" ./spec/support/bin/cani_integrate.sh edge
 	$(OK) "edge tests passed"
 
 cover:
@@ -325,20 +350,27 @@ csm-down: ## Run the CSM simulator
 	docker compose -f testdata/fixtures/csm/simulator/docker-compose.yml down
 	$(OK) "CSM simulator stopped"
 
+SHELLSPEC_VERSION ?= 0.28.1
+
 .PHONY: spec-setup
-spec-setup: ## Install shellspec for BDD tests
+spec-setup: ## Install shellspec into .tools/ (no sudo required)
 	$(INFO) "setting up shellspec"
-	@if ! [ -d ./shellspec ]; then \
-	  git clone https://github.com/shellspec/shellspec.git; \
+	@if command -v shellspec >/dev/null 2>&1; then \
+	  echo "  shellspec already on PATH ($$(command -v shellspec)), skipping"; \
+	else \
+	  if ! [ -d $(TOOLS_DIR)/shellspec ]; then \
+	    git clone --depth 1 --branch $(SHELLSPEC_VERSION) \
+	      https://github.com/shellspec/shellspec.git $(TOOLS_DIR)/shellspec; \
+	  fi; \
+	  mkdir -p $(TOOLS_BIN); \
+	  ln -sf ../shellspec/shellspec $(TOOLS_BIN)/shellspec; \
 	fi
-	@ln -sf "$(shell pwd)"/shellspec/shellspec /usr/local/bin/
 	$(OK) "shellspec ready"
 
 .PHONY: spec-clean
-spec-clean: ## Remove shellspec directory and symlink
+spec-clean: ## Remove the local shellspec install
 	$(INFO) "cleaning shellspec"
-	rm -rf ./shellspec
-	rm -f /usr/local/bin/shellspec
+	rm -rf $(TOOLS_DIR) ./shellspec
 	$(OK) "shellspec cleaned"
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -386,6 +418,14 @@ load-sls:
 	$(INFO) "loading SLS data for simulator tests"
 	spec/support/bin/setup_simulator.sh ./hms-simulation-environment ../testdata/fixtures/sls/no_hardware.json
 	$(OK) "SLS data loaded"
+
+.PHONY: sim-up
+sim-up: csm-up nautobot-up ## Start every simulator the integration tests need
+	$(OK) "simulators running (CSM :8443, Nautobot :8081)"
+
+.PHONY: sim-down
+sim-down: csm-down nautobot-down ## Stop every simulator
+	$(OK) "simulators stopped"
 
 # ──────────────────────────────────────────────────────────────────────────────
 #  Documentation

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,5 +1,183 @@
 # Testing
 
-Traditional unit tests for `cani` are in the `*_test.go` files.  Run `make utest` to run those tests.
+`cani` has two kinds of tests.
 
-Shellspec tests are used for functional and integration-style tests, which test the usability of the CLI interface.  Run `make ftest or make itest` to run those tests.
+**Go unit tests** live beside the code in `*_test.go` and exercise packages in-process. Run them with
+`make utest`.
+
+**ShellSpec tests** live under `spec/` and exercise the *compiled binary*. They assert on the things a Go
+unit test cannot reach: exit codes, what lands on stdout versus stderr, flag parsing, help text, and the
+state of the datastore after a command runs. That is the CLI contract, and it is what users actually depend
+on.
+
+Most contributors only need `make test-fast` (unit + functional). See
+[CONTRIBUTING.md](https://github.com/Cray-HPE/cani/blob/main/.github/CONTRIBUTING.md) for the test tiers and
+prerequisites.
+
+## Getting ShellSpec
+
+```shell
+make spec-setup
+```
+
+This clones a pinned ShellSpec into `.tools/` and symlinks it into `.tools/bin`. No `sudo`, nothing outside
+the repo. The `ftest`, `itest`, and `etest` targets add `.tools/bin` to `PATH` themselves, so you do not need
+to. If ShellSpec is already on your `PATH`, the target leaves it alone.
+
+`make spec-clean` removes it again.
+
+## Anatomy of a spec
+
+`.shellspec` loads `spec/spec_helper.sh` for every run, which is where the shared environment and helpers
+come from. A spec is a tree of `Describe` blocks containing `It` examples:
+
+```shell
+Describe 'cani alpha update location'
+  Before 'setup_crud_env'
+
+  Describe 'valid name'
+    It 'updates a location by name'
+      When call bin/cani alpha update location test-site --description "updated" --config "$CANI_CONF"
+      The status should equal 0
+      The stderr should include 'Updated location'
+    End
+  End
+End
+```
+
+The pieces:
+
+| Directive | Purpose |
+| --- | --- |
+| `Describe` / `Context` | Group examples. Nest freely; the names concatenate in the output |
+| `It` | One example. Exactly one `When` per example |
+| `When call <cmd>` | Run `<cmd>` in the current shell and capture status, stdout, stderr |
+| `When run <cmd>` | Same, but in a subshell. Use when the command may `exit` |
+| `The status should equal 0` | Assert the exit code |
+| `The stdout should include '...'` | Assert on output. Also `should equal`, `should match pattern`, `should start with` |
+| `Before` / `After` | Run a helper before/after every example in the block |
+| `BeforeCall` / `BeforeAll` | Run just before the `When`, or once per block |
+| `Skip if '<reason>' <fn>` | Skip the block when `<fn>` returns 0 |
+
+`cani` builds to `bin/cani`, and the helper puts that directory on `PATH`, so specs invoke `bin/cani`
+directly.
+
+!!! warning "`Skip if` takes a command, not a shell expression"
+
+    `Skip if 'reason' ! curl ...` is **silently ignored** — `!` is a shell keyword, so ShellSpec never sees a
+    condition and the block runs anyway. Wrap the negation in a function instead:
+
+    ```shell
+    nautobot_unreachable() {
+      ! curl -sf -H "Authorization: Token ${NAUTOBOT_TOKEN}" "${NAUTOBOT_URL}/status/" >/dev/null 2>&1
+    }
+    Skip if 'Nautobot is not reachable' nautobot_unreachable
+    ```
+
+    A bare `[ ... ]` test is fine, because `[` is a real command.
+
+## Environment and helpers
+
+`spec_helper_precheck()` exports these for every spec:
+
+| Variable | Value | Notes |
+| --- | --- | --- |
+| `FIXTURES` | `spec/testdata/fixtures` | Root for all fixture files |
+| `CANI_DIR` | `/tmp/.cani` | Shared scratch dir, kept off your real config |
+| `CANI_CONF` / `CANI_DS` / `CANI_LOG` | under `CANI_DIR` | Config, datastore, log |
+| `NAUTOBOT_URL` / `NAUTOBOT_TOKEN` | `localhost:8081`, a fake token | Must match `cani_0.6.x.yml` |
+| `SKIP_EXTERNAL_TESTS` | `1` unless `RUN_EXTERNAL_TESTS=1` | External-service tests are opt-in |
+
+Environment builders — each wipes `CANI_DIR` and lays down a known state:
+
+| Helper | Gives you |
+| --- | --- |
+| `setup_test_env` | Empty config, no datastore |
+| `setup_populated_env` | The `test-rack` inventory |
+| `setup_crud_env` | test-site, test-rack, test-device, test-module, test-cable, an interface |
+| `setup_connections_env` | CRUD inventory for connection tests |
+| `setup_orphan_env` | Orphaned devices and racks |
+| `setup_migration_env <cfg>` | A legacy config fixture, e.g. `cani_0.1.x.yml` |
+| `setup_datastore_migration_env <ds>` | A legacy datastore only, so `cani` must create the config |
+| `setup_nautobot_env` | Config pointing at the local Nautobot |
+| `teardown_test_env` | Removes `CANI_DIR` |
+
+Also available: `remove_config`, `remove_datastore`, `remove_log`, `fixture` (compare a value to a fixture
+file), `match_colored_text` / `match_rich_text` (match through ANSI escapes), and for Nautobot,
+`wait_for_nautobot`, `nb_create`, `nb_list`, `nb_list_field`.
+
+Because every builder wipes `/tmp/.cani`, a spec that dies midway can leave stale state behind. `rm -rf
+/tmp/.cani` resets it.
+
+## Functional or integration?
+
+The deciding question is **does this test need a live service?**
+
+- **No** → `spec/functional/`. Runs against local fixtures. `make ftest` needs nothing but ShellSpec.
+- **Yes** → `spec/integration/`. Needs CSM on `:8443` or Nautobot on `:8081` via `make sim-up`.
+
+Most changes want both. A functional spec proves the command parses its flags and prints what it should; only
+an integration spec proves it put the right data in the provider. Integration coverage is expected when you
+add a command or flag that touches a provider, add a provider, or modify an existing one — including its API
+client, field mapping, or translation logic. The same applies to shared code every provider routes through,
+such as the datastore, the inventory schema, or CRUD plumbing.
+
+For a provider, the round trip is the thing worth asserting: import → modify → export → re-import, with the
+last step proving idempotency.
+
+Assert on the provider's API from inside the spec itself. `spec/spec_helper.sh` provides `nb_list`,
+`nb_list_field`, and `nb_create` for Nautobot; for anything else, wrap a `curl` call in a helper function the
+way `spec/integration/nautobot_import_export_spec.sh` does.
+
+!!! warning "Tavern assertions are deprecated"
+
+    Some CSM specs still pair with a [tavern](https://tavern.readthedocs.io) assertion file, matched by
+    filename: `spec/integration/foo_spec.sh` is followed by `spec/integration/tavern/test_foo.tavern.yml`
+    when that file exists, and `spec/support/bin/cani_integrate.sh` wires the two together.
+
+    They are kept for backwards compatibility only — **do not write new ones.** Every one of them targets
+    CSM, their endpoints are pinned to the legacy simulator on `localhost:8080`, and they are the reason
+    `make itest` needs a Python virtualenv at all.
+
+Guard anything that talks to a live service so the suite stays green without it:
+
+```shell
+Describe 'INTEGRATION: Nautobot round-trip'
+  Skip if 'SKIP_EXTERNAL_TESTS is set' [ "${SKIP_EXTERNAL_TESTS:-0}" = "1" ]
+  Skip if 'Nautobot is not reachable' nautobot_unreachable
+```
+
+## Running a subset
+
+```shell
+shellspec spec/functional/add_spec.sh          # one file
+shellspec spec/functional/add_spec.sh:42       # the example at line 42
+shellspec spec/functional --focus              # only blocks marked fDescribe/fIt
+shellspec spec/functional -f documentation     # readable output instead of TAP
+shellspec spec/functional/add_spec.sh -x       # trace every command (debugging)
+```
+
+Run `make bin` first — specs test the binary in `bin/`, not your working tree.
+
+## Reading TAP output
+
+`make ftest` reports TAP, which CI parses:
+
+```
+ok 12 - cani alpha add rack --help exits 0
+not ok 13 - cani alpha add rack adds a rack
+not ok 54 - is a Todo # TODO Not yet implemented
+ok 3 - INTEGRATION: Nautobot round-trip imports # SKIP Nautobot is not reachable
+```
+
+`# TODO` and `# SKIP` do not fail the suite. A bare `not ok` does.
+
+## Placeholders
+
+To reserve a test for behaviour that is not implemented yet, write an example with no `When`:
+
+```shell
+It 'is a Todo'
+End
+```
+

--- a/spec/integration/nautobot_import_export_spec.sh
+++ b/spec/integration/nautobot_import_export_spec.sh
@@ -41,10 +41,15 @@
 Describe 'INTEGRATION: Nautobot import/export round-trip'
 
   # Skip the entire block if external tests are disabled or Nautobot is down.
-  Skip if 'SKIP_EXTERNAL_TESTS is set' [ "${SKIP_EXTERNAL_TESTS:-0}" = "1" ]
-  Skip if 'Nautobot is not reachable' \
+  # The reachability probe must be a function: `Skip if 'x' ! cmd` is silently
+  # ignored by shellspec because `!` is a shell keyword, not a command.
+  nautobot_unreachable() {
     ! curl -sf -H "Authorization: Token ${NAUTOBOT_TOKEN}" \
       "${NAUTOBOT_URL}/status/" >/dev/null 2>&1
+  }
+
+  Skip if 'SKIP_EXTERNAL_TESTS is set' [ "${SKIP_EXTERNAL_TESTS:-0}" = "1" ]
+  Skip if 'Nautobot is not reachable' nautobot_unreachable
 
   # --- helpers available inside this Describe scope ---
 

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -49,9 +49,17 @@ spec_helper_precheck() {
   setenv NAUTOBOT_URL="http://localhost:8081/api"
   setenv NAUTOBOT_TOKEN="0123456789abcdef0123456789abcdef01234567"
 
-  # Skip tests that require external services (CSM API, mock servers, etc.)
-  # Set SKIP_EXTERNAL_TESTS=1 to skip these tests
-  : "${SKIP_EXTERNAL_TESTS:=0}"
+  # Tests needing a live service (Nautobot, CSM API) are skipped by default so a
+  # fresh clone is green with no simulator running. Opt in with
+  # RUN_EXTERNAL_TESTS=1; setting SKIP_EXTERNAL_TESTS explicitly still wins.
+  # setenv is required here: a plain assignment does not reach the specs.
+  if [ -n "${SKIP_EXTERNAL_TESTS:-}" ]; then
+    setenv SKIP_EXTERNAL_TESTS="${SKIP_EXTERNAL_TESTS}"
+  elif [ "${RUN_EXTERNAL_TESTS:-0}" = "1" ]; then
+    setenv SKIP_EXTERNAL_TESTS="0"
+  else
+    setenv SKIP_EXTERNAL_TESTS="1"
+  fi
 	
   # On macOS, GNU sed (gsed) is required for GNU sed extensions (e.g., 0, address)
   # A wrapper at spec/support/bin/sed handles this transparently

--- a/tools/doctor.sh
+++ b/tools/doctor.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env sh
+#
+# MIT License
+#
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Preflight check for the cani test tiers.  Reports which prerequisites are
+# present and prints the exact command that fixes each one that is not.
+#
+# Prerequisites at or below the requested tier are required and cause a
+# non-zero exit; anything above it is reported as a note so you can see what a
+# higher tier will need later.
+#
+# Usage: tools/doctor.sh [unit|func|int|all]
+
+set -u
+
+SHELLSPEC_MIN="0.28.1"
+CSM_REGISTRY="artifactory.algol60.net"
+NAUTOBOT_HEALTH="http://localhost:8081/api/status/"
+CSM_HEALTH="https://localhost:8443/apis/sls/v1/health"
+
+TIER="${1:-func}"
+case "$TIER" in
+unit) want=1 ;;
+func) want=2 ;;
+int | all) want=3 ;;
+*)
+  echo "usage: $0 [unit|func|int|all]" >&2
+  exit 2
+  ;;
+esac
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  c_reset=$(printf '\033[0m')
+  c_green=$(printf '\033[32m')
+  c_red=$(printf '\033[31m')
+  c_yellow=$(printf '\033[33m')
+  c_dim=$(printf '\033[2m')
+  c_bold=$(printf '\033[1m')
+else
+  c_reset='' c_green='' c_red='' c_yellow='' c_dim='' c_bold=''
+fi
+
+missing=0
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# report <tier> <label> <ok?0:1> <detail> <fix>
+report() {
+  if [ "$3" -eq 0 ]; then
+    printf '  %s%-7s%s %-16s %s%s%s\n' \
+      "$c_green" "ok" "$c_reset" "$2" "$c_dim" "$4" "$c_reset"
+  elif [ "$1" -le "$want" ]; then
+    printf '  %s%-7s%s %-16s %s\n' "$c_red" "missing" "$c_reset" "$2" "$5"
+    missing=$((missing + 1))
+  else
+    printf '  %s%-7s%s %-16s %s%s%s\n' \
+      "$c_yellow" "note" "$c_reset" "$2" "$c_dim" "$5" "$c_reset"
+  fi
+}
+
+# check_cmd <tier> <label> <binary> <fix>
+check_cmd() {
+  if have "$3"; then
+    report "$1" "$2" 0 "$(command -v "$3")" ""
+  else
+    report "$1" "$2" 1 "" "$4"
+  fi
+}
+
+# Numeric field sort keeps this POSIX-safe; `sort -V` is not portable.
+version_at_least() {
+  [ -n "$1" ] || return 1
+  [ "$(printf '%s\n%s\n' "$2" "$1" | sort -t. -k1,1n -k2,2n -k3,3n | head -n1)" = "$2" ]
+}
+
+printf '%scani doctor%s  tier: %s%s%s\n\n' \
+  "$c_bold" "$c_reset" "$c_bold" "$TIER" "$c_reset"
+
+# ── toolchain ────────────────────────────────────────────────────────────────
+printf ' toolchain\n'
+
+if have go; then
+  go_want=$(awk '/^go /{print $2; exit}' go.mod 2>/dev/null)
+  report 1 go 0 "$(go env GOVERSION 2>/dev/null) (go.mod wants ${go_want:-?})" ""
+else
+  report 1 go 1 "" "install Go: https://go.dev/dl/"
+fi
+
+check_cmd 1 git git "install git"
+check_cmd 1 curl curl "install curl"
+
+if [ "$(git config --get core.hooksPath 2>/dev/null)" = ".githooks" ]; then
+  report 1 git-hooks 0 ".githooks" ""
+else
+  report 1 git-hooks 1 "" "make hooks"
+fi
+
+# ── shell tests ──────────────────────────────────────────────────────────────
+printf '\n shell tests\n'
+
+if have shellspec; then
+  spec_version=$(shellspec --version 2>/dev/null | head -n1)
+  if version_at_least "$spec_version" "$SHELLSPEC_MIN"; then
+    report 2 shellspec 0 "$spec_version" ""
+  else
+    report 2 shellspec 1 "" \
+      "found $spec_version, need >= $SHELLSPEC_MIN: make spec-clean spec-setup"
+  fi
+else
+  report 2 shellspec 1 "" "make spec-setup"
+fi
+
+if [ "$(uname -s)" = "Darwin" ]; then
+  check_cmd 2 gsed gsed "brew install gnu-sed (specs need GNU sed ranges)"
+fi
+
+# ── integration ──────────────────────────────────────────────────────────────
+printf '\n integration\n'
+
+check_cmd 3 docker docker "install Docker or Podman with a docker shim"
+
+if have docker && docker compose version >/dev/null 2>&1; then
+  report 3 docker-compose 0 "$(docker compose version --short 2>/dev/null)" ""
+else
+  report 3 docker-compose 1 "" "install the Docker Compose v2 plugin"
+fi
+
+check_cmd 3 python3 python3 "install Python 3.12+"
+check_cmd 3 virtualenv virtualenv "pip3 install virtualenv"
+check_cmd 3 jq jq "install jq (specs parse API responses with it)"
+check_cmd 3 openssl openssl "install openssl (make csm-certs needs it)"
+
+if [ -f venv/bin/activate ]; then
+  report 3 venv 0 "venv/" ""
+else
+  report 3 venv 1 "" "make venv"
+fi
+
+# The registry key lands in the Docker config even when a credential helper
+# holds the secret, so this detects a login without ever reading credentials.
+docker_config="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
+if [ -f "$docker_config" ] && grep -q "$CSM_REGISTRY" "$docker_config" 2>/dev/null; then
+  report 3 csm-registry 0 "$CSM_REGISTRY" ""
+else
+  report 3 csm-registry 1 "" \
+    "docker login $CSM_REGISTRY (CSM simulator images are HPE-internal)"
+fi
+
+# ── services (informational: `make sim-up` starts these on demand) ───────────
+printf '\n simulators %s(started on demand by make sim-up)%s\n' "$c_dim" "$c_reset"
+
+if curl -sf -o /dev/null --max-time 3 "$NAUTOBOT_HEALTH" 2>/dev/null; then
+  report 9 nautobot 0 "http://localhost:8081" ""
+else
+  report 9 nautobot 1 "" "not running: make nautobot-up"
+fi
+
+if curl -skf -o /dev/null --max-time 3 "$CSM_HEALTH" 2>/dev/null; then
+  report 9 csm 0 "https://localhost:8443" ""
+else
+  report 9 csm 1 "" "not running: make csm-up"
+fi
+
+# ── summary ──────────────────────────────────────────────────────────────────
+printf '\n'
+if [ "$missing" -gt 0 ]; then
+  printf '%s✖%s %d prerequisite(s) missing for tier %s.\n' \
+    "$c_red" "$c_reset" "$missing" "$TIER"
+  printf '  run the fixes above, then: make doctor TIER=%s\n' "$TIER"
+  exit 1
+fi
+
+printf '%s✔%s tier %s is ready.\n' "$c_green" "$c_reset" "$TIER"
+case "$TIER" in
+unit) printf '  next: make utest\n' ;;
+func) printf '  next: make test-fast   (higher tier: make doctor TIER=int)\n' ;;
+*) printf '  next: make sim-up && make test\n' ;;
+esac


### PR DESCRIPTION
…utor onboarding

Following the guide did not work: `make spec-setup` symlinked into /usr/local/bin (sudo required), `make test` pulled from an HPE-internal registry and stood up two Docker stacks, and external-service tests defaulted to on, so a fresh clone went red.

- install shellspec into .tools/ at a pinned version, without sudo
- add `make doctor`, a tiered preflight that names the fix for each gap
- add `make hooks` to wire core.hooksPath, which nothing did before
- add `make test-fast` (unit + functional) and `make sim-up`/`sim-down`
- skip external-service tests unless RUN_EXTERNAL_TESTS=1
- rewrite CONTRIBUTING.md and turn testing.md into a shellspec primer

Also repairs a silently dead guard: `Skip if 'reason' ! cmd` never fires because `!` is a shell keyword rather than a command, so the Nautobot reachability check had never worked.

# Summary and Scope

<!-- This is a comment. Add a summary below this line of what your PR does -->



# Risks and Mitigations
 
<!-- What is the risk level of this change? -->

