### PR TITLE
fix(export): FORGE-211 - converge existing objects on --merge

### DIFF
--- a/pkg/provider/nautobot/export/custom_field_drift.go
+++ b/pkg/provider/nautobot/export/custom_field_drift.go
@@ -1,0 +1,118 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2023-2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package export
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	nautobotapi "github.com/Cray-HPE/cani/pkg/nautobot"
+	"github.com/google/uuid"
+)
+
+// reconcileCustomFieldDrift compares the remote custom field definition against
+// the local intent and PATCHes any drifted fields (label, type, content_types,
+// required, default, weight, description).
+func (e *Exporter) reconcileCustomFieldDrift(ctx context.Context, id uuid.UUID, remote nautobotapi.CustomField, local devicetypes.CustomFieldDefinition) error {
+	var drifted bool
+	req := nautobotapi.PatchedWritableCustomFieldRequest{}
+
+	if remote.Label != local.Label {
+		req.Label = &local.Label
+		drifted = true
+	}
+	if remote.Type.Value != nil && string(*remote.Type.Value) != local.Type {
+		t := nautobotapi.CustomFieldTypeChoices(local.Type)
+		req.Type = &t
+		drifted = true
+	}
+	if !stringSlicesEqual(remote.ContentTypes, local.ContentTypes) {
+		req.ContentTypes = &local.ContentTypes
+		drifted = true
+	}
+	remoteRequired := remote.Required != nil && *remote.Required
+	if remoteRequired != local.Required {
+		req.Required = &local.Required
+		drifted = true
+	}
+	remoteWeight := 0
+	if remote.Weight != nil {
+		remoteWeight = *remote.Weight
+	}
+	if remoteWeight != local.Weight {
+		req.Weight = &local.Weight
+		drifted = true
+	}
+	remoteDesc := ""
+	if remote.Description != nil {
+		remoteDesc = *remote.Description
+	}
+	if remoteDesc != local.Description {
+		req.Description = &local.Description
+		drifted = true
+	}
+
+	if !drifted {
+		return nil
+	}
+
+	if e.Options.DryRun {
+		clog.DryRun("Would update drifted custom field definition: %s (key=%s)", local.Label, local.Key)
+		return nil
+	}
+
+	resp, err := e.Client.ExtrasCustomFieldsPartialUpdateWithResponse(ctx, id,
+		&nautobotapi.ExtrasCustomFieldsPartialUpdateParams{}, req)
+	if err != nil {
+		return fmt.Errorf("PATCH custom field %q: %w", local.Key, err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("PATCH custom field %q: status %d: %s", local.Key, resp.StatusCode(), string(resp.Body))
+	}
+	clog.Changed("Reconciled drifted custom field: %s (key=%s)", local.Label, local.Key)
+	return nil
+}
+
+// stringSlicesEqual reports whether two string slices contain the same elements
+// (order-insensitive).
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[string]int, len(a))
+	for _, s := range a {
+		counts[s]++
+	}
+	for _, s := range b {
+		counts[s]--
+		if counts[s] < 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/provider/nautobot/export/custom_field_drift_test.go
+++ b/pkg/provider/nautobot/export/custom_field_drift_test.go
@@ -1,0 +1,245 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package export
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	nautobotapi "github.com/Cray-HPE/cani/pkg/nautobot"
+	"github.com/google/uuid"
+)
+
+// -----------------------------------------------------------------------------
+// reconcileCustomFieldDrift
+// -----------------------------------------------------------------------------
+
+func TestReconcileCustomFieldDrift_PatchesWhenDrifted(t *testing.T) {
+	cfID := uuid.New()
+	var patchCalls int
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "extras/custom-fields") {
+			patchCalls++
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{}`)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, emptyListJSON)
+	}
+
+	e, cleanup := newExporterWithServer(t, handler)
+	defer cleanup()
+	e.Options.Merge = true
+
+	typeValue := nautobotapi.CustomFieldTypeValue("text")
+	remote := nautobotapi.CustomField{
+		Label:        "Old Label",
+		Type:         nautobotapi.CustomFieldType{Value: &typeValue},
+		ContentTypes: []string{"dcim.device"},
+	}
+	local := devicetypes.CustomFieldDefinition{
+		Key:          "my_field",
+		Label:        "New Label",
+		Type:         "text",
+		ContentTypes: []string{"dcim.device"},
+	}
+
+	err := e.reconcileCustomFieldDrift(context.Background(), cfID, remote, local)
+	if err != nil {
+		t.Fatalf("reconcileCustomFieldDrift() error = %v", err)
+	}
+	if patchCalls != 1 {
+		t.Errorf("expected 1 PATCH call, got %d", patchCalls)
+	}
+}
+
+func TestReconcileCustomFieldDrift_SkipsWhenIdentical(t *testing.T) {
+	cfID := uuid.New()
+	var patchCalls int
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPatch {
+			patchCalls++
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, emptyListJSON)
+	}
+
+	e, cleanup := newExporterWithServer(t, handler)
+	defer cleanup()
+	e.Options.Merge = true
+
+	typeValue := nautobotapi.CustomFieldTypeValue("text")
+	remote := nautobotapi.CustomField{
+		Label:        "My Field",
+		Type:         nautobotapi.CustomFieldType{Value: &typeValue},
+		ContentTypes: []string{"dcim.device"},
+	}
+	local := devicetypes.CustomFieldDefinition{
+		Key:          "my_field",
+		Label:        "My Field",
+		Type:         "text",
+		ContentTypes: []string{"dcim.device"},
+	}
+
+	err := e.reconcileCustomFieldDrift(context.Background(), cfID, remote, local)
+	if err != nil {
+		t.Fatalf("reconcileCustomFieldDrift() error = %v", err)
+	}
+	if patchCalls != 0 {
+		t.Errorf("expected 0 PATCH calls for identical fields, got %d", patchCalls)
+	}
+}
+
+func TestReconcileCustomFieldDrift_DryRunDoesNotPatch(t *testing.T) {
+	cfID := uuid.New()
+	var patchCalls int
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPatch {
+			patchCalls++
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, emptyListJSON)
+	}
+
+	e, cleanup := newExporterWithServer(t, handler)
+	defer cleanup()
+	e.Options.Merge = true
+	e.Options.DryRun = true
+
+	typeValue := nautobotapi.CustomFieldTypeValue("text")
+	remote := nautobotapi.CustomField{
+		Label:        "Old",
+		Type:         nautobotapi.CustomFieldType{Value: &typeValue},
+		ContentTypes: []string{"dcim.device"},
+	}
+	local := devicetypes.CustomFieldDefinition{
+		Key:          "my_field",
+		Label:        "New",
+		Type:         "text",
+		ContentTypes: []string{"dcim.device"},
+	}
+
+	err := e.reconcileCustomFieldDrift(context.Background(), cfID, remote, local)
+	if err != nil {
+		t.Fatalf("reconcileCustomFieldDrift() error = %v", err)
+	}
+	if patchCalls != 0 {
+		t.Errorf("dry-run should not PATCH, got %d calls", patchCalls)
+	}
+}
+
+func TestReconcileCustomFieldDrift_DetectsContentTypeDrift(t *testing.T) {
+	cfID := uuid.New()
+	var patchCalls int
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPatch {
+			patchCalls++
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{}`)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, emptyListJSON)
+	}
+
+	e, cleanup := newExporterWithServer(t, handler)
+	defer cleanup()
+	e.Options.Merge = true
+
+	typeValue := nautobotapi.CustomFieldTypeValue("text")
+	remote := nautobotapi.CustomField{
+		Label:        "Field",
+		Type:         nautobotapi.CustomFieldType{Value: &typeValue},
+		ContentTypes: []string{"dcim.device"},
+	}
+	local := devicetypes.CustomFieldDefinition{
+		Key:          "field",
+		Label:        "Field",
+		Type:         "text",
+		ContentTypes: []string{"dcim.device", "dcim.rack"},
+	}
+
+	err := e.reconcileCustomFieldDrift(context.Background(), cfID, remote, local)
+	if err != nil {
+		t.Fatalf("reconcileCustomFieldDrift() error = %v", err)
+	}
+	if patchCalls != 1 {
+		t.Errorf("expected 1 PATCH for content type drift, got %d", patchCalls)
+	}
+}
+
+func TestReconcileCustomFieldDrift_DetectsWeightDrift(t *testing.T) {
+	cfID := uuid.New()
+	var patchCalls int
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPatch {
+			patchCalls++
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{}`)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, emptyListJSON)
+	}
+
+	e, cleanup := newExporterWithServer(t, handler)
+	defer cleanup()
+	e.Options.Merge = true
+
+	typeValue := nautobotapi.CustomFieldTypeValue("integer")
+	remoteWeight := 100
+	remote := nautobotapi.CustomField{
+		Label:        "Priority",
+		Type:         nautobotapi.CustomFieldType{Value: &typeValue},
+		ContentTypes: []string{"dcim.device"},
+		Weight:       &remoteWeight,
+	}
+	local := devicetypes.CustomFieldDefinition{
+		Key:          "priority",
+		Label:        "Priority",
+		Type:         "integer",
+		ContentTypes: []string{"dcim.device"},
+		Weight:       200,
+	}
+
+	err := e.reconcileCustomFieldDrift(context.Background(), cfID, remote, local)
+	if err != nil {
+		t.Fatalf("reconcileCustomFieldDrift() error = %v", err)
+	}
+	if patchCalls != 1 {
+		t.Errorf("expected 1 PATCH for weight drift, got %d", patchCalls)
+	}
+}

--- a/pkg/provider/nautobot/export/diff.go
+++ b/pkg/provider/nautobot/export/diff.go
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2023-2024, 2026 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),
@@ -26,8 +26,8 @@
 package export
 
 import (
-	"context"
 	"fmt"
+	"sort"
 	"strconv"
 
 	"github.com/Cray-HPE/cani/pkg/devicetypes"
@@ -45,6 +45,14 @@ type FieldDiff struct {
 // compareDeviceFields compares the local device intent against the existing
 // Nautobot device and returns a list of fields that would change.
 // It resolves UUIDs to human-readable names via the mapper and cache.
+// refFieldSpec drives the table-driven comparison of UUID-referenced fields.
+type refFieldSpec struct {
+	field    string                                                                  // diff field name
+	cache    string                                                                  // cache category for reverse lookup
+	resolve  func(*devicetypes.CaniDeviceType, *DeviceMapper) *CachedItem            // resolve local intent
+	remoteID func(*nautobotapi.Device) *nautobotapi.BulkWritableCableRequestStatusId // extract remote ref
+}
+
 func compareDeviceFields(
 	device *devicetypes.CaniDeviceType,
 	remote *nautobotapi.Device,
@@ -52,88 +60,71 @@ func compareDeviceFields(
 ) []FieldDiff {
 	var diffs []FieldDiff
 
-	// Compare device type
-	if dt := resolveLocalDeviceType(device, mapper); dt != nil {
-		if remoteID := refID(remote.DeviceType.Id); remoteID != dt.ID {
-			remoteName := mapper.cache.FindNameByID("deviceType", remoteID)
-			diffs = append(diffs, FieldDiff{
-				Field:     "device_type",
-				LocalVal:  dt.Name,
-				RemoteVal: remoteName,
-			})
+	// Table-driven comparison for UUID-referenced fields.
+	refFields := []refFieldSpec{
+		{"device_type", "deviceType", resolveLocalDeviceType, func(d *nautobotapi.Device) *nautobotapi.BulkWritableCableRequestStatusId { return d.DeviceType.Id }},
+		{"location", "location", resolveLocalLocation, func(d *nautobotapi.Device) *nautobotapi.BulkWritableCableRequestStatusId { return d.Location.Id }},
+		{"status", "status", resolveLocalStatus, func(d *nautobotapi.Device) *nautobotapi.BulkWritableCableRequestStatusId { return d.Status.Id }},
+		{"role", "role", resolveLocalRole, func(d *nautobotapi.Device) *nautobotapi.BulkWritableCableRequestStatusId { return d.Role.Id }},
+	}
+	for _, spec := range refFields {
+		if local := spec.resolve(device, mapper); local != nil {
+			if remoteID := refID(spec.remoteID(remote)); remoteID != local.ID {
+				diffs = append(diffs, FieldDiff{
+					Field:     spec.field,
+					LocalVal:  local.Name,
+					RemoteVal: mapper.cache.FindNameByID(spec.cache, remoteID),
+				})
+			}
 		}
 	}
 
-	// Compare location
-	if loc := resolveLocalLocation(device, mapper); loc != nil {
-		if remoteID := refID(remote.Location.Id); remoteID != loc.ID {
-			remoteName := mapper.cache.FindNameByID("location", remoteID)
-			diffs = append(diffs, FieldDiff{
-				Field:     "location",
-				LocalVal:  loc.Name,
-				RemoteVal: remoteName,
-			})
-		}
-	}
-
-	// Compare status
-	if st := resolveLocalStatus(device, mapper); st != nil {
-		if remoteID := refID(remote.Status.Id); remoteID != st.ID {
-			remoteName := mapper.cache.FindNameByID("status", remoteID)
-			diffs = append(diffs, FieldDiff{
-				Field:     "status",
-				LocalVal:  st.Name,
-				RemoteVal: remoteName,
-			})
-		}
-	}
-
-	// Compare role
-	if rl := resolveLocalRole(device, mapper); rl != nil {
-		if remoteID := refID(remote.Role.Id); remoteID != rl.ID {
-			remoteName := mapper.cache.FindNameByID("role", remoteID)
-			diffs = append(diffs, FieldDiff{
-				Field:     "role",
-				LocalVal:  rl.Name,
-				RemoteVal: remoteName,
-			})
-		}
-	}
-
-	// Compare rack
 	diffs = append(diffs, compareRack(device, remote, mapper)...)
-
-	// Compare position
 	diffs = append(diffs, comparePosition(device, remote)...)
-
-	// Compare face
 	diffs = append(diffs, compareFace(device, remote)...)
-
-	// Compare serial
-	if device.Serial != "" {
-		remoteSerial := ptrStr(remote.Serial)
-		if device.Serial != remoteSerial {
-			diffs = append(diffs, FieldDiff{
-				Field:     "serial",
-				LocalVal:  device.Serial,
-				RemoteVal: remoteSerial,
-			})
-		}
-	}
-
-	// Compare asset tag
-	if device.AssetTag != "" {
-		remoteAsset := ptrStr(remote.AssetTag)
-		if device.AssetTag != remoteAsset {
-			diffs = append(diffs, FieldDiff{
-				Field:     "asset_tag",
-				LocalVal:  device.AssetTag,
-				RemoteVal: remoteAsset,
-			})
-		}
-	}
+	diffs = append(diffs, compareScalarFields(device, remote)...)
+	diffs = append(diffs, compareCustomFields(device.FlattenProviderMetadata(), remote.CustomFields)...)
 
 	return diffs
+}
+
+// compareCustomFields compares local custom field values against the remote
+// object's custom_fields map, returning diffs for changed or new values.
+func compareCustomFields(local map[string]any, remote *map[string]interface{}) []FieldDiff {
+	if len(local) == 0 {
+		return nil
+	}
+	remoteMap := map[string]interface{}{}
+	if remote != nil {
+		remoteMap = *remote
+	}
+	var diffs []FieldDiff
+	for _, k := range sortedMapKeys(local) {
+		localStr := fmt.Sprintf("%v", local[k])
+		remoteVal, exists := remoteMap[k]
+		remoteStr := ""
+		if exists {
+			remoteStr = fmt.Sprintf("%v", remoteVal)
+		}
+		if localStr != remoteStr {
+			diffs = append(diffs, FieldDiff{
+				Field:     "custom_field:" + k,
+				LocalVal:  localStr,
+				RemoteVal: orNone(remoteStr),
+			})
+		}
+	}
+	return diffs
+}
+
+// sortedMapKeys returns the keys of a map in sorted order.
+func sortedMapKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // resolveLocalDeviceType resolves the device type from the mapper, ignoring errors.
@@ -170,6 +161,29 @@ func resolveLocalRole(device *devicetypes.CaniDeviceType, mapper *DeviceMapper) 
 		return nil
 	}
 	return item
+}
+
+// compareScalarFields compares simple string fields (serial, asset_tag).
+func compareScalarFields(device *devicetypes.CaniDeviceType, remote *nautobotapi.Device) []FieldDiff {
+	type scalarSpec struct {
+		field    string
+		local    string
+		remoteFn func() string
+	}
+	specs := []scalarSpec{
+		{"serial", device.Serial, func() string { return ptrStr(remote.Serial) }},
+		{"asset_tag", device.AssetTag, func() string { return ptrStr(remote.AssetTag) }},
+	}
+	var diffs []FieldDiff
+	for _, s := range specs {
+		if s.local == "" {
+			continue
+		}
+		if rv := s.remoteFn(); s.local != rv {
+			diffs = append(diffs, FieldDiff{Field: s.field, LocalVal: s.local, RemoteVal: rv})
+		}
+	}
+	return diffs
 }
 
 // compareRack compares the rack assignment between local and remote.
@@ -273,66 +287,4 @@ func refID(id *nautobotapi.BulkWritableCableRequestStatusId) uuid.UUID {
 // in BulkWritableCircuitRequestTenant references.
 func tenantRefID(id *nautobotapi.BulkWritableCableRequestStatusId) uuid.UUID {
 	return refID(id)
-}
-
-// fetchFullDeviceByID retrieves the full Device object from the Nautobot API by UUID.
-// This avoids ambiguity when multiple devices share the same name.
-func (e *Exporter) fetchFullDeviceByID(ctx context.Context, id uuid.UUID) (*nautobotapi.Device, error) {
-	resp, err := e.Client.DcimDevicesRetrieveWithResponse(ctx, id, &nautobotapi.DcimDevicesRetrieveParams{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch device %s: %w", id, err)
-	}
-	if resp.StatusCode() != 200 {
-		return nil, fmt.Errorf("failed to fetch device %s: status %d", id, resp.StatusCode())
-	}
-	if resp.JSON200 == nil {
-		return nil, fmt.Errorf("device %s not found", id)
-	}
-	return resp.JSON200, nil
-}
-
-// ptrStr dereferences a *string, returning "" for nil.
-func ptrStr(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
-}
-
-// orNone returns "(none)" when s is empty.
-func orNone(s string) string {
-	if s == "" {
-		return "(none)"
-	}
-	return s
-}
-
-// printDeviceDiffs prints the field diffs for a device using colored output.
-func printDeviceDiffs(deviceName string, diffs []FieldDiff) {
-	if len(diffs) == 0 {
-		return
-	}
-	clog.Changed("  %s: %d field(s) would change with --merge:", deviceName, len(diffs))
-	for _, d := range diffs {
-		clog.Diff(d.Field, d.RemoteVal, d.LocalVal)
-	}
-}
-
-// fetchFullDevice retrieves the full Device object from the Nautobot API by name.
-func (e *Exporter) fetchFullDevice(ctx context.Context, name string) (*nautobotapi.Device, error) {
-	nameFilter := []string{name}
-	resp, err := e.Client.DcimDevicesListWithResponse(ctx, &nautobotapi.DcimDevicesListParams{
-		Name: &nameFilter,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch full device %s: %w", name, err)
-	}
-	if resp.StatusCode() != 200 {
-		return nil, fmt.Errorf("failed to fetch full device %s: status %d", name, resp.StatusCode())
-	}
-	if resp.JSON200 == nil || resp.JSON200.Results == nil || len(resp.JSON200.Results) == 0 {
-		return nil, fmt.Errorf("device %s not found", name)
-	}
-	d := resp.JSON200.Results[0]
-	return &d, nil
 }

--- a/pkg/provider/nautobot/export/diff_custom_fields_test.go
+++ b/pkg/provider/nautobot/export/diff_custom_fields_test.go
@@ -1,0 +1,180 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package export
+
+import (
+	"testing"
+
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	nautobotapi "github.com/Cray-HPE/cani/pkg/nautobot"
+)
+
+// -----------------------------------------------------------------------------
+// compareCustomFields — pure logic
+// -----------------------------------------------------------------------------
+
+func TestCompareCustomFields_DetectsChangedValue(t *testing.T) {
+	local := map[string]any{"tier": "gold"}
+	remote := map[string]interface{}{"tier": "silver"}
+	diffs := compareCustomFields(local, &remote)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if diffs[0].Field != "custom_field:tier" {
+		t.Errorf("Field = %q, want custom_field:tier", diffs[0].Field)
+	}
+	if diffs[0].LocalVal != "gold" || diffs[0].RemoteVal != "silver" {
+		t.Errorf("values = %q/%q, want gold/silver", diffs[0].LocalVal, diffs[0].RemoteVal)
+	}
+}
+
+func TestCompareCustomFields_DetectsNewKey(t *testing.T) {
+	local := map[string]any{"env": "prod"}
+	remote := map[string]interface{}{}
+	diffs := compareCustomFields(local, &remote)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if diffs[0].RemoteVal != "(none)" {
+		t.Errorf("RemoteVal = %q, want (none)", diffs[0].RemoteVal)
+	}
+}
+
+func TestCompareCustomFields_NoDiffWhenEqual(t *testing.T) {
+	local := map[string]any{"tier": "gold", "env": "prod"}
+	remote := map[string]interface{}{"tier": "gold", "env": "prod"}
+	diffs := compareCustomFields(local, &remote)
+	if len(diffs) != 0 {
+		t.Errorf("expected 0 diffs, got %d: %v", len(diffs), diffs)
+	}
+}
+
+func TestCompareCustomFields_NilRemote(t *testing.T) {
+	local := map[string]any{"tier": "gold"}
+	diffs := compareCustomFields(local, nil)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff for nil remote, got %d", len(diffs))
+	}
+}
+
+func TestCompareCustomFields_EmptyLocal(t *testing.T) {
+	remote := map[string]interface{}{"tier": "gold"}
+	diffs := compareCustomFields(nil, &remote)
+	if diffs != nil {
+		t.Errorf("expected nil for empty local, got %v", diffs)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// sortedMapKeys — pure logic
+// -----------------------------------------------------------------------------
+
+func TestSortedMapKeys_DeterministicOrder(t *testing.T) {
+	m := map[string]any{"z": 1, "a": 2, "m": 3}
+	keys := sortedMapKeys(m)
+	if len(keys) != 3 || keys[0] != "a" || keys[1] != "m" || keys[2] != "z" {
+		t.Errorf("sortedMapKeys = %v, want [a m z]", keys)
+	}
+}
+
+func TestSortedMapKeys_EmptyMap(t *testing.T) {
+	keys := sortedMapKeys(map[string]any{})
+	if len(keys) != 0 {
+		t.Errorf("expected empty slice, got %v", keys)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// compareDeviceFields — custom field integration
+// -----------------------------------------------------------------------------
+
+func TestCompareDeviceFields_IncludesCustomFieldDiffs(t *testing.T) {
+	device := &devicetypes.CaniDeviceType{
+		ObjectMeta: devicetypes.ObjectMeta{
+			ProviderMetadata: map[string]any{
+				"nautobot": map[string]any{"rack_elevation": "top"},
+			},
+		},
+	}
+
+	remoteCF := map[string]interface{}{"rack_elevation": "bottom"}
+	remote := &nautobotapi.Device{
+		DeviceType:   nautobotapi.BulkWritableCableRequestStatus{},
+		Location:     nautobotapi.BulkWritableCableRequestStatus{},
+		Status:       nautobotapi.BulkWritableCableRequestStatus{},
+		CustomFields: &remoteCF,
+	}
+
+	// Use a real mapper with empty cache so resolvers return nil (not panic)
+	var calls int
+	e, cleanup := newExporterWithServer(t, jsonHandler(&calls, 200, emptyListJSON))
+	defer cleanup()
+	mapper := NewDeviceMapper(e.Cache, &MapperOpts{})
+
+	diffs := compareDeviceFields(device, remote, mapper)
+	found := false
+	for _, d := range diffs {
+		if d.Field == "custom_field:rack_elevation" {
+			found = true
+			if d.LocalVal != "top" || d.RemoteVal != "bottom" {
+				t.Errorf("custom field diff values = %q/%q", d.LocalVal, d.RemoteVal)
+			}
+		}
+	}
+	if !found {
+		t.Error("compareDeviceFields did not include custom_field:rack_elevation diff")
+	}
+}
+
+func TestCompareDeviceFields_NoDiffWhenCustomFieldsMatch(t *testing.T) {
+	device := &devicetypes.CaniDeviceType{
+		ObjectMeta: devicetypes.ObjectMeta{
+			ProviderMetadata: map[string]any{
+				"nautobot": map[string]any{"tier": "1"},
+			},
+		},
+	}
+
+	remoteCF := map[string]interface{}{"tier": "1"}
+	remote := &nautobotapi.Device{
+		DeviceType:   nautobotapi.BulkWritableCableRequestStatus{},
+		Location:     nautobotapi.BulkWritableCableRequestStatus{},
+		Status:       nautobotapi.BulkWritableCableRequestStatus{},
+		CustomFields: &remoteCF,
+	}
+
+	var calls int
+	e, cleanup := newExporterWithServer(t, jsonHandler(&calls, 200, emptyListJSON))
+	defer cleanup()
+	mapper := NewDeviceMapper(e.Cache, &MapperOpts{})
+
+	diffs := compareDeviceFields(device, remote, mapper)
+	for _, d := range diffs {
+		if d.Field == "custom_field:tier" {
+			t.Errorf("unexpected diff for tier: %+v", d)
+		}
+	}
+}

--- a/pkg/provider/nautobot/export/diff_helpers.go
+++ b/pkg/provider/nautobot/export/diff_helpers.go
@@ -1,0 +1,128 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package export
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	nautobotapi "github.com/Cray-HPE/cani/pkg/nautobot"
+	"github.com/google/uuid"
+)
+
+// fetchFullDeviceByID retrieves the full Device object from the Nautobot API by UUID.
+func (e *Exporter) fetchFullDeviceByID(ctx context.Context, id uuid.UUID) (*nautobotapi.Device, error) {
+	resp, err := e.Client.DcimDevicesRetrieveWithResponse(ctx, id, &nautobotapi.DcimDevicesRetrieveParams{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch device %s: %w", id, err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch device %s: status %d", id, resp.StatusCode())
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("device %s not found", id)
+	}
+	return resp.JSON200, nil
+}
+
+// fetchFullDevice retrieves the full Device object from the Nautobot API by name.
+func (e *Exporter) fetchFullDevice(ctx context.Context, name string) (*nautobotapi.Device, error) {
+	nameFilter := []string{name}
+	resp, err := e.Client.DcimDevicesListWithResponse(ctx, &nautobotapi.DcimDevicesListParams{
+		Name: &nameFilter,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch full device %s: %w", name, err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch full device %s: status %d", name, resp.StatusCode())
+	}
+	if resp.JSON200 == nil || resp.JSON200.Results == nil || len(resp.JSON200.Results) == 0 {
+		return nil, fmt.Errorf("device %s not found", name)
+	}
+	d := resp.JSON200.Results[0]
+	return &d, nil
+}
+
+// ptrStr dereferences a *string, returning "" for nil.
+func ptrStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// orNone returns "(none)" when s is empty.
+func orNone(s string) string {
+	if s == "" {
+		return "(none)"
+	}
+	return s
+}
+
+// printDeviceDiffs prints the field diffs for a device using colored output.
+func printDeviceDiffs(deviceName string, diffs []FieldDiff) {
+	if len(diffs) == 0 {
+		return
+	}
+	clog.Changed("  %s: %d field(s) would change with --merge:", deviceName, len(diffs))
+	for _, d := range diffs {
+		clog.Diff(d.Field, d.RemoteVal, d.LocalVal)
+	}
+}
+
+// mergedCustomFields combines explicit custom fields and flattened provider metadata.
+func mergedCustomFields(explicit map[string]any, flat map[string]any) map[string]interface{} {
+	cf := make(map[string]interface{}, len(explicit)+len(flat))
+	for k, v := range explicit {
+		cf[k] = v
+	}
+	for k, v := range flat {
+		cf[k] = v
+	}
+	return cf
+}
+
+// customFieldsDrifted returns true if any local custom field value differs from remote.
+func customFieldsDrifted(local map[string]interface{}, remote *map[string]interface{}) bool {
+	remoteMap := map[string]interface{}{}
+	if remote != nil {
+		remoteMap = *remote
+	}
+	for k, v := range local {
+		localStr := fmt.Sprintf("%v", v)
+		remoteVal, exists := remoteMap[k]
+		remoteStr := ""
+		if exists {
+			remoteStr = fmt.Sprintf("%v", remoteVal)
+		}
+		if localStr != remoteStr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/provider/nautobot/export/export.go
+++ b/pkg/provider/nautobot/export/export.go
@@ -72,6 +72,9 @@ func PrintSummary(result *LoadResult) {
 	if len(result.LocationsCreated) > 0 {
 		clog.Created("Created locations: %d", len(result.LocationsCreated))
 	}
+	if len(result.LocationsUpdated) > 0 {
+		clog.Changed("Updated locations: %d", len(result.LocationsUpdated))
+	}
 	if len(result.LocationsSkipped) > 0 {
 		clog.Skipped("Skipped locations (already exist): %d", len(result.LocationsSkipped))
 	}
@@ -135,6 +138,9 @@ func PrintSummary(result *LoadResult) {
 
 	if result.VLANsCreated > 0 {
 		clog.Created("Created VLANs: %d", result.VLANsCreated)
+	}
+	if result.VLANsUpdated > 0 {
+		clog.Changed("Updated VLANs: %d", result.VLANsUpdated)
 	}
 	if result.VLANsSkipped > 0 {
 		clog.Skipped("Skipped VLANs (already exist): %d", result.VLANsSkipped)

--- a/pkg/provider/nautobot/export/load.go
+++ b/pkg/provider/nautobot/export/load.go
@@ -73,6 +73,7 @@ type LoadResult struct {
 	Errors                      []string       // Error messages
 	Conflicts                   []ConflictInfo // Detailed conflict information
 	LocationsCreated            []string       // Names of locations created
+	LocationsUpdated            []string       // Names of locations updated (merged)
 	LocationsSkipped            []string       // Names of locations skipped (already exist)
 	RacksCreated                []string       // Names of racks created
 	RacksSkipped                int            // Number of racks skipped (already exist)
@@ -86,6 +87,7 @@ type LoadResult struct {
 	CablesSkipped               int            // Number of cables skipped (already exist in Nautobot)
 	CablesConflicted            int            // Number of cables skipped (an endpoint interface is already cabled)
 	VLANsCreated                int            // Number of VLANs created
+	VLANsUpdated                int            // Number of VLANs updated (merged)
 	VLANsSkipped                int            // Number of VLANs skipped (already exist)
 	VRFsCreated                 int            // Number of VRFs created
 	VRFsSkipped                 int            // Number of VRFs skipped (already exist)
@@ -192,7 +194,31 @@ func setExternalID(m *map[string]uuid.UUID, provider string, id uuid.UUID) {
 	(*m)[provider] = id
 }
 
-// Load syncs the local inventory to Nautobot.
+// Load syncs the local inventory to Nautobot using a multi-phase pipeline:
+//
+//	Phase 0a  – Custom-field definitions (ensure CF schema exists before objects reference them)
+//	Phase 0b  – Locations (topological order, parents first)
+//	Phase 1   – Racks (from inventory.Racks)
+//	Phase 1b  – Racks (legacy: from inventory.Devices with rack category)
+//	Phase 2   – Devices
+//	Phase 3   – Interfaces (bulk batched)
+//	Phase 4   – Modules
+//	Phase 5   – FRUs (inventory items)
+//	Phase 6   – Cables
+//	Phase 6c  – VRFs
+//	Phase 7   – VLANs
+//	Phase 7b  – Interface enrichment (LAG, switchport mode, VLAN assignment)
+//	Phase 8   – Prefixes
+//	Phase 9   – IP Addresses
+//	Phase 10  – Relationship associations (assigned_vlans, bmc_device)
+//	Phase 11  – Primary IPs (assign to devices)
+//
+// With --merge each phase uses fetch-compare-patch: it fetches the remote
+// object, compares fields against the portable model, and PATCHes only if
+// drift is detected. Without --merge, existing objects that conflict are
+// reported but not modified. --dry-run prevents all mutations while still
+// reporting what would change.
+//
 // The caller must initialise Client, Cache (with context) and Options before calling Load.
 func (e *Exporter) Load(inventory *devicetypes.Inventory) error {
 	ctx := context.Background()
@@ -205,6 +231,7 @@ func (e *Exporter) Load(inventory *devicetypes.Inventory) error {
 		Errors:           make([]string, 0),
 		Conflicts:        make([]ConflictInfo, 0),
 		LocationsCreated: make([]string, 0),
+		LocationsUpdated: make([]string, 0),
 		LocationsSkipped: make([]string, 0),
 		RacksCreated:     make([]string, 0),
 	}
@@ -1392,6 +1419,9 @@ func (e *Exporter) printLoadSummary(result *LoadResult) {
 			clog.SummaryCreated("%s", name)
 		}
 	}
+	if len(result.LocationsUpdated) > 0 {
+		clog.Changed("Updated locations: %d", len(result.LocationsUpdated))
+	}
 	if len(result.LocationsSkipped) > 0 {
 		clog.Skipped("Skipped locations (already exist): %d", len(result.LocationsSkipped))
 	}
@@ -1469,6 +1499,9 @@ func (e *Exporter) printLoadSummary(result *LoadResult) {
 	// VLANs
 	if result.VLANsCreated > 0 {
 		clog.Created("Created VLANs: %d", result.VLANsCreated)
+	}
+	if result.VLANsUpdated > 0 {
+		clog.Changed("Updated VLANs: %d", result.VLANsUpdated)
 	}
 	if result.VLANsSkipped > 0 {
 		clog.Skipped("Skipped VLANs (already exist): %d", result.VLANsSkipped)

--- a/pkg/provider/nautobot/export/load_locations.go
+++ b/pkg/provider/nautobot/export/load_locations.go
@@ -65,6 +65,17 @@ func (e *Exporter) loadLocations(
 		if err == nil && existing != nil {
 			created[loc.ID] = existing.ID
 			setExternalID(&loc.ExternalIDs, "nautobot", existing.ID)
+
+			if e.Options.Merge {
+				if updated, mergeErr := e.mergeLocation(ctx, loc, existing.ID); mergeErr != nil {
+					result.Errors = append(result.Errors,
+						fmt.Sprintf("location %s: merge error: %v", loc.Name, mergeErr))
+				} else if updated {
+					result.LocationsUpdated = append(result.LocationsUpdated, loc.Name)
+					continue
+				}
+			}
+
 			result.LocationsSkipped = append(result.LocationsSkipped, loc.Name)
 			clog.Skipped("Skipped location (already exists): %s", loc.Name)
 			continue

--- a/pkg/provider/nautobot/export/load_locations_merge.go
+++ b/pkg/provider/nautobot/export/load_locations_merge.go
@@ -1,0 +1,118 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package export
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	nautobotapi "github.com/Cray-HPE/cani/pkg/nautobot"
+	"github.com/google/uuid"
+)
+
+// mergeLocation fetches the remote location, compares against local intent,
+// and PATCHes any drifted fields. Returns true if the location was updated.
+func (e *Exporter) mergeLocation(ctx context.Context, loc *devicetypes.CaniLocationType, nautobotID uuid.UUID) (bool, error) {
+	remote, err := e.fetchLocationByID(ctx, nautobotID)
+	if err != nil {
+		return false, err
+	}
+
+	req, drifted := buildLocationPatch(loc, remote)
+	if !drifted {
+		return false, nil
+	}
+
+	if e.Options.DryRun {
+		clog.DryRun("Would merge location: %s", loc.Name)
+		return true, nil
+	}
+
+	resp, err := e.Client.DcimLocationsPartialUpdateWithResponse(ctx, nautobotID,
+		&nautobotapi.DcimLocationsPartialUpdateParams{}, *req)
+	if err != nil {
+		return false, fmt.Errorf("API error: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return false, fmt.Errorf("unexpected status %d: %s", resp.StatusCode(), string(resp.Body))
+	}
+	clog.Changed("Merged location: %s", loc.Name)
+	return true, nil
+}
+
+// fetchLocationByID retrieves a full Location from Nautobot by UUID.
+func (e *Exporter) fetchLocationByID(ctx context.Context, id uuid.UUID) (*nautobotapi.Location, error) {
+	resp, err := e.Client.DcimLocationsRetrieveWithResponse(ctx, id, &nautobotapi.DcimLocationsRetrieveParams{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch location %s: %w", id, err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch location %s: status %d", id, resp.StatusCode())
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("location %s not found", id)
+	}
+	return resp.JSON200, nil
+}
+
+// buildLocationPatch compares local location intent against the remote state
+// and returns a PATCH request with drifted fields.
+func buildLocationPatch(loc *devicetypes.CaniLocationType, remote *nautobotapi.Location) (*nautobotapi.PatchedLocationRequest, bool) {
+	req := &nautobotapi.PatchedLocationRequest{}
+	drifted := false
+
+	drifted = driftStr(loc.Description, remote.Description, &req.Description) || drifted
+	drifted = driftStr(loc.Facility, remote.Facility, &req.Facility) || drifted
+	drifted = driftStr(loc.PhysicalAddress, remote.PhysicalAddress, &req.PhysicalAddress) || drifted
+	drifted = driftStr(loc.ShippingAddress, remote.ShippingAddress, &req.ShippingAddress) || drifted
+	drifted = driftStr(loc.ContactName, remote.ContactName, &req.ContactName) || drifted
+	drifted = driftStr(loc.ContactPhone, remote.ContactPhone, &req.ContactPhone) || drifted
+	drifted = driftStr(loc.ContactEmail, remote.ContactEmail, &req.ContactEmail) || drifted
+	drifted = driftStr(loc.TimeZone, remote.TimeZone, &req.TimeZone) || drifted
+	drifted = driftStr(loc.Latitude, remote.Latitude, &req.Latitude) || drifted
+	drifted = driftStr(loc.Longitude, remote.Longitude, &req.Longitude) || drifted
+	drifted = driftStr(loc.Comments, remote.Comments, &req.Comments) || drifted
+
+	// Compare custom fields (explicit + flattened provider metadata)
+	localCF := mergedCustomFields(loc.CustomFields, loc.FlattenProviderMetadata())
+	if len(localCF) > 0 && customFieldsDrifted(localCF, remote.CustomFields) {
+		req.CustomFields = &localCF
+		drifted = true
+	}
+
+	return req, drifted
+}
+
+// driftStr sets target when local differs from remote (including clearing).
+func driftStr(local string, remote *string, target **string) bool {
+	if local != ptrStr(remote) {
+		*target = &local
+		return true
+	}
+	return false
+}

--- a/pkg/provider/nautobot/export/load_primary_ips.go
+++ b/pkg/provider/nautobot/export/load_primary_ips.go
@@ -88,6 +88,13 @@ func (e *Exporter) loadPrimaryIPs(ctx context.Context, inventory *devicetypes.In
 			continue
 		}
 
+		// Compare against remote state to skip redundant PATCHes.
+		if remote, err := e.fetchFullDeviceByID(ctx, deviceNautobotID); err == nil {
+			if primaryIPsMatch(payload, remote) {
+				continue
+			}
+		}
+
 		if e.Options.DryRun {
 			clog.DryRun("Would set primary IP on device: %s", device.Name)
 			continue
@@ -119,4 +126,30 @@ func (e *Exporter) loadPrimaryIPs(ctx context.Context, inventory *devicetypes.In
 		return fmt.Errorf("%d primary IP error(s): %s", len(errs), errs[0])
 	}
 	return nil
+}
+
+// primaryIPsMatch returns true when the remote device already has the same
+// primary IP assignments the payload would set.
+func primaryIPsMatch(payload map[string]any, remote *nautobotapi.Device) bool {
+	if v, ok := payload["primary_ip4"]; ok {
+		localID := v.(map[string]string)["id"]
+		remoteID := uuid.Nil
+		if remote.PrimaryIp4 != nil {
+			remoteID = refID(remote.PrimaryIp4.Id)
+		}
+		if localID != remoteID.String() {
+			return false
+		}
+	}
+	if v, ok := payload["primary_ip6"]; ok {
+		localID := v.(map[string]string)["id"]
+		remoteID := uuid.Nil
+		if remote.PrimaryIp6 != nil {
+			remoteID = refID(remote.PrimaryIp6.Id)
+		}
+		if localID != remoteID.String() {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/provider/nautobot/export/load_primary_ips_http_test.go
+++ b/pkg/provider/nautobot/export/load_primary_ips_http_test.go
@@ -1,0 +1,140 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package export
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	"github.com/google/uuid"
+)
+
+func TestLoadPrimaryIPs_SkipsWhenAlreadySet(t *testing.T) {
+	deviceID := uuid.New()
+	ipID := uuid.New()
+	nautobotDev := uuid.New()
+	nautobotIP := uuid.New()
+
+	var patchCalls int
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		// GET device retrieve — return device with matching primary_ip4
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "dcim/devices/"+nautobotDev.String()) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"id":%q,"name":"sw1","primary_ip4":{"id":%q},"device_type":{"id":%q},"location":{"id":%q},"status":{"id":%q}}`,
+				nautobotDev, nautobotIP, uuid.New(), uuid.New(), uuid.New())
+			return
+		}
+		if r.Method == http.MethodPatch {
+			patchCalls++
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}
+
+	e, cleanup := newExporterWithServer(t, handler)
+	defer cleanup()
+
+	inv := devicetypes.NewInventory()
+	inv.Devices = map[uuid.UUID]*devicetypes.CaniDeviceType{
+		deviceID: {
+			Name:        "sw1",
+			PrimaryIPv4: ipID,
+			ObjectMeta:  devicetypes.ObjectMeta{ExternalIDs: map[string]uuid.UUID{"nautobot": nautobotDev}},
+		},
+	}
+	inv.IPAddresses = map[uuid.UUID]*devicetypes.CaniIPAddress{
+		ipID: {ID: ipID, ObjectMeta: devicetypes.ObjectMeta{ExternalIDs: map[string]uuid.UUID{"nautobot": nautobotIP}}},
+	}
+
+	err := e.loadPrimaryIPs(context.Background(), inv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if patchCalls != 0 {
+		t.Errorf("expected 0 PATCH calls (already set), got %d", patchCalls)
+	}
+}
+
+func TestLoadPrimaryIPs_DryRunDoesNotPatch(t *testing.T) {
+	deviceID := uuid.New()
+	ipID := uuid.New()
+	nautobotDev := uuid.New()
+	nautobotIP := uuid.New()
+
+	var patchCalls int
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		// GET device retrieve — return device with no primary IP set
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "dcim/devices/"+nautobotDev.String()) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"id":%q,"name":"sw1","device_type":{"id":%q},"location":{"id":%q},"status":{"id":%q}}`,
+				nautobotDev, uuid.New(), uuid.New(), uuid.New())
+			return
+		}
+		if r.Method == http.MethodPatch {
+			patchCalls++
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}
+
+	e, cleanup := newExporterWithServer(t, handler)
+	defer cleanup()
+	e.Options.DryRun = true
+
+	inv := devicetypes.NewInventory()
+	inv.Devices = map[uuid.UUID]*devicetypes.CaniDeviceType{
+		deviceID: {
+			Name:        "sw1",
+			PrimaryIPv4: ipID,
+			ObjectMeta:  devicetypes.ObjectMeta{ExternalIDs: map[string]uuid.UUID{"nautobot": nautobotDev}},
+		},
+	}
+	inv.IPAddresses = map[uuid.UUID]*devicetypes.CaniIPAddress{
+		ipID: {ID: ipID, ObjectMeta: devicetypes.ObjectMeta{ExternalIDs: map[string]uuid.UUID{"nautobot": nautobotIP}}},
+	}
+
+	err := e.loadPrimaryIPs(context.Background(), inv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if patchCalls != 0 {
+		t.Errorf("dry-run should issue 0 PATCH calls, got %d", patchCalls)
+	}
+}

--- a/pkg/provider/nautobot/export/load_primary_ips_test.go
+++ b/pkg/provider/nautobot/export/load_primary_ips_test.go
@@ -33,6 +33,7 @@ import (
 	"testing"
 
 	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	nautobotapi "github.com/Cray-HPE/cani/pkg/nautobot"
 	"github.com/google/uuid"
 )
 
@@ -139,5 +140,66 @@ func TestLoadPrimaryIPs_IndependentFamilyResolution(t *testing.T) {
 	}
 	if patchCount != 1 {
 		t.Errorf("expected 1 patch (IPv4 only), got %d", patchCount)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// primaryIPsMatch — pure logic
+// -----------------------------------------------------------------------------
+
+func makePrimaryIPRef(id uuid.UUID) *nautobotapi.PrimaryIPv4 {
+	var union nautobotapi.BulkWritableCableRequestStatusId
+	union.FromBulkWritableCableRequestStatusId0(id)
+	return &nautobotapi.PrimaryIPv4{Id: &union}
+}
+
+func TestPrimaryIPsMatch_TrueWhenSameIPv4(t *testing.T) {
+	ipID := uuid.New()
+	payload := map[string]any{"primary_ip4": map[string]string{"id": ipID.String()}}
+	remote := &nautobotapi.Device{
+		PrimaryIp4: makePrimaryIPRef(ipID),
+		DeviceType: nautobotapi.BulkWritableCableRequestStatus{},
+		Location:   nautobotapi.BulkWritableCableRequestStatus{},
+		Status:     nautobotapi.BulkWritableCableRequestStatus{},
+	}
+	if !primaryIPsMatch(payload, remote) {
+		t.Error("expected match when IPv4 IDs are the same")
+	}
+}
+
+func TestPrimaryIPsMatch_FalseWhenDifferentIPv4(t *testing.T) {
+	payload := map[string]any{"primary_ip4": map[string]string{"id": uuid.New().String()}}
+	remote := &nautobotapi.Device{
+		PrimaryIp4: makePrimaryIPRef(uuid.New()),
+		DeviceType: nautobotapi.BulkWritableCableRequestStatus{},
+		Location:   nautobotapi.BulkWritableCableRequestStatus{},
+		Status:     nautobotapi.BulkWritableCableRequestStatus{},
+	}
+	if primaryIPsMatch(payload, remote) {
+		t.Error("expected mismatch when IPv4 IDs differ")
+	}
+}
+
+func TestPrimaryIPsMatch_FalseWhenRemoteHasNoIPv4(t *testing.T) {
+	payload := map[string]any{"primary_ip4": map[string]string{"id": uuid.New().String()}}
+	remote := &nautobotapi.Device{
+		DeviceType: nautobotapi.BulkWritableCableRequestStatus{},
+		Location:   nautobotapi.BulkWritableCableRequestStatus{},
+		Status:     nautobotapi.BulkWritableCableRequestStatus{},
+	}
+	if primaryIPsMatch(payload, remote) {
+		t.Error("expected mismatch when remote has no primary IPv4")
+	}
+}
+
+func TestPrimaryIPsMatch_TrueWhenNoIPInPayload(t *testing.T) {
+	remote := &nautobotapi.Device{
+		PrimaryIp4: makePrimaryIPRef(uuid.New()),
+		DeviceType: nautobotapi.BulkWritableCableRequestStatus{},
+		Location:   nautobotapi.BulkWritableCableRequestStatus{},
+		Status:     nautobotapi.BulkWritableCableRequestStatus{},
+	}
+	if !primaryIPsMatch(map[string]any{}, remote) {
+		t.Error("empty payload should match anything")
 	}
 }

--- a/pkg/provider/nautobot/export/load_vlans.go
+++ b/pkg/provider/nautobot/export/load_vlans.go
@@ -73,6 +73,17 @@ func (e *Exporter) loadVLANs(
 		if existing != nil {
 			created[vlan.ID] = existing.ID
 			setExternalID(&vlan.ExternalIDs, "nautobot", existing.ID)
+
+			if e.Options.Merge {
+				if updated, mergeErr := e.mergeVLAN(ctx, vlan, existing.ID); mergeErr != nil {
+					result.Errors = append(result.Errors,
+						fmt.Sprintf("vlan %d (%s): merge error: %v", vlan.VID, vlan.Name, mergeErr))
+				} else if updated {
+					result.VLANsUpdated++
+					continue
+				}
+			}
+
 			result.VLANsSkipped++
 			continue
 		}

--- a/pkg/provider/nautobot/export/load_vlans_merge.go
+++ b/pkg/provider/nautobot/export/load_vlans_merge.go
@@ -1,0 +1,106 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package export
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	nautobotapi "github.com/Cray-HPE/cani/pkg/nautobot"
+	"github.com/google/uuid"
+)
+
+// mergeVLAN fetches the remote VLAN, compares against local intent,
+// and PATCHes any drifted fields. Returns true if the VLAN was updated.
+func (e *Exporter) mergeVLAN(ctx context.Context, vlan *devicetypes.CaniVLAN, nautobotID uuid.UUID) (bool, error) {
+	remote, err := e.fetchVLANByID(ctx, nautobotID)
+	if err != nil {
+		return false, err
+	}
+
+	req, drifted := buildVLANPatch(vlan, remote)
+	if !drifted {
+		return false, nil
+	}
+
+	if e.Options.DryRun {
+		clog.DryRun("Would merge VLAN %d: %s", vlan.VID, vlan.Name)
+		return true, nil
+	}
+
+	resp, err := e.Client.IpamVlansPartialUpdateWithResponse(ctx, nautobotID,
+		&nautobotapi.IpamVlansPartialUpdateParams{}, *req)
+	if err != nil {
+		return false, fmt.Errorf("API error: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return false, fmt.Errorf("unexpected status %d: %s", resp.StatusCode(), string(resp.Body))
+	}
+	clog.Changed("Merged VLAN %d: %s", vlan.VID, vlan.Name)
+	return true, nil
+}
+
+// fetchVLANByID retrieves a full VLAN from Nautobot by UUID.
+func (e *Exporter) fetchVLANByID(ctx context.Context, id uuid.UUID) (*nautobotapi.VLAN, error) {
+	resp, err := e.Client.IpamVlansRetrieveWithResponse(ctx, id, &nautobotapi.IpamVlansRetrieveParams{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch VLAN %s: %w", id, err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch VLAN %s: status %d", id, resp.StatusCode())
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("VLAN %s not found", id)
+	}
+	return resp.JSON200, nil
+}
+
+// buildVLANPatch compares local VLAN intent against the remote state
+// and returns a PATCH request with drifted fields.
+func buildVLANPatch(vlan *devicetypes.CaniVLAN, remote *nautobotapi.VLAN) (*nautobotapi.PatchedVLANRequest, bool) {
+	req := &nautobotapi.PatchedVLANRequest{}
+	drifted := false
+
+	if vlan.Name != remote.Name {
+		req.Name = &vlan.Name
+		drifted = true
+	}
+	if vlan.Description != "" && vlan.Description != ptrStr(remote.Description) {
+		req.Description = &vlan.Description
+		drifted = true
+	}
+
+	// Compare custom fields (explicit + flattened provider metadata)
+	localCF := mergedCustomFields(vlan.CustomFields, vlan.FlattenProviderMetadata())
+	if len(localCF) > 0 && customFieldsDrifted(localCF, remote.CustomFields) {
+		req.CustomFields = &localCF
+		drifted = true
+	}
+
+	return req, drifted
+}

--- a/pkg/provider/nautobot/export/lookup_custom_fields.go
+++ b/pkg/provider/nautobot/export/lookup_custom_fields.go
@@ -86,6 +86,11 @@ func (e *Exporter) ensureCustomField(ctx context.Context, def devicetypes.Custom
 		for _, cf := range resp.JSON200.Results {
 			if cf.Key != nil && *cf.Key == def.Key {
 				id := toUUID(cf.Id)
+				if e.Options.Merge {
+					if err := e.reconcileCustomFieldDrift(ctx, id, cf, def); err != nil {
+						return id, fmt.Errorf("drift reconciliation: %w", err)
+					}
+				}
 				clog.Skipped("Custom field %q already exists (ID: %s)", def.Key, id)
 				return id, nil
 			}

--- a/pkg/provider/nautobot/export/merge_location_http_test.go
+++ b/pkg/provider/nautobot/export/merge_location_http_test.go
@@ -1,0 +1,289 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package export
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	"github.com/google/uuid"
+)
+
+// locationMergeHandler simulates Nautobot for the merge flow:
+// GET /dcim/locations/{id}/ returns a location with old values,
+// PATCH /dcim/locations/{id}/ accepts the merge.
+func locationMergeHandler(locID uuid.UUID, remoteJSON string, patchCalls *int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "dcim/locations/"+locID.String()) {
+			if r.Method == http.MethodPatch {
+				*patchCalls++
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, `{}`)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, remoteJSON)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, emptyListJSON)
+	}
+}
+
+func TestMergeLocation_PatchesWhenDrifted(t *testing.T) {
+	locID := uuid.New()
+	remoteJSON := fmt.Sprintf(`{"id":%q,"name":"DC1","description":"old","location_type":{"id":"%s"},"status":{"id":"%s"}}`,
+		locID, uuid.New(), uuid.New())
+	var patchCalls int
+	e, cleanup := newExporterWithServer(t, locationMergeHandler(locID, remoteJSON, &patchCalls))
+	defer cleanup()
+	e.Options.Merge = true
+
+	loc := &devicetypes.CaniLocationType{
+		ID:          uuid.New(),
+		Name:        "DC1",
+		Description: "new",
+	}
+
+	updated, err := e.mergeLocation(context.Background(), loc, locID)
+	if err != nil {
+		t.Fatalf("mergeLocation() error = %v", err)
+	}
+	if !updated {
+		t.Error("expected updated=true when description drifted")
+	}
+	if patchCalls != 1 {
+		t.Errorf("expected 1 PATCH, got %d", patchCalls)
+	}
+}
+
+func TestMergeLocation_SkipsWhenNoDrift(t *testing.T) {
+	locID := uuid.New()
+	remoteJSON := fmt.Sprintf(`{"id":%q,"name":"DC1","location_type":{"id":"%s"},"status":{"id":"%s"}}`,
+		locID, uuid.New(), uuid.New())
+	var patchCalls int
+	e, cleanup := newExporterWithServer(t, locationMergeHandler(locID, remoteJSON, &patchCalls))
+	defer cleanup()
+	e.Options.Merge = true
+
+	loc := &devicetypes.CaniLocationType{
+		ID:   uuid.New(),
+		Name: "DC1",
+	}
+
+	updated, err := e.mergeLocation(context.Background(), loc, locID)
+	if err != nil {
+		t.Fatalf("mergeLocation() error = %v", err)
+	}
+	if updated {
+		t.Error("expected updated=false when no drift")
+	}
+	if patchCalls != 0 {
+		t.Errorf("expected 0 PATCH calls, got %d", patchCalls)
+	}
+}
+
+func TestMergeLocation_DryRunDoesNotPatch(t *testing.T) {
+	locID := uuid.New()
+	remoteJSON := fmt.Sprintf(`{"id":%q,"name":"DC1","description":"old","location_type":{"id":"%s"},"status":{"id":"%s"}}`,
+		locID, uuid.New(), uuid.New())
+	var patchCalls int
+	e, cleanup := newExporterWithServer(t, locationMergeHandler(locID, remoteJSON, &patchCalls))
+	defer cleanup()
+	e.Options.Merge = true
+	e.Options.DryRun = true
+
+	loc := &devicetypes.CaniLocationType{
+		ID:          uuid.New(),
+		Name:        "DC1",
+		Description: "new",
+	}
+
+	updated, err := e.mergeLocation(context.Background(), loc, locID)
+	if err != nil {
+		t.Fatalf("mergeLocation() error = %v", err)
+	}
+	if !updated {
+		t.Error("dry-run should still report updated=true")
+	}
+	if patchCalls != 0 {
+		t.Errorf("dry-run should not PATCH, got %d", patchCalls)
+	}
+}
+
+// loadLocationsHandler handles the full loadLocations flow: the location lookup
+// (returns existing), the retrieve (returns remote state), and the PATCH.
+func loadLocationsHandler(locID uuid.UUID, existingJSON, retrieveJSON string, patchCalls *int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "dcim/locations/"+locID.String()):
+			if r.Method == http.MethodPatch {
+				*patchCalls++
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, `{}`)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, retrieveJSON)
+		case strings.Contains(r.URL.Path, "dcim/locations"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, existingJSON)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, emptyListJSON)
+		}
+	}
+}
+
+func TestLoadLocations_MergeUpdatesWhenDrifted(t *testing.T) {
+	locID := uuid.New()
+	existingJSON := fmt.Sprintf(`{"count":1,"results":[{"id":%q,"name":"DC1","display":"DC1"}]}`, locID)
+	retrieveJSON := fmt.Sprintf(`{"id":%q,"name":"DC1","description":"old","location_type":{"id":"%s"},"status":{"id":"%s"}}`,
+		locID, uuid.New(), uuid.New())
+	var patchCalls int
+	e, cleanup := newExporterWithServer(t, loadLocationsHandler(locID, existingJSON, retrieveJSON, &patchCalls))
+	defer cleanup()
+	e.Options.Merge = true
+
+	caniID := uuid.New()
+	inv := &devicetypes.Inventory{
+		Locations: map[uuid.UUID]*devicetypes.CaniLocationType{
+			caniID: {
+				ID:           caniID,
+				Name:         "DC1",
+				LocationType: "Section",
+				Description:  "new",
+			},
+		},
+	}
+	result := &LoadResult{
+		LocationsCreated: make([]string, 0),
+		LocationsUpdated: make([]string, 0),
+		LocationsSkipped: make([]string, 0),
+	}
+
+	_, err := e.loadLocations(context.Background(), inv, result)
+	if err != nil {
+		t.Fatalf("loadLocations() error = %v", err)
+	}
+	if len(result.LocationsUpdated) != 1 || result.LocationsUpdated[0] != "DC1" {
+		t.Errorf("LocationsUpdated = %v, want [DC1]", result.LocationsUpdated)
+	}
+	if len(result.LocationsSkipped) != 0 {
+		t.Errorf("LocationsSkipped = %v, want empty", result.LocationsSkipped)
+	}
+	if patchCalls != 1 {
+		t.Errorf("expected 1 PATCH, got %d", patchCalls)
+	}
+}
+
+func TestLoadLocations_MergeSkipsWhenIdentical(t *testing.T) {
+	locID := uuid.New()
+	existingJSON := fmt.Sprintf(`{"count":1,"results":[{"id":%q,"name":"DC1","display":"DC1"}]}`, locID)
+	retrieveJSON := fmt.Sprintf(`{"id":%q,"name":"DC1","location_type":{"id":"%s"},"status":{"id":"%s"}}`,
+		locID, uuid.New(), uuid.New())
+	var patchCalls int
+	e, cleanup := newExporterWithServer(t, loadLocationsHandler(locID, existingJSON, retrieveJSON, &patchCalls))
+	defer cleanup()
+	e.Options.Merge = true
+
+	caniID := uuid.New()
+	inv := &devicetypes.Inventory{
+		Locations: map[uuid.UUID]*devicetypes.CaniLocationType{
+			caniID: {
+				ID:           caniID,
+				Name:         "DC1",
+				LocationType: "Section",
+			},
+		},
+	}
+	result := &LoadResult{
+		LocationsCreated: make([]string, 0),
+		LocationsUpdated: make([]string, 0),
+		LocationsSkipped: make([]string, 0),
+	}
+
+	_, err := e.loadLocations(context.Background(), inv, result)
+	if err != nil {
+		t.Fatalf("loadLocations() error = %v", err)
+	}
+	if len(result.LocationsUpdated) != 0 {
+		t.Errorf("LocationsUpdated = %v, want empty", result.LocationsUpdated)
+	}
+	if len(result.LocationsSkipped) != 1 {
+		t.Errorf("LocationsSkipped = %v, want [DC1]", result.LocationsSkipped)
+	}
+	if patchCalls != 0 {
+		t.Errorf("expected 0 PATCH calls, got %d", patchCalls)
+	}
+}
+
+func TestLoadLocations_MergeDryRunIssuesNoMutations(t *testing.T) {
+	locID := uuid.New()
+	existingJSON := fmt.Sprintf(`{"count":1,"results":[{"id":%q,"name":"DC1","display":"DC1"}]}`, locID)
+	retrieveJSON := fmt.Sprintf(`{"id":%q,"name":"DC1","description":"old","location_type":{"id":"%s"},"status":{"id":"%s"}}`,
+		locID, uuid.New(), uuid.New())
+	var patchCalls int
+	e, cleanup := newExporterWithServer(t, loadLocationsHandler(locID, existingJSON, retrieveJSON, &patchCalls))
+	defer cleanup()
+	e.Options.Merge = true
+	e.Options.DryRun = true
+
+	caniID := uuid.New()
+	inv := &devicetypes.Inventory{
+		Locations: map[uuid.UUID]*devicetypes.CaniLocationType{
+			caniID: {
+				ID:           caniID,
+				Name:         "DC1",
+				LocationType: "Section",
+				Description:  "new",
+			},
+		},
+	}
+	result := &LoadResult{
+		LocationsCreated: make([]string, 0),
+		LocationsUpdated: make([]string, 0),
+		LocationsSkipped: make([]string, 0),
+	}
+
+	_, err := e.loadLocations(context.Background(), inv, result)
+	if err != nil {
+		t.Fatalf("loadLocations() error = %v", err)
+	}
+	if patchCalls != 0 {
+		t.Errorf("dry-run should issue 0 PATCH calls, got %d", patchCalls)
+	}
+	if len(result.LocationsUpdated) != 1 {
+		t.Errorf("LocationsUpdated = %v, want [DC1]", result.LocationsUpdated)
+	}
+}

--- a/pkg/provider/nautobot/export/merge_patch_test.go
+++ b/pkg/provider/nautobot/export/merge_patch_test.go
@@ -1,0 +1,292 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package export
+
+import (
+	"testing"
+
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	nautobotapi "github.com/Cray-HPE/cani/pkg/nautobot"
+	"github.com/google/uuid"
+)
+
+// -----------------------------------------------------------------------------
+// buildLocationPatch — pure logic
+// -----------------------------------------------------------------------------
+
+func TestBuildLocationPatch_DetectsDescriptionDrift(t *testing.T) {
+	loc := &devicetypes.CaniLocationType{
+		ID:          uuid.New(),
+		Name:        "DC1",
+		Description: "new desc",
+	}
+	remoteDesc := "old desc"
+	remote := &nautobotapi.Location{Name: "DC1", Description: &remoteDesc}
+
+	req, drifted := buildLocationPatch(loc, remote)
+	if !drifted {
+		t.Fatal("expected drift for changed description")
+	}
+	if req.Description == nil || *req.Description != "new desc" {
+		t.Errorf("Description = %v, want 'new desc'", req.Description)
+	}
+}
+
+func TestBuildLocationPatch_DetectsFacilityDrift(t *testing.T) {
+	loc := &devicetypes.CaniLocationType{
+		ID:       uuid.New(),
+		Name:     "DC1",
+		Facility: "fac-2",
+	}
+	remoteFac := "fac-1"
+	remote := &nautobotapi.Location{Name: "DC1", Facility: &remoteFac}
+
+	req, drifted := buildLocationPatch(loc, remote)
+	if !drifted {
+		t.Fatal("expected drift for changed facility")
+	}
+	if req.Facility == nil || *req.Facility != "fac-2" {
+		t.Errorf("Facility = %v, want 'fac-2'", req.Facility)
+	}
+}
+
+func TestBuildLocationPatch_DetectsContactDrift(t *testing.T) {
+	loc := &devicetypes.CaniLocationType{
+		ID:           uuid.New(),
+		Name:         "DC1",
+		ContactName:  "Alice",
+		ContactPhone: "555-0100",
+		ContactEmail: "alice@example.com",
+	}
+	oldName := "Bob"
+	oldPhone := "555-0000"
+	oldEmail := "bob@example.com"
+	remote := &nautobotapi.Location{
+		Name:         "DC1",
+		ContactName:  &oldName,
+		ContactPhone: &oldPhone,
+		ContactEmail: &oldEmail,
+	}
+
+	req, drifted := buildLocationPatch(loc, remote)
+	if !drifted {
+		t.Fatal("expected drift for changed contact fields")
+	}
+	if req.ContactName == nil || *req.ContactName != "Alice" {
+		t.Errorf("ContactName = %v, want 'Alice'", req.ContactName)
+	}
+	if req.ContactPhone == nil || *req.ContactPhone != "555-0100" {
+		t.Errorf("ContactPhone = %v, want '555-0100'", req.ContactPhone)
+	}
+	if req.ContactEmail == nil || *req.ContactEmail != "alice@example.com" {
+		t.Errorf("ContactEmail = %v, want 'alice@example.com'", req.ContactEmail)
+	}
+}
+
+func TestBuildLocationPatch_DetectsCustomFieldDrift(t *testing.T) {
+	loc := &devicetypes.CaniLocationType{
+		ID:   uuid.New(),
+		Name: "DC1",
+		ObjectMeta: devicetypes.ObjectMeta{
+			CustomFields: map[string]any{"tier": "gold"},
+		},
+	}
+	remoteCF := map[string]interface{}{"tier": "silver"}
+	remote := &nautobotapi.Location{Name: "DC1", CustomFields: &remoteCF}
+
+	req, drifted := buildLocationPatch(loc, remote)
+	if !drifted {
+		t.Fatal("expected drift for changed custom fields")
+	}
+	if req.CustomFields == nil {
+		t.Fatal("CustomFields patch should not be nil")
+	}
+	if (*req.CustomFields)["tier"] != "gold" {
+		t.Errorf("CustomFields[tier] = %v, want 'gold'", (*req.CustomFields)["tier"])
+	}
+}
+
+func TestBuildLocationPatch_NoDriftWhenIdentical(t *testing.T) {
+	loc := &devicetypes.CaniLocationType{
+		ID:          uuid.New(),
+		Name:        "DC1",
+		Description: "same",
+		Facility:    "fac-1",
+	}
+	desc := "same"
+	fac := "fac-1"
+	remote := &nautobotapi.Location{Name: "DC1", Description: &desc, Facility: &fac}
+
+	_, drifted := buildLocationPatch(loc, remote)
+	if drifted {
+		t.Error("expected no drift when all fields match")
+	}
+}
+
+func TestBuildLocationPatch_EmptyLocalClearsRemote(t *testing.T) {
+	loc := &devicetypes.CaniLocationType{
+		ID:   uuid.New(),
+		Name: "DC1",
+		// All optional fields empty — should converge remote to empty
+	}
+	desc := "remote has desc"
+	remote := &nautobotapi.Location{Name: "DC1", Description: &desc}
+
+	req, drifted := buildLocationPatch(loc, remote)
+	if !drifted {
+		t.Error("should detect drift when local is empty but remote is not")
+	}
+	if req.Description == nil || *req.Description != "" {
+		t.Errorf("Description = %v, want empty string to clear remote", req.Description)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// buildVLANPatch — pure logic
+// -----------------------------------------------------------------------------
+
+func TestBuildVLANPatch_DetectsNameDrift(t *testing.T) {
+	vlan := &devicetypes.CaniVLAN{ID: uuid.New(), VID: 100, Name: "new-name"}
+	remote := &nautobotapi.VLAN{Name: "old-name", Vid: 100}
+
+	req, drifted := buildVLANPatch(vlan, remote)
+	if !drifted {
+		t.Fatal("expected drift for changed name")
+	}
+	if req.Name == nil || *req.Name != "new-name" {
+		t.Errorf("Name = %v, want 'new-name'", req.Name)
+	}
+}
+
+func TestBuildVLANPatch_DetectsDescriptionDrift(t *testing.T) {
+	vlan := &devicetypes.CaniVLAN{ID: uuid.New(), VID: 200, Name: "mgmt", Description: "updated"}
+	oldDesc := "original"
+	remote := &nautobotapi.VLAN{Name: "mgmt", Vid: 200, Description: &oldDesc}
+
+	req, drifted := buildVLANPatch(vlan, remote)
+	if !drifted {
+		t.Fatal("expected drift for changed description")
+	}
+	if req.Description == nil || *req.Description != "updated" {
+		t.Errorf("Description = %v, want 'updated'", req.Description)
+	}
+}
+
+func TestBuildVLANPatch_DetectsCustomFieldDrift(t *testing.T) {
+	vlan := &devicetypes.CaniVLAN{
+		ID:   uuid.New(),
+		VID:  300,
+		Name: "storage",
+		ObjectMeta: devicetypes.ObjectMeta{
+			CustomFields: map[string]any{"priority": "high"},
+		},
+	}
+	remoteCF := map[string]interface{}{"priority": "low"}
+	remote := &nautobotapi.VLAN{Name: "storage", Vid: 300, CustomFields: &remoteCF}
+
+	req, drifted := buildVLANPatch(vlan, remote)
+	if !drifted {
+		t.Fatal("expected drift for changed custom fields")
+	}
+	if req.CustomFields == nil {
+		t.Fatal("CustomFields patch should not be nil")
+	}
+}
+
+func TestBuildVLANPatch_NoDriftWhenIdentical(t *testing.T) {
+	vlan := &devicetypes.CaniVLAN{ID: uuid.New(), VID: 100, Name: "mgmt", Description: "same"}
+	desc := "same"
+	remote := &nautobotapi.VLAN{Name: "mgmt", Vid: 100, Description: &desc}
+
+	_, drifted := buildVLANPatch(vlan, remote)
+	if drifted {
+		t.Error("expected no drift when all fields match")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// mergedCustomFields — pure logic
+// -----------------------------------------------------------------------------
+
+func TestMergedCustomFields_CombinesBothMaps(t *testing.T) {
+	explicit := map[string]any{"a": "1"}
+	flat := map[string]any{"b": "2"}
+	merged := mergedCustomFields(explicit, flat)
+	if merged["a"] != "1" || merged["b"] != "2" {
+		t.Errorf("merged = %v, want {a:1, b:2}", merged)
+	}
+}
+
+func TestMergedCustomFields_FlatOverridesExplicit(t *testing.T) {
+	explicit := map[string]any{"key": "explicit"}
+	flat := map[string]any{"key": "flat"}
+	merged := mergedCustomFields(explicit, flat)
+	if merged["key"] != "flat" {
+		t.Errorf("merged[key] = %v, want 'flat'", merged["key"])
+	}
+}
+
+func TestMergedCustomFields_EmptyInputs(t *testing.T) {
+	merged := mergedCustomFields(nil, nil)
+	if len(merged) != 0 {
+		t.Errorf("expected empty map, got %v", merged)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// customFieldsDrifted — pure logic
+// -----------------------------------------------------------------------------
+
+func TestCustomFieldsDrifted_TrueWhenDifferent(t *testing.T) {
+	local := map[string]interface{}{"tier": "gold"}
+	remote := map[string]interface{}{"tier": "silver"}
+	if !customFieldsDrifted(local, &remote) {
+		t.Error("expected true when values differ")
+	}
+}
+
+func TestCustomFieldsDrifted_TrueWhenNewKey(t *testing.T) {
+	local := map[string]interface{}{"env": "prod"}
+	remote := map[string]interface{}{}
+	if !customFieldsDrifted(local, &remote) {
+		t.Error("expected true when local has new key")
+	}
+}
+
+func TestCustomFieldsDrifted_FalseWhenEqual(t *testing.T) {
+	local := map[string]interface{}{"tier": "gold"}
+	remote := map[string]interface{}{"tier": "gold"}
+	if customFieldsDrifted(local, &remote) {
+		t.Error("expected false when values match")
+	}
+}
+
+func TestCustomFieldsDrifted_TrueWhenRemoteNil(t *testing.T) {
+	local := map[string]interface{}{"tier": "gold"}
+	if !customFieldsDrifted(local, nil) {
+		t.Error("expected true when remote is nil")
+	}
+}

--- a/pkg/provider/nautobot/export/merge_vlan_http_test.go
+++ b/pkg/provider/nautobot/export/merge_vlan_http_test.go
@@ -1,0 +1,262 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package export
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Cray-HPE/cani/pkg/devicetypes"
+	"github.com/google/uuid"
+)
+
+func vlanMergeHandler(vlanID uuid.UUID, remoteJSON string, patchCalls *int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "ipam/vlans/"+vlanID.String()) {
+			if r.Method == http.MethodPatch {
+				*patchCalls++
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, `{}`)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, remoteJSON)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, emptyListJSON)
+	}
+}
+
+func TestMergeVLAN_PatchesWhenDrifted(t *testing.T) {
+	vlanID := uuid.New()
+	remoteJSON := fmt.Sprintf(`{"id":%q,"name":"old-name","vid":100,"status":{"id":"%s"}}`,
+		vlanID, uuid.New())
+	var patchCalls int
+	e, cleanup := newExporterWithServer(t, vlanMergeHandler(vlanID, remoteJSON, &patchCalls))
+	defer cleanup()
+	e.Options.Merge = true
+
+	vlan := &devicetypes.CaniVLAN{ID: uuid.New(), VID: 100, Name: "new-name"}
+
+	updated, err := e.mergeVLAN(context.Background(), vlan, vlanID)
+	if err != nil {
+		t.Fatalf("mergeVLAN() error = %v", err)
+	}
+	if !updated {
+		t.Error("expected updated=true when name drifted")
+	}
+	if patchCalls != 1 {
+		t.Errorf("expected 1 PATCH, got %d", patchCalls)
+	}
+}
+
+func TestMergeVLAN_SkipsWhenNoDrift(t *testing.T) {
+	vlanID := uuid.New()
+	remoteJSON := fmt.Sprintf(`{"id":%q,"name":"mgmt","vid":100,"status":{"id":"%s"}}`,
+		vlanID, uuid.New())
+	var patchCalls int
+	e, cleanup := newExporterWithServer(t, vlanMergeHandler(vlanID, remoteJSON, &patchCalls))
+	defer cleanup()
+	e.Options.Merge = true
+
+	vlan := &devicetypes.CaniVLAN{ID: uuid.New(), VID: 100, Name: "mgmt"}
+
+	updated, err := e.mergeVLAN(context.Background(), vlan, vlanID)
+	if err != nil {
+		t.Fatalf("mergeVLAN() error = %v", err)
+	}
+	if updated {
+		t.Error("expected updated=false when no drift")
+	}
+	if patchCalls != 0 {
+		t.Errorf("expected 0 PATCH calls, got %d", patchCalls)
+	}
+}
+
+func TestMergeVLAN_DryRunDoesNotPatch(t *testing.T) {
+	vlanID := uuid.New()
+	remoteJSON := fmt.Sprintf(`{"id":%q,"name":"old","vid":200,"status":{"id":"%s"}}`,
+		vlanID, uuid.New())
+	var patchCalls int
+	e, cleanup := newExporterWithServer(t, vlanMergeHandler(vlanID, remoteJSON, &patchCalls))
+	defer cleanup()
+	e.Options.Merge = true
+	e.Options.DryRun = true
+
+	vlan := &devicetypes.CaniVLAN{ID: uuid.New(), VID: 200, Name: "new"}
+
+	updated, err := e.mergeVLAN(context.Background(), vlan, vlanID)
+	if err != nil {
+		t.Fatalf("mergeVLAN() error = %v", err)
+	}
+	if !updated {
+		t.Error("dry-run should still report updated=true")
+	}
+	if patchCalls != 0 {
+		t.Errorf("dry-run should not PATCH, got %d", patchCalls)
+	}
+}
+
+func loadVLANsHandler(vlanID uuid.UUID, existingJSON, retrieveJSON string, patchCalls *int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "ipam/vlans/"+vlanID.String()):
+			if r.Method == http.MethodPatch {
+				*patchCalls++
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, `{}`)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, retrieveJSON)
+		case strings.Contains(r.URL.Path, "ipam/vlans"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, existingJSON)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, emptyListJSON)
+		}
+	}
+}
+
+func TestLoadVLANs_MergeUpdatesWhenDrifted(t *testing.T) {
+	resetIPAMCaches()
+	vlanID := uuid.New()
+	existingJSON := fmt.Sprintf(`{"count":1,"results":[{"id":%q,"name":"old-mgmt","vid":100,"display":"old-mgmt"}]}`, vlanID)
+	retrieveJSON := fmt.Sprintf(`{"id":%q,"name":"old-mgmt","vid":100,"status":{"id":"%s"}}`, vlanID, uuid.New())
+	var patchCalls int
+	e, cleanup := newExporterWithServer(t, loadVLANsHandler(vlanID, existingJSON, retrieveJSON, &patchCalls))
+	defer cleanup()
+	e.Options.Merge = true
+	e.Options.DefaultLocation = "DC1"
+
+	caniID := uuid.New()
+	inv := &devicetypes.Inventory{
+		VLANs: map[uuid.UUID]*devicetypes.CaniVLAN{
+			caniID: {
+				ID:   caniID,
+				VID:  100,
+				Name: "new-mgmt",
+			},
+		},
+	}
+	result := &LoadResult{}
+
+	_, err := e.loadVLANs(context.Background(), inv, map[uuid.UUID]uuid.UUID{}, result)
+	if err != nil {
+		t.Fatalf("loadVLANs() error = %v", err)
+	}
+	if result.VLANsUpdated != 1 {
+		t.Errorf("VLANsUpdated = %d, want 1", result.VLANsUpdated)
+	}
+	if result.VLANsSkipped != 0 {
+		t.Errorf("VLANsSkipped = %d, want 0", result.VLANsSkipped)
+	}
+	if patchCalls != 1 {
+		t.Errorf("expected 1 PATCH, got %d", patchCalls)
+	}
+}
+
+func TestLoadVLANs_MergeSkipsWhenIdentical(t *testing.T) {
+	resetIPAMCaches()
+	vlanID := uuid.New()
+	existingJSON := fmt.Sprintf(`{"count":1,"results":[{"id":%q,"name":"mgmt","vid":100,"display":"mgmt"}]}`, vlanID)
+	retrieveJSON := fmt.Sprintf(`{"id":%q,"name":"mgmt","vid":100,"status":{"id":"%s"}}`, vlanID, uuid.New())
+	var patchCalls int
+	e, cleanup := newExporterWithServer(t, loadVLANsHandler(vlanID, existingJSON, retrieveJSON, &patchCalls))
+	defer cleanup()
+	e.Options.Merge = true
+	e.Options.DefaultLocation = "DC1"
+
+	caniID := uuid.New()
+	inv := &devicetypes.Inventory{
+		VLANs: map[uuid.UUID]*devicetypes.CaniVLAN{
+			caniID: {
+				ID:   caniID,
+				VID:  100,
+				Name: "mgmt",
+			},
+		},
+	}
+	result := &LoadResult{}
+
+	_, err := e.loadVLANs(context.Background(), inv, map[uuid.UUID]uuid.UUID{}, result)
+	if err != nil {
+		t.Fatalf("loadVLANs() error = %v", err)
+	}
+	if result.VLANsUpdated != 0 {
+		t.Errorf("VLANsUpdated = %d, want 0", result.VLANsUpdated)
+	}
+	if result.VLANsSkipped != 1 {
+		t.Errorf("VLANsSkipped = %d, want 1", result.VLANsSkipped)
+	}
+	if patchCalls != 0 {
+		t.Errorf("expected 0 PATCH calls, got %d", patchCalls)
+	}
+}
+
+func TestLoadVLANs_MergeDryRunIssuesNoMutations(t *testing.T) {
+	resetIPAMCaches()
+	vlanID := uuid.New()
+	existingJSON := fmt.Sprintf(`{"count":1,"results":[{"id":%q,"name":"old-mgmt","vid":100,"display":"old-mgmt"}]}`, vlanID)
+	retrieveJSON := fmt.Sprintf(`{"id":%q,"name":"old-mgmt","vid":100,"status":{"id":"%s"}}`, vlanID, uuid.New())
+	var patchCalls int
+	e, cleanup := newExporterWithServer(t, loadVLANsHandler(vlanID, existingJSON, retrieveJSON, &patchCalls))
+	defer cleanup()
+	e.Options.Merge = true
+	e.Options.DryRun = true
+	e.Options.DefaultLocation = "DC1"
+
+	caniID := uuid.New()
+	inv := &devicetypes.Inventory{
+		VLANs: map[uuid.UUID]*devicetypes.CaniVLAN{
+			caniID: {
+				ID:   caniID,
+				VID:  100,
+				Name: "new-mgmt",
+			},
+		},
+	}
+	result := &LoadResult{}
+
+	_, err := e.loadVLANs(context.Background(), inv, map[uuid.UUID]uuid.UUID{}, result)
+	if err != nil {
+		t.Fatalf("loadVLANs() error = %v", err)
+	}
+	if patchCalls != 0 {
+		t.Errorf("dry-run should issue 0 PATCH calls, got %d", patchCalls)
+	}
+	if result.VLANsUpdated != 1 {
+		t.Errorf("VLANsUpdated = %d, want 1 (reported even in dry-run)", result.VLANsUpdated)
+	}
+}

--- a/pkg/provider/nautobot/export/string_slices_test.go
+++ b/pkg/provider/nautobot/export/string_slices_test.go
@@ -1,0 +1,74 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package export
+
+import "testing"
+
+// -----------------------------------------------------------------------------
+// stringSlicesEqual — pure logic
+// -----------------------------------------------------------------------------
+
+func TestStringSlicesEqual_SameElements(t *testing.T) {
+	if !stringSlicesEqual([]string{"a", "b", "c"}, []string{"a", "b", "c"}) {
+		t.Error("identical slices should be equal")
+	}
+}
+
+func TestStringSlicesEqual_DifferentOrder(t *testing.T) {
+	if !stringSlicesEqual([]string{"c", "a", "b"}, []string{"a", "b", "c"}) {
+		t.Error("same elements in different order should be equal")
+	}
+}
+
+func TestStringSlicesEqual_DifferentLengths(t *testing.T) {
+	if stringSlicesEqual([]string{"a", "b"}, []string{"a", "b", "c"}) {
+		t.Error("different lengths should not be equal")
+	}
+}
+
+func TestStringSlicesEqual_DifferentElements(t *testing.T) {
+	if stringSlicesEqual([]string{"a", "b", "c"}, []string{"a", "b", "d"}) {
+		t.Error("different elements should not be equal")
+	}
+}
+
+func TestStringSlicesEqual_Duplicates(t *testing.T) {
+	if stringSlicesEqual([]string{"a", "a", "b"}, []string{"a", "b", "b"}) {
+		t.Error("different duplicate counts should not be equal")
+	}
+}
+
+func TestStringSlicesEqual_BothEmpty(t *testing.T) {
+	if !stringSlicesEqual([]string{}, []string{}) {
+		t.Error("two empty slices should be equal")
+	}
+}
+
+func TestStringSlicesEqual_BothNil(t *testing.T) {
+	if !stringSlicesEqual(nil, nil) {
+		t.Error("two nil slices should be equal")
+	}
+}


### PR DESCRIPTION
## Summary

[FORGE-211](https://jira-pro.it.hpe.com:8443/browse/FORGE-211)

When `--merge` is set, the Nautobot exporter now **fetches remote state before writing** and PATCHes only drifted fields for locations, VLANs, primary IPs, and custom field definitions. This makes `cani export` idempotent — running it twice produces no redundant API calls.

Dry-run is honored at every mutation point.

## Changes

### Merge / drift reconciliation (core fix)
- **Location merge**: compare 11 string fields + custom fields against remote, PATCH only what drifted
- **VLAN merge**: compare name, description, custom fields; skip when identical
- **Primary IP assignment**: resolve IPv4/IPv6 independently, skip when remote already matches
- **Custom field definition drift**: reconcile label, type, content_types, required, weight, description

### Refactoring (follow-up)
- Split `load_vlans.go` (was 313 lines) into `load_vlans.go` + `load_vlans_merge.go`
- Extract `mergedCustomFields` / `customFieldsDrifted` into `diff_helpers.go`
- Replace 11 repetitive if-blocks in `buildLocationPatch` with `driftStr` helper
- Fix bare `200` → `http.StatusOK` for consistency

### Tests
- HTTP-level merge tests for locations, VLANs, and custom field drift
- Pure-logic tests for patch builders, string slice comparison, custom field drift detection
- `loadPrimaryIPs` HTTP tests: idempotent skip + dry-run guard

## File summary

19 files changed: +2190 / -133 (net ~2057 lines, mostly tests)

| Category | Files |
|----------|-------|
| New production | `custom_field_drift.go`, `diff_helpers.go`, `load_locations_merge.go`, `load_vlans_merge.go` |
| Modified production | `diff.go`, `export.go`, `load.go`, `load_locations.go`, `load_primary_ips.go`, `load_vlans.go`, `lookup_custom_fields.go` |
| New tests | `custom_field_drift_test.go`, `diff_custom_fields_test.go`, `load_primary_ips_http_test.go`, `load_primary_ips_test.go`, `merge_location_http_test.go`, `merge_patch_test.go`, `merge_vlan_http_test.go`, `string_slices_test.go` |

## Testing
- Ran two AI code reviews (`/code-review --scope=branch`) and fixed all that was found.

- Ran `make test`
```
cani % make test

<snip>

>>> running unit tests
GOOS=darwin GOARCH=arm64 go test -cover ./...
	github.com/Cray-HPE/cani		coverage: 0.0% of statements
	github.com/Cray-HPE/cani/cmd		coverage: 0.0% of statements
	github.com/Cray-HPE/cani/cmd/add		coverage: 0.0% of statements
	github.com/Cray-HPE/cani/cmd/alpha		coverage: 0.0% of statements
	github.com/Cray-HPE/cani/cmd/classify		coverage: 0.0% of statements
ok  	github.com/Cray-HPE/cani/cmd/export	(cached)	coverage: 27.1% of statements
ok  	github.com/Cray-HPE/cani/cmd/import	(cached)	coverage: 21.0% of statements
	github.com/Cray-HPE/cani/cmd/init		coverage: 0.0% of statements
	github.com/Cray-HPE/cani/cmd/remove		coverage: 0.0% of statements
	github.com/Cray-HPE/cani/cmd/serve		coverage: 0.0% of statements
	github.com/Cray-HPE/cani/cmd/show		coverage: 0.0% of statements
ok  	github.com/Cray-HPE/cani/cmd/update	(cached)	coverage: 1.5% of statements
ok  	github.com/Cray-HPE/cani/internal/cli	(cached)	coverage: 60.2% of statements
ok  	github.com/Cray-HPE/cani/internal/config	(cached)	coverage: 63.3% of statements
	github.com/Cray-HPE/cani/internal/core		coverage: 0.0% of statements
ok  	github.com/Cray-HPE/cani/internal/openapi/runtime	(cached)	coverage: 3.7% of statements
	github.com/Cray-HPE/cani/internal/openapi/types		coverage: 0.0% of statements
ok  	github.com/Cray-HPE/cani/internal/provider	(cached)	coverage: 100.0% of statements
ok  	github.com/Cray-HPE/cani/internal/provider/conformance	(cached)	coverage: [no statements]
ok  	github.com/Cray-HPE/cani/internal/util/nameexpand	(cached)	coverage: 96.5% of statements
ok  	github.com/Cray-HPE/cani/internal/util/placement	(cached)	coverage: 92.2% of statements
ok  	github.com/Cray-HPE/cani/internal/util/resolve	(cached)	coverage: 98.4% of statements
ok  	github.com/Cray-HPE/cani/internal/util/store	(cached)	coverage: 81.8% of statements
ok  	github.com/Cray-HPE/cani/internal/util/uuidutil	(cached)	coverage: 100.0% of statements
ok  	github.com/Cray-HPE/cani/internal/util/validate	(cached)	coverage: 100.0% of statements
	github.com/Cray-HPE/cani/pkg/canu		coverage: 0.0% of statements
ok  	github.com/Cray-HPE/cani/pkg/datastores	(cached)	coverage: 83.7% of statements
ok  	github.com/Cray-HPE/cani/pkg/devicetypes	(cached)	coverage: 90.6% of statements
ok  	github.com/Cray-HPE/cani/pkg/devicetypes/connections	(cached)	coverage: 97.4% of statements
ok  	github.com/Cray-HPE/cani/pkg/devicetypes/schema	1.208s	coverage: 93.5% of statements
	github.com/Cray-HPE/cani/pkg/nautobot		coverage: 0.0% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/csm	(cached)	coverage: 34.2% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/csm/client	(cached)	coverage: 26.9% of statements
	github.com/Cray-HPE/cani/pkg/provider/csm/commands		coverage: 0.0% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/csm/export	(cached)	coverage: 38.6% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/csm/import	(cached)	coverage: 42.3% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/csm/transform	(cached)	coverage: 85.9% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/example	(cached)	coverage: 62.2% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/example/commands	(cached)	coverage: 100.0% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/example/export	(cached)	coverage: 100.0% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/example/import	(cached)	coverage: 99.5% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/example/transform	(cached)	coverage: 99.1% of statements
	github.com/Cray-HPE/cani/pkg/provider/hpcm		coverage: 0.0% of statements
	github.com/Cray-HPE/cani/pkg/provider/hpcm/commands		coverage: 0.0% of statements
	github.com/Cray-HPE/cani/pkg/provider/hpcm/export		coverage: 0.0% of statements
	github.com/Cray-HPE/cani/pkg/provider/hpcm/import		coverage: 0.0% of statements
?   	github.com/Cray-HPE/cani/pkg/provider/hpcm/import/cmconfig	[no test files]
?   	github.com/Cray-HPE/cani/pkg/provider/hpcm/import/cmdb	[no test files]
ok  	github.com/Cray-HPE/cani/pkg/provider/hpcm/transform	(cached)	coverage: 27.9% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/nautobot	(cached)	coverage: 49.3% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/nautobot/commands	(cached)	coverage: 100.0% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/nautobot/export	(cached)	coverage: 80.4% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/nautobot/import	(cached)	coverage: 88.1% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/nautobot/logcolor	(cached)	coverage: 100.0% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/nautobot/transform	(cached)	coverage: 97.3% of statements
	github.com/Cray-HPE/cani/pkg/provider/ochami		coverage: 0.0% of statements
	github.com/Cray-HPE/cani/pkg/provider/ochami/commands		coverage: 0.0% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/ochami/export	(cached)	coverage: 98.5% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/ochami/import	(cached)	coverage: 82.8% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/ochami/transform	(cached)	coverage: 54.1% of statements
	github.com/Cray-HPE/cani/pkg/provider/redfish		coverage: 0.0% of statements
	github.com/Cray-HPE/cani/pkg/provider/redfish/commands		coverage: 0.0% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/redfish/export	(cached)	coverage: 100.0% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/redfish/import	(cached)	coverage: 98.0% of statements
ok  	github.com/Cray-HPE/cani/pkg/provider/redfish/transform	(cached)	coverage: 100.0% of statements
	github.com/Cray-HPE/cani/pkg/utils		coverage: 0.0% of statements
ok  	github.com/Cray-HPE/cani/pkg/visual	(cached)	coverage: 9.8% of statements
	github.com/Cray-HPE/cani/pkg/xname		coverage: 0.0% of statements
	github.com/Cray-HPE/cani/tools/gendocs		coverage: 0.0% of statements
	github.com/Cray-HPE/cani/tools/genschema		coverage: 0.0% of statements
 ✔  unit tests passed
>>> running functional tests
shellspec ./spec/functional -f tap
Tests that the compiled binary works as expected
1..449
ok 1 - cani alpha add cable valid slug adds a cable with a known slug
ok 2 - cani alpha add cable invalid slug rejects an unknown slug
ok 3 - cani alpha add cable cable endpoints creates a cable between two devices
<snip>
ok 447 - cani alpha show visual flags rack visual flags lists --labels flag
ok 448 - cani alpha show visual flags rack visual flags lists --interactive flag
ok 449 - cani alpha show visual flags rejects unknown tree detail values
 ✔  functional tests passed
>>> running integration tests
. venv/bin/activate && ./spec/support/bin/cani_integrate.sh integration
+ shellspec ./spec/integration/add_blade_ex235a_spec.sh -f tap --no-banner
1..6
ok 1 - INTEGRATION: import from simulator
ok 2 - INTEGRATION: verify blades exist after import
ok 3 - INTEGRATION: add ex235a blade
ok 4 - INTEGRATION: verify staged blade
ok 5 - INTEGRATION: verify staged nodes
ok 6 - INTEGRATION: export to simulator
+ set +x
+ tavern-ci --tavern-global-cfg=./spec/tavern_global_config.yaml ./spec/integration/tavern/test_add_blade_ex235a.tavern.yml -W ignore::DeprecationWarning
=========================================================================================== test session starts ============================================================================================
platform darwin -- Python 3.12.9, pytest-7.2.2, pluggy-1.6.0
rootdir: /Users/studenym/workspace/cani
plugins: tavern-2.2.0
collected 64 items

spec/integration/tavern/test_add_blade_ex235a.tavern.yml ................................................................                                                                            [100%]

============================================================================================ 64 passed in 1.04s ============================================================================================
+ set +x
+ shellspec ./spec/integration/add_blade_ex235n_spec.sh -f tap --no-banner
1..6
ok 1 - INTEGRATION: import from simulator
ok 2 - INTEGRATION: verify blades exist after import
ok 3 - INTEGRATION: add ex235n blade
ok 4 - INTEGRATION: verify staged blade
ok 5 - INTEGRATION: verify staged nodes
ok 6 - INTEGRATION: export to simulator

<snip>

============================================================================================ 70 passed in 0.85s ============================================================================================
+ set +x
+ shellspec ./spec/integration/session_start_import_ignore_validation_spec.sh -f tap --no-banner
1..3
ok 1 - INTEGRATION: attempt to start a session with failures
ok 2 - INTEGRATION: start a session ignoring validation failures
ok 3 - INTEGRATION: commit and reconcile ignoring validation failures
+ set +x
+ shellspec ./spec/integration/visual_parity_spec.sh -f tap --no-banner
1..5
ok 1 - INTEGRATION: visual output parity renders device tables with resolved rack names and U positions
ok 2 - INTEGRATION: visual output parity renders cable tables with resolved endpoint device names and ports
ok 3 - INTEGRATION: visual output parity renders classic rack rows with stable Unicode width and cable details
ok 4 - INTEGRATION: visual output parity renders tree connectors with roles interfaces empty U slots and cable leaves
ok 5 - INTEGRATION: visual output parity renders routing labels for intra-rack cables
+ set +x
 ✔  integration tests passed
 ✔  all tests passed
 ```
 
-  I ran `gnv2_inventory_lag.sh` and exported to Nautobot.  i did spot checks to verify location, VLAN, primary IP, and custom fields look as they did before in both `canidb.json` and local Nautobot.
